### PR TITLE
feat(colors): ramps and pairs as schema primitives (#1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,34 +13,40 @@
     },
     "packages/cli": {
       "name": "@google/design.md",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "design.md": "./dist/index.js",
-        "designmd": "./dist/index.js",
       },
       "dependencies": {
+        "@json-render/core": "^0.16.0",
+        "@json-render/ink": "^0.16.0",
+        "citty": "^0.1.6",
+        "ink": "^7.0.0",
+        "mdast": "^3.0.0",
+        "react": "^19.2.5",
+        "remark-frontmatter": "^5.0.0",
+        "remark-mdx": "^3.1.1",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0",
+        "yaml": "^2.7.1",
         "zod": "^3.24.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/mdast": "^4.0.4",
         "@types/node": "^20.11.24",
+        "@types/react": "^19.2.14",
         "bun-types": "^1.3.12",
-        "citty": "^0.1.6",
-        "mdast": "^3.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-mdx": "^3.1.1",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
         "tailwindcss": "3",
         "typescript": "^5.7.3",
-        "unified": "^11.0.5",
-        "unist-util-visit": "^5.1.0",
-        "yaml": "^2.7.1",
       },
     },
   },
   "packages": {
+    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@google/design.md": ["@google/design.md@workspace:packages/cli"],
@@ -52,6 +58,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@json-render/core": ["@json-render/core@0.16.0", "", { "dependencies": { "zod": "^4.3.6" } }, "sha512-qQp8BB/3pWYapTGXBDSBMXRCdrC05VJPLL3drXMPX/QbUB3nuvtyXUGmAZFUz8eLUy7JImODvb3GNIq38dGzhQ=="],
+
+    "@json-render/ink": ["@json-render/ink@0.16.0", "", { "dependencies": { "@json-render/core": "0.16.0", "marked": "^17.0.0" }, "peerDependencies": { "ink": "^6.0.0", "react": "^19.0.0" } }, "sha512-oJ/MbW0zLkv3i6MSZVk8QiI6mbyvtA0XZpJEuJBTCf1yjMMdxN16Mz/uW/5AV9FMOBjZXohQPONLMxvSxil6Bg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -71,7 +81,7 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
 
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
@@ -87,17 +97,27 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
+
+    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -111,6 +131,8 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
@@ -123,11 +145,23 @@
 
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
+    "cli-boxes": ["cli-boxes@4.0.1", "", {}, "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw=="],
+
+    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
+
+    "cli-truncate": ["cli-truncate@6.0.0", "", { "dependencies": { "slice-ansi": "^9.0.0", "string-width": "^8.2.0" } }, "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA=="],
+
+    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
+
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
+    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -141,9 +175,13 @@
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+    "es-toolkit": ["es-toolkit@1.46.0", "", {}, "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
@@ -167,9 +205,15 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "ink": ["ink@7.0.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.3.0", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.3", "auto-bind": "^5.0.1", "chalk": "^5.6.2", "cli-boxes": "^4.0.1", "cli-cursor": "^4.0.0", "cli-truncate": "^6.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.45.1", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^9.0.0", "stack-utils": "^2.0.6", "string-width": "^8.2.0", "terminal-size": "^4.0.1", "type-fest": "^5.5.0", "widest-line": "^6.0.0", "wrap-ansi": "^10.0.0", "ws": "^8.20.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.2.0", "react": ">=19.2.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-o6LAC268PLawlGVYrXTyaTfke4VtJftEheuwbgkQf7yvSXyWp1nRwBbAyKEkWXFZZsW/la5wrMuNbuBvZK2C1w=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -183,9 +227,13 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -198,6 +246,8 @@
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
 
     "mdast": ["mdast@3.0.0", "", {}, "sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g=="],
 
@@ -281,6 +331,8 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
@@ -293,7 +345,11 @@
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
 
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
+    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
@@ -321,6 +377,10 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
+
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
@@ -335,19 +395,37 @@
 
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
+    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
+
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
+
+    "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -362,6 +440,8 @@
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
     "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
+
+    "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
@@ -385,7 +465,15 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
+    "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
+
+    "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -395,9 +483,15 @@
 
     "@google/design.md/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
+    "@json-render/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "mdast-util-frontmatter/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 

--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -89,6 +89,6 @@ describe('spec command', () => {
     const output = JSON.parse(outputStr);
     expect(output.spec).toBeDefined();
     expect(output.rules).toBeDefined();
-    expect(output.rules.length).toBe(8);
+    expect(output.rules.length).toBe(11);
   });
 });

--- a/packages/cli/src/linter/dtcg/handler.test.ts
+++ b/packages/cli/src/linter/dtcg/handler.test.ts
@@ -14,7 +14,9 @@
 
 import { describe, test, expect } from 'bun:test';
 import { DtcgEmitterHandler } from './handler.js';
+import { ModelHandler } from '../model/handler.js';
 import type { DesignSystemState, ResolvedColor, ResolvedDimension, ResolvedTypography } from '../model/spec.js';
+import type { ParsedDesignSystem } from '../parser/spec.js';
 
 function emptyState(overrides?: Partial<DesignSystemState>): DesignSystemState {
   return {
@@ -23,6 +25,8 @@ function emptyState(overrides?: Partial<DesignSystemState>): DesignSystemState {
     rounded: new Map(),
     spacing: new Map(),
     components: new Map(),
+    colorRamps: new Map(),
+    colorPairs: new Map(),
     symbolTable: new Map(),
     ...overrides,
   };
@@ -190,5 +194,59 @@ describe('DtcgEmitterHandler', () => {
     expect(value['fontWeight']).toBeUndefined();
     expect(value['lineHeight']).toBeUndefined();
     expect(value['letterSpacing']).toBeUndefined();
+  });
+
+  describe('ramps and pairs', () => {
+    const model = new ModelHandler();
+    function build(overrides: Partial<ParsedDesignSystem>): DesignSystemState {
+      return model.execute({ sourceMap: new Map(), ...overrides }).designSystem;
+    }
+
+    test('ramps emit as nested DTCG groups with vendor extension and anchor alias', () => {
+      const state = build({
+        colors: {
+          primary: { type: 'ramp', anchor: '#3b82f6', humanName: 'Sky' },
+        },
+      });
+      const result = handler.execute(state);
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      const colorGroup = result.data['color'] as Record<string, unknown>;
+      const primary = colorGroup['primary'] as Record<string, unknown>;
+      expect(primary['$type']).toBe('color');
+      const extensions = primary['$extensions'] as Record<string, Record<string, unknown>>;
+      expect(extensions['design.md']?.['type']).toBe('ramp');
+      expect(extensions['design.md']?.['humanName']).toBe('Sky');
+      expect(primary['500']).toBeDefined();
+      expect(primary['50']).toBeDefined();
+
+      const anchor = primary['anchor'] as Record<string, unknown>;
+      expect(anchor['$value']).toBe('{color.primary.500}');
+    });
+
+    test('standalone pairs emit container + onContainer with role extensions', () => {
+      const state = build({
+        colors: {
+          'surface-info': { type: 'pair', container: '#E0F2FE', onContainer: '#0C4A6E' },
+        },
+      });
+      const result = handler.execute(state);
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      const colorGroup = result.data['color'] as Record<string, unknown>;
+      const pairGroup = colorGroup['surface-info'] as Record<string, unknown>;
+      const ext = pairGroup['$extensions'] as Record<string, Record<string, unknown>>;
+      expect(ext['design.md']?.['type']).toBe('pair');
+
+      const container = pairGroup['container'] as Record<string, unknown>;
+      const containerExt = container['$extensions'] as Record<string, Record<string, unknown>>;
+      expect(containerExt['design.md']?.['role']).toBe('container');
+
+      const onContainer = pairGroup['onContainer'] as Record<string, unknown>;
+      const onContainerExt = onContainer['$extensions'] as Record<string, Record<string, unknown>>;
+      expect(onContainerExt['design.md']?.['role']).toBe('on-container');
+    });
   });
 });

--- a/packages/cli/src/linter/dtcg/handler.ts
+++ b/packages/cli/src/linter/dtcg/handler.ts
@@ -49,11 +49,71 @@ export class DtcgEmitterHandler implements DtcgEmitterSpec {
   private mapColors(state: DesignSystemState): DtcgGroup | null {
     if (state.colors.size === 0) return null;
     const group: DtcgGroup = { $type: 'color' };
-    for (const [name, color] of state.colors) {
-      group[name] = {
-        $value: this.colorToValue(color),
+
+    // Ramps emit as nested groups: every step is a token at `<ramp>.<step>`,
+    // and a sibling alias `<ramp>` aliases the anchor step (default 500) so
+    // unqualified references like `{primary}` keep resolving downstream.
+    for (const [rampName, ramp] of state.colorRamps) {
+      const rampGroup: DtcgGroup = { $type: 'color' };
+      const extension: Record<string, unknown> = { type: 'ramp' };
+      if (ramp.humanName) extension['humanName'] = ramp.humanName;
+      if (ramp.description) extension['description'] = ramp.description;
+      rampGroup['$extensions'] = { 'design.md': extension };
+
+      for (const [step, color] of [...ramp.steps].sort(([a], [b]) => a - b)) {
+        rampGroup[String(step)] = {
+          $value: this.colorToValue(color),
+        } as DtcgToken;
+      }
+      // Anchor alias under the ramp's name. Use a DTCG `$value` reference so
+      // round-trip consumers preserve the link between the two tokens.
+      rampGroup['anchor'] = {
+        $value: `{color.${rampName}.500}`,
       } as DtcgToken;
+      group[rampName] = rampGroup;
     }
+
+    // Standalone pairs emit as nested groups with both members + a vendor
+    // extension that records the pair role. Inline-ramp pairs are flattened
+    // (their members already live in state.colors as hyphenated aliases).
+    for (const [pairName, pair] of state.colorPairs) {
+      if (pair.derivedFromRamp) continue;
+      const pairGroup: DtcgGroup = {
+        $type: 'color',
+        $extensions: { 'design.md': { type: 'pair', minContrast: pair.minContrast } },
+      };
+      pairGroup['container'] = {
+        $value: this.colorToValue(pair.container),
+        $extensions: { 'design.md': { pair: pairName, role: 'container' } },
+      } as DtcgToken;
+      pairGroup['onContainer'] = {
+        $value: this.colorToValue(pair.onContainer),
+        $extensions: { 'design.md': { pair: pairName, role: 'on-container' } },
+      } as DtcgToken;
+      group[pairName] = pairGroup;
+    }
+
+    // Flat colors (and inline-ramp-pair flat aliases) emit as top-level tokens.
+    // Skip:
+    // - ramp steps (already nested under their ramp)
+    // - dotted standalone-pair members (already nested under their pair group)
+    // - flat aliases of standalone pairs (would overwrite the pair group)
+    for (const [name, color] of state.colors) {
+      if (color.rampMember) continue;
+      if (color.pairRole && !pair_isFlatAlias(name)) continue;
+      if (color.pairRole) {
+        const owningPair = state.colorPairs.get(color.pairRole.pair);
+        if (owningPair && !owningPair.derivedFromRamp) continue;
+      }
+      const token: DtcgToken = {
+        $value: this.colorToValue(color),
+      };
+      if (color.pairRole) {
+        token.$extensions = { 'design.md': { pair: color.pairRole.pair, role: color.pairRole.role } };
+      }
+      group[name] = token;
+    }
+
     return group;
   }
 
@@ -115,4 +175,14 @@ export class DtcgEmitterHandler implements DtcgEmitterSpec {
   private round(n: number): number {
     return Math.round(n * 1000) / 1000;
   }
+}
+
+/**
+ * Whether a color map key is a flat pair-member alias (e.g., `primary-container`,
+ * `on-primary-container`, `surface-info`, `on-surface-info`) rather than a
+ * dotted member like `surface-info.container`. Flat aliases are emitted as
+ * top-level DTCG tokens; dotted members already live inside their pair group.
+ */
+function pair_isFlatAlias(name: string): boolean {
+  return !name.includes('.');
 }

--- a/packages/cli/src/linter/dtcg/spec.ts
+++ b/packages/cli/src/linter/dtcg/spec.ts
@@ -42,12 +42,18 @@ export interface DtcgToken {
   $type?: string;
   $value: DtcgColorValue | DtcgDimensionValue | DtcgTypographyValue | string | number;
   $description?: string;
+  /**
+   * DTCG vendor extensions. We use `design.md` as the namespace for ramp
+   * provenance, pair role, and human-readable anchor names.
+   */
+  $extensions?: Record<string, unknown>;
 }
 
 export interface DtcgGroup {
   $type?: string;
   $description?: string;
-  [key: string]: DtcgToken | DtcgGroup | string | undefined;
+  $extensions?: Record<string, unknown>;
+  [key: string]: DtcgToken | DtcgGroup | string | Record<string, unknown> | undefined;
 }
 
 /** The complete tokens.json output file. */

--- a/packages/cli/src/linter/fixture.test.ts
+++ b/packages/cli/src/linter/fixture.test.ts
@@ -58,4 +58,39 @@ describe('Fixture Test', () => {
     // We expect at least the summary info
     expect(result.summary.infos).toBeGreaterThan(0);
   });
+
+  it('processes RAMPS_AND_PAIRS.md end-to-end with no errors', () => {
+    const path = join(import.meta.dir, 'fixtures', 'RAMPS_AND_PAIRS.md');
+    const content = readFileSync(path, 'utf-8');
+
+    const result = lint(content);
+
+    // The fixture is intentionally clean: no errors, no pair-contrast or
+    // mixed-pair-foreground warnings, and no missing humanName warnings.
+    const errors = result.findings.filter(d => d.severity === 'error');
+    expect(errors).toEqual([]);
+    expect(result.findings.some(d => d.message.includes('Pair'))).toBe(false);
+    expect(result.findings.some(d => d.message.includes("missing a 'humanName'"))).toBe(false);
+
+    // Ramp expansion populated steps and the inline-pair flat aliases.
+    const ds = result.designSystem;
+    expect(ds.colorRamps.get('primary')?.humanName).toBe('Ocean');
+    expect(ds.colors.get('primary.500')?.hex).toBe('#3b82f6');
+    expect(ds.colors.get('primary-container')).toBeDefined();
+    expect(ds.colors.get('on-primary-container')).toBeDefined();
+
+    // Standalone pair created both dotted members and hyphen aliases.
+    expect(ds.colorPairs.get('surface-info')).toBeDefined();
+    expect(ds.colors.get('surface-info')?.hex).toBe('#e0f2fe');
+    expect(ds.colors.get('on-surface-info')?.hex).toBe('#0c4a6e');
+
+    // Tailwind output groups the ramp under a nested object.
+    if (!result.tailwindConfig.success) throw new Error('Tailwind emit failed');
+    const colors = result.tailwindConfig.data.theme.extend.colors!;
+    const primary = colors['primary'] as Record<string, string>;
+    expect(primary['DEFAULT']).toBe('#3b82f6');
+    expect(primary['500']).toBe('#3b82f6');
+    expect(colors['surface-info']).toBe('#e0f2fe');
+    expect(colors['primary-container']).toBeDefined();
+  });
 });

--- a/packages/cli/src/linter/fixtures/RAMPS_AND_PAIRS.md
+++ b/packages/cli/src/linter/fixtures/RAMPS_AND_PAIRS.md
@@ -1,0 +1,50 @@
+---
+name: Ramps and Pairs Demo
+colors:
+  primary:
+    type: ramp
+    anchor: "#3b82f6"
+    humanName: "Ocean"
+    description: "Driver for interaction."
+    pairs:
+      container: { bg: 100, fg: 800 }
+  neutral: "#F7F5F2"
+  surface-info:
+    type: pair
+    container: "#E0F2FE"
+    onContainer: "#0C4A6E"
+typography:
+  body-md:
+    fontFamily: Public Sans
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.6
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.neutral}"
+    rounded: 4px
+    padding: 12px
+  callout-info:
+    backgroundColor: "{colors.surface-info}"
+    textColor: "{colors.on-surface-info}"
+    padding: 16px
+  badge-strong:
+    backgroundColor: "{colors.primary-container}"
+    textColor: "{colors.on-primary-container}"
+    padding: 4px
+---
+
+## Overview
+Demonstrates ramp expansion and pair authoring side-by-side with flat tokens.
+
+## Colors
+"Ocean" anchors the ramp at step 500. Steps 50–900 are derived in OKLCH.
+The `surface-info` pair wires container and on-container together; the
+`primary-container` pair is derived inline on the ramp.
+
+## Typography
+Body text only.
+
+## Components
+Three components: a primary button, an info callout, and a strong badge.

--- a/packages/cli/src/linter/linter/rules/index.ts
+++ b/packages/cli/src/linter/linter/rules/index.ts
@@ -23,12 +23,18 @@ import { tokenSummaryRule } from './token-summary.js';
 import { missingSectionsRule } from './missing-sections.js';
 import { sectionOrderRule } from './section-order.js';
 import { missingTypographyRule } from './missing-typography.js';
+import { pairContrastRule } from './pair-contrast.js';
+import { mixedPairForegroundRule } from './mixed-pair-foreground.js';
+import { rampAnchorNamingRule } from './ramp-anchor-naming.js';
 
 /** The default set of lint rule descriptors, in order. */
 export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
   brokenRefRule,
   missingPrimaryRule,
   contrastCheckRule,
+  pairContrastRule,
+  mixedPairForegroundRule,
+  rampAnchorNamingRule,
   orphanedTokensRule,
   tokenSummaryRule,
   missingSectionsRule,
@@ -58,4 +64,7 @@ export { tokenSummary } from './token-summary.js';
 export { missingSections } from './missing-sections.js';
 export { missingTypography } from './missing-typography.js';
 export { sectionOrder } from './section-order.js';
+export { pairContrast } from './pair-contrast.js';
+export { mixedPairForeground } from './mixed-pair-foreground.js';
+export { rampAnchorNaming } from './ramp-anchor-naming.js';
 export type { LintRule } from './types.js';

--- a/packages/cli/src/linter/linter/rules/mixed-pair-foreground.test.ts
+++ b/packages/cli/src/linter/linter/rules/mixed-pair-foreground.test.ts
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { ModelHandler } from '../../model/handler.js';
+import { mixedPairForeground } from './mixed-pair-foreground.js';
+import type { ParsedDesignSystem } from '../../parser/spec.js';
+
+const model = new ModelHandler();
+
+function build(input: Partial<ParsedDesignSystem>) {
+  return model.execute({ sourceMap: new Map(), ...input }).designSystem;
+}
+
+describe('mixed-pair-foreground rule', () => {
+  it('passes when a component pairs container with its matching on-container', () => {
+    const state = build({
+      colors: {
+        'surface-info': { type: 'pair', container: '#E0F2FE', onContainer: '#0C4A6E' },
+      },
+      components: {
+        callout: {
+          backgroundColor: '{colors.surface-info}',
+          textColor: '{colors.on-surface-info}',
+        },
+      },
+    });
+    expect(mixedPairForeground(state)).toEqual([]);
+  });
+
+  it('warns when a component uses the container with an unrelated foreground', () => {
+    const state = build({
+      colors: {
+        'surface-info': { type: 'pair', container: '#E0F2FE', onContainer: '#0C4A6E' },
+        ink: '#1A1C1E',
+      },
+      components: {
+        callout: {
+          backgroundColor: '{colors.surface-info}',
+          textColor: '{colors.ink}',
+        },
+      },
+    });
+    const findings = mixedPairForeground(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.path).toBe('components.callout.textColor');
+    expect(findings[0]?.message).toContain("'callout'");
+    expect(findings[0]?.message).toContain('on-container');
+  });
+
+  it('ignores components whose backgroundColor is not a pair container', () => {
+    const state = build({
+      colors: { neutral: '#F7F5F2', ink: '#1A1C1E' },
+      components: {
+        body: {
+          backgroundColor: '{colors.neutral}',
+          textColor: '{colors.ink}',
+        },
+      },
+    });
+    expect(mixedPairForeground(state)).toEqual([]);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/mixed-pair-foreground.ts
+++ b/packages/cli/src/linter/linter/rules/mixed-pair-foreground.ts
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState, ResolvedColor, ResolvedValue } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Mixed pair foreground — a component using a pair's container as backgroundColor
+ * must use the matching on-container as textColor (not some unrelated color).
+ * Catches the "right container, wrong foreground" failure mode that breaks the
+ * pair's contrast contract.
+ */
+export function mixedPairForeground(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  for (const [compName, comp] of state.components) {
+    const bgValue = comp.properties.get('backgroundColor');
+    const textValue = comp.properties.get('textColor');
+    if (!bgValue || !textValue) continue;
+
+    const bgColor = asColor(bgValue);
+    const textColor = asColor(textValue);
+    if (!bgColor || !textColor) continue;
+
+    const bgRole = bgColor.pairRole;
+    if (!bgRole || bgRole.role !== 'container') continue;
+
+    const partner = state.colorPairs.get(bgRole.pair);
+    if (!partner) continue;
+
+    if (textColor.hex !== partner.onContainer.hex) {
+      findings.push({
+        path: `components.${compName}.textColor`,
+        message: `'${compName}' uses pair '${bgRole.pair}' container as backgroundColor but textColor (${textColor.hex}) is not the matching on-container (${partner.onContainer.hex}).`,
+      });
+    }
+  }
+  return findings;
+}
+
+function asColor(value: ResolvedValue): ResolvedColor | null {
+  if (typeof value === 'object' && value !== null && 'type' in value && value.type === 'color') {
+    return value as ResolvedColor;
+  }
+  return null;
+}
+
+export const mixedPairForegroundRule: RuleDescriptor = {
+  name: 'mixed-pair-foreground',
+  severity: 'warning',
+  description: 'Component using a pair container as backgroundColor must use the matching on-container as textColor.',
+  run: mixedPairForeground,
+};

--- a/packages/cli/src/linter/linter/rules/orphaned-tokens.test.ts
+++ b/packages/cli/src/linter/linter/rules/orphaned-tokens.test.ts
@@ -33,4 +33,34 @@ describe('orphanedTokens', () => {
     const state = buildState({ colors: { primary: '#ff0000' } });
     expect(orphanedTokens(state)).toEqual([]);
   });
+
+  it('does not flag individual ramp steps when only the anchor is referenced', () => {
+    const state = buildState({
+      colors: { primary: { type: 'ramp', anchor: '#3b82f6', humanName: 'Sky' } },
+      components: {
+        button: { backgroundColor: '{colors.primary}' },
+      },
+    });
+    const findings = orphanedTokens(state);
+    // Steps like primary.50, primary.100, ... should not appear.
+    expect(findings.some(f => f.path?.includes('primary.'))).toBe(false);
+    // Anchor itself is referenced, so not orphaned.
+    expect(findings.some(f => f.path === 'colors.primary')).toBe(false);
+  });
+
+  it('does not flag pair members when the pair is referenced', () => {
+    const state = buildState({
+      colors: {
+        'surface-info': { type: 'pair', container: '#E0F2FE', onContainer: '#0C4A6E' },
+      },
+      components: {
+        callout: {
+          backgroundColor: '{colors.surface-info}',
+          textColor: '{colors.on-surface-info}',
+        },
+      },
+    });
+    const findings = orphanedTokens(state);
+    expect(findings.some(f => f.path?.startsWith('colors.surface-info'))).toBe(false);
+  });
 });

--- a/packages/cli/src/linter/linter/rules/orphaned-tokens.ts
+++ b/packages/cli/src/linter/linter/rules/orphaned-tokens.ts
@@ -17,6 +17,11 @@ import type { RuleDescriptor, RuleFinding } from './types.js';
 
 /**
  * Orphaned tokens — tokens defined but never referenced by any component.
+ *
+ * Ramp-derived steps and pair-derived members are exempt: they are synthesized
+ * from a single declaration, so flagging each individually would flood the
+ * report. Only the ramp anchor (or the pair name itself) triggers the warning
+ * when nothing in the system references the group.
  */
 export function orphanedTokens(state: DesignSystemState): RuleFinding[] {
   if (state.components.size === 0) return [];
@@ -34,15 +39,39 @@ export function orphanedTokens(state: DesignSystemState): RuleFinding[] {
     }
   }
 
+  // Treat any reference to a ramp step or pair member as a reference to the
+  // group as a whole — so the anchor / pair doesn't get falsely flagged.
+  const referencedRamps = new Set<string>();
+  const referencedPairs = new Set<string>();
+  for (const path of referencedPaths) {
+    const colorKey = path.startsWith('colors.') ? path.slice('colors.'.length) : null;
+    if (!colorKey) continue;
+    const resolved = state.colors.get(colorKey);
+    if (resolved?.rampMember) referencedRamps.add(resolved.rampMember.ramp);
+    if (resolved?.pairRole) referencedPairs.add(resolved.pairRole.pair);
+  }
+
   const findings: RuleFinding[] = [];
-  for (const [name] of state.colors) {
+  for (const [name, color] of state.colors) {
+    // Skip ramp steps and pair members; they're reported via their group, not individually.
+    if (color.rampMember && color.rampMember.ramp !== name) continue;
+    if (color.pairRole) continue;
+
     const path = `colors.${name}`;
-    if (!referencedPaths.has(path)) {
-      findings.push({
-        path,
-        message: `'${name}' is defined but never referenced by any component.`,
-      });
+    if (referencedPaths.has(path)) continue;
+
+    // For a ramp anchor, also check whether any of its steps or derived pairs are referenced.
+    if (color.rampMember && referencedRamps.has(color.rampMember.ramp)) continue;
+    const ramp = state.colorRamps.get(name);
+    if (ramp) {
+      const derivedPairUsed = [...ramp.pairs.keys()].some(k => referencedPairs.has(`${name}-${k}`));
+      if (derivedPairUsed) continue;
     }
+
+    findings.push({
+      path,
+      message: `'${name}' is defined but never referenced by any component.`,
+    });
   }
   return findings;
 }

--- a/packages/cli/src/linter/linter/rules/pair-contrast.test.ts
+++ b/packages/cli/src/linter/linter/rules/pair-contrast.test.ts
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { ModelHandler } from '../../model/handler.js';
+import { pairContrast } from './pair-contrast.js';
+import type { ParsedDesignSystem } from '../../parser/spec.js';
+
+const model = new ModelHandler();
+
+function build(colors: NonNullable<ParsedDesignSystem['colors']>) {
+  return model.execute({ sourceMap: new Map(), colors }).designSystem;
+}
+
+describe('pair-contrast rule', () => {
+  it('passes when pair contrast meets the default 4.5:1 floor', () => {
+    const state = build({
+      'surface-info': { type: 'pair', container: '#E0F2FE', onContainer: '#0C4A6E' },
+    });
+    expect(pairContrast(state)).toEqual([]);
+  });
+
+  it('emits a finding when pair contrast falls below the declared floor', () => {
+    const state = build({
+      muddy: { type: 'pair', container: '#777777', onContainer: '#888888' },
+    });
+    const findings = pairContrast(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.path).toBe('colors.muddy');
+    expect(findings[0]?.message).toContain('below the declared floor');
+  });
+
+  it('respects an explicit minContrast (AAA)', () => {
+    // 4.6:1 passes AA but fails AAA (7:1).
+    const state = build({
+      borderline: { type: 'pair', container: '#FFFFFF', onContainer: '#767676', minContrast: 7 },
+    });
+    expect(pairContrast(state).length).toBe(1);
+  });
+
+  it('returns no findings when no pairs are declared', () => {
+    const state = build({ neutral: '#F7F5F2' });
+    expect(pairContrast(state)).toEqual([]);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/pair-contrast.ts
+++ b/packages/cli/src/linter/linter/rules/pair-contrast.ts
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import { contrastRatio } from '../../model/handler.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Pair contrast — every declared color pair must satisfy its minContrast floor.
+ * Fires once per pair whose container/on-container ratio falls below the floor.
+ */
+export function pairContrast(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  for (const [, pair] of state.colorPairs) {
+    const ratio = contrastRatio(pair.container, pair.onContainer);
+    if (ratio < pair.minContrast) {
+      findings.push({
+        path: `colors.${pair.name}`,
+        message: `Pair '${pair.name}' has contrast ratio ${ratio.toFixed(2)}:1 between container (${pair.container.hex}) and on-container (${pair.onContainer.hex}), below the declared floor of ${pair.minContrast}:1.`,
+      });
+    }
+  }
+  return findings;
+}
+
+export const pairContrastRule: RuleDescriptor = {
+  name: 'pair-contrast',
+  severity: 'error',
+  description: 'Every declared color pair must satisfy its minContrast floor (default 4.5:1, WCAG AA body).',
+  run: pairContrast,
+};

--- a/packages/cli/src/linter/linter/rules/ramp-anchor-naming.test.ts
+++ b/packages/cli/src/linter/linter/rules/ramp-anchor-naming.test.ts
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { ModelHandler } from '../../model/handler.js';
+import { rampAnchorNaming } from './ramp-anchor-naming.js';
+import type { ParsedDesignSystem } from '../../parser/spec.js';
+
+const model = new ModelHandler();
+
+function build(colors: NonNullable<ParsedDesignSystem['colors']>) {
+  return model.execute({ sourceMap: new Map(), colors }).designSystem;
+}
+
+describe('ramp-anchor-naming rule', () => {
+  it('warns when a ramp lacks humanName', () => {
+    const state = build({
+      primary: { type: 'ramp', anchor: '#1A1C1E' },
+    });
+    const findings = rampAnchorNaming(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]?.path).toBe('colors.primary');
+    expect(findings[0]?.message).toContain('humanName');
+  });
+
+  it('passes when humanName is declared', () => {
+    const state = build({
+      primary: { type: 'ramp', anchor: '#1A1C1E', humanName: 'Boston Clay' },
+    });
+    expect(rampAnchorNaming(state)).toEqual([]);
+  });
+
+  it('does not run on flat colors', () => {
+    const state = build({ neutral: '#F7F5F2' });
+    expect(rampAnchorNaming(state)).toEqual([]);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/ramp-anchor-naming.ts
+++ b/packages/cli/src/linter/linter/rules/ramp-anchor-naming.ts
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Ramp anchor naming — every ramp should declare a `humanName` (e.g., "Boston Clay")
+ * so prose can anchor hex literals to a named color and downstream rules
+ * (prose-token-mismatch, #4) can validate "Boston Clay (#1A1C1E)" sentences.
+ */
+export function rampAnchorNaming(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  for (const [, ramp] of state.colorRamps) {
+    if (!ramp.humanName) {
+      findings.push({
+        path: `colors.${ramp.name}`,
+        message: `Ramp '${ramp.name}' is missing a 'humanName'. Add one (e.g., humanName: "Boston Clay") so prose can reference it by name.`,
+      });
+    }
+  }
+  return findings;
+}
+
+export const rampAnchorNamingRule: RuleDescriptor = {
+  name: 'ramp-anchor-naming',
+  severity: 'warning',
+  description: 'Every ramp should declare a humanName for prose anchoring.',
+  run: rampAnchorNaming,
+};

--- a/packages/cli/src/linter/linter/rules/types.test.ts
+++ b/packages/cli/src/linter/linter/rules/types.test.ts
@@ -25,6 +25,8 @@ describe('LintRule type', () => {
       rounded: new Map(),
       spacing: new Map(),
       components: new Map(),
+      colorRamps: new Map(),
+      colorPairs: new Map(),
       symbolTable: new Map(),
     })).toEqual([]);
   });
@@ -40,7 +42,7 @@ describe('LintRule type', () => {
   });
 
   it('has all rules in DEFAULT_RULE_DESCRIPTORS', () => {
-    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(8);
+    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(11);
     DEFAULT_RULE_DESCRIPTORS.forEach((rule: RuleDescriptor) => {
       expect(rule.name).toBeTruthy();
       expect(rule.severity).toBeTruthy();

--- a/packages/cli/src/linter/model/color-ramp.test.ts
+++ b/packages/cli/src/linter/model/color-ramp.test.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { generateRampSteps, srgbToOklch, oklchToSrgb, DEFAULT_RAMP_STEPS } from './color-ramp.js';
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const h = hex.startsWith('#') ? hex.slice(1) : hex;
+  return {
+    r: parseInt(h.slice(0, 2), 16) / 255,
+    g: parseInt(h.slice(2, 4), 16) / 255,
+    b: parseInt(h.slice(4, 6), 16) / 255,
+  };
+}
+
+describe('OKLCH conversion', () => {
+  it('round-trips a mid-value sRGB color within ~0.5% per channel', () => {
+    const rgb = hexToRgb('#3b82f6');
+    const oklch = srgbToOklch(rgb);
+    const back = oklchToSrgb(oklch);
+    expect(Math.abs(back.r - rgb.r)).toBeLessThan(0.005);
+    expect(Math.abs(back.g - rgb.g)).toBeLessThan(0.005);
+    expect(Math.abs(back.b - rgb.b)).toBeLessThan(0.005);
+  });
+
+  it('places pure white at L≈1 and pure black at L≈0', () => {
+    expect(srgbToOklch({ r: 1, g: 1, b: 1 }).L).toBeCloseTo(1, 1);
+    expect(srgbToOklch({ r: 0, g: 0, b: 0 }).L).toBeCloseTo(0, 1);
+  });
+});
+
+describe('generateRampSteps', () => {
+  it('produces all default steps with the anchor preserved verbatim at 500', () => {
+    const steps = generateRampSteps('#1A1C1E');
+    expect(steps.size).toBe(DEFAULT_RAMP_STEPS.length);
+    expect(steps.get(500)).toBe('#1a1c1e');
+  });
+
+  it('lighter steps have higher OKLab lightness; darker steps have lower', () => {
+    const steps = generateRampSteps('#3b82f6'); // mid-lightness blue
+    const lightnessOf = (hex: string) => srgbToOklch(hexToRgb(hex)).L;
+
+    const ladder = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900].map(s => lightnessOf(steps.get(s)!));
+    for (let i = 1; i < ladder.length; i++) {
+      // Each next step should be at least as dark as the previous (within float noise).
+      expect(ladder[i]).toBeLessThanOrEqual(ladder[i - 1]! + 1e-6);
+    }
+  });
+
+  it('respects a custom step list', () => {
+    const steps = generateRampSteps('#ff0000', [100, 500, 900]);
+    expect(steps.size).toBe(3);
+    expect(steps.has(100)).toBe(true);
+    expect(steps.has(500)).toBe(true);
+    expect(steps.has(900)).toBe(true);
+  });
+
+  it('throws on malformed anchor hex', () => {
+    expect(() => generateRampSteps('not-a-hex')).toThrow();
+  });
+});

--- a/packages/cli/src/linter/model/color-ramp.ts
+++ b/packages/cli/src/linter/model/color-ramp.ts
@@ -1,0 +1,157 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * OKLCH color math for ramp interpolation.
+ *
+ * Reference: Björn Ottosson's OKLab specification
+ * https://bottosson.github.io/posts/oklab/
+ *
+ * Pipeline: hex → sRGB → linear sRGB → LMS → OKLab → OKLCH → (interpolate L) →
+ *           OKLab → LMS → linear sRGB → sRGB → hex.
+ *
+ * Steps map to a target lightness via linear interpolation from the anchor's
+ * lightness toward L=1.0 (lighter steps) or L=0.0 (darker steps). Anchor is
+ * step 500 by default; the anchor's chroma and hue are preserved.
+ */
+
+export const DEFAULT_RAMP_STEPS = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900] as const;
+const ANCHOR_STEP = 500;
+
+export interface OkLch {
+  L: number;
+  C: number;
+  /** Hue in degrees, 0..360. */
+  h: number;
+}
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+function srgbToLinear(c: number): number {
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function linearToSrgb(c: number): number {
+  return c <= 0.0031308 ? 12.92 * c : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+}
+
+function clamp01(c: number): number {
+  return c < 0 ? 0 : c > 1 ? 1 : c;
+}
+
+/** Hex (#RRGGBB or #RGB) → 0..1 sRGB triple. Throws on malformed input. */
+function hexToRgb(hex: string): Rgb {
+  let h = hex.trim().toLowerCase();
+  if (h.startsWith('#')) h = h.slice(1);
+  if (h.length === 3) h = h.split('').map(c => c + c).join('');
+  if (h.length === 4) h = h.slice(0, 3).split('').map(c => c + c).join('');
+  if (h.length === 8) h = h.slice(0, 6);
+  if (h.length !== 6) throw new Error(`Invalid hex: ${hex}`);
+  const n = parseInt(h, 16);
+  return {
+    r: ((n >> 16) & 0xff) / 255,
+    g: ((n >> 8) & 0xff) / 255,
+    b: (n & 0xff) / 255,
+  };
+}
+
+function rgbToHex({ r, g, b }: Rgb): string {
+  const to = (c: number) => Math.round(clamp01(c) * 255).toString(16).padStart(2, '0');
+  return `#${to(r)}${to(g)}${to(b)}`;
+}
+
+/** sRGB (0..1) → OKLCH. */
+export function srgbToOklch({ r, g, b }: Rgb): OkLch {
+  const lr = srgbToLinear(r);
+  const lg = srgbToLinear(g);
+  const lb = srgbToLinear(b);
+
+  const l_ = Math.cbrt(0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb);
+  const m_ = Math.cbrt(0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb);
+  const s_ = Math.cbrt(0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb);
+
+  const L = 0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_;
+  const a = 1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_;
+  const bb = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_;
+
+  const C = Math.hypot(a, bb);
+  let h = (Math.atan2(bb, a) * 180) / Math.PI;
+  if (h < 0) h += 360;
+
+  return { L, C, h };
+}
+
+/** OKLCH → sRGB (0..1). May produce out-of-gamut values; caller should clamp. */
+export function oklchToSrgb({ L, C, h }: OkLch): Rgb {
+  const a = C * Math.cos((h * Math.PI) / 180);
+  const b = C * Math.sin((h * Math.PI) / 180);
+
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.2914855480 * b;
+
+  const lc = l_ * l_ * l_;
+  const mc = m_ * m_ * m_;
+  const sc = s_ * s_ * s_;
+
+  const lr = +4.0767416621 * lc - 3.3077115913 * mc + 0.2309699292 * sc;
+  const lg = -1.2684380046 * lc + 2.6097574011 * mc - 0.3413193965 * sc;
+  const lb = -0.0041960863 * lc - 0.7034186147 * mc + 1.7076147010 * sc;
+
+  return {
+    r: clamp01(linearToSrgb(lr)),
+    g: clamp01(linearToSrgb(lg)),
+    b: clamp01(linearToSrgb(lb)),
+  };
+}
+
+/**
+ * Compute the target OKLab lightness for a step given the anchor's lightness.
+ * Steps below ANCHOR_STEP (500) interpolate toward white (L=1); steps above
+ * interpolate toward black (L=0). The anchor itself is preserved at step 500.
+ */
+function targetLightness(step: number, anchorL: number): number {
+  if (step === ANCHOR_STEP) return anchorL;
+  if (step < ANCHOR_STEP) {
+    const t = (ANCHOR_STEP - step) / ANCHOR_STEP;
+    return anchorL + (1 - anchorL) * t;
+  }
+  const t = (step - ANCHOR_STEP) / (1000 - ANCHOR_STEP);
+  return anchorL * (1 - t);
+}
+
+/**
+ * Generate ramp step colors as hex strings keyed by step number.
+ * Preserves the anchor's chroma and hue across all steps; varies L only.
+ * The anchor's hex is reused exactly at step 500 to avoid round-trip drift.
+ */
+export function generateRampSteps(anchorHex: string, steps: readonly number[] = DEFAULT_RAMP_STEPS): Map<number, string> {
+  const anchorRgb = hexToRgb(anchorHex);
+  const anchorOklch = srgbToOklch(anchorRgb);
+  const out = new Map<number, string>();
+  for (const step of steps) {
+    if (step === ANCHOR_STEP) {
+      out.set(step, anchorHex.toLowerCase().startsWith('#') ? anchorHex.toLowerCase() : `#${anchorHex.toLowerCase()}`);
+      continue;
+    }
+    const L = targetLightness(step, anchorOklch.L);
+    const rgb = oklchToSrgb({ L, C: anchorOklch.C, h: anchorOklch.h });
+    out.set(step, rgbToHex(rgb));
+  }
+  return out;
+}

--- a/packages/cli/src/linter/model/handler.ramps-pairs.test.ts
+++ b/packages/cli/src/linter/model/handler.ramps-pairs.test.ts
@@ -1,0 +1,176 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { ModelHandler } from './handler.js';
+import type { ParsedDesignSystem } from '../parser/spec.js';
+import type { ResolvedColor, ResolvedValue } from './spec.js';
+
+const handler = new ModelHandler();
+
+function makeParsed(overrides: Partial<ParsedDesignSystem> = {}): ParsedDesignSystem {
+  return { sourceMap: new Map(), ...overrides };
+}
+
+function asColor(v: ResolvedValue | undefined): ResolvedColor | null {
+  if (typeof v === 'object' && v !== null && 'type' in v && v.type === 'color') return v as ResolvedColor;
+  return null;
+}
+
+describe('ModelHandler — ramp expansion', () => {
+  it('expands a ramp into anchor + every step in colors and symbolTable', () => {
+    const result = handler.execute(makeParsed({
+      colors: {
+        primary: { type: 'ramp', anchor: '#1A1C1E', humanName: 'Boston Clay' },
+      },
+    }));
+    expect(result.findings.filter(f => f.severity === 'error')).toEqual([]);
+    const ds = result.designSystem;
+
+    const anchor = ds.colors.get('primary');
+    expect(anchor?.hex).toBe('#1a1c1e');
+    expect(anchor?.humanName).toBe('Boston Clay');
+
+    // Every default step is in the flat colors map and in the symbol table.
+    for (const step of [50, 100, 200, 300, 400, 500, 600, 700, 800, 900]) {
+      const flat = ds.colors.get(`primary.${step}`);
+      expect(flat).toBeDefined();
+      expect(flat?.rampMember).toEqual({ ramp: 'primary', step });
+      expect(asColor(ds.symbolTable.get(`colors.primary.${step}`))?.hex).toBe(flat?.hex);
+    }
+  });
+
+  it('records ramp metadata in state.colorRamps', () => {
+    const result = handler.execute(makeParsed({
+      colors: {
+        primary: { type: 'ramp', anchor: '#1A1C1E', humanName: 'Boston Clay', description: 'Driver for interaction.' },
+      },
+    }));
+    const ramp = result.designSystem.colorRamps.get('primary');
+    expect(ramp).toBeDefined();
+    expect(ramp?.humanName).toBe('Boston Clay');
+    expect(ramp?.description).toBe('Driver for interaction.');
+    expect(ramp?.steps.size).toBe(10);
+  });
+
+  it('synthesizes flat aliases for inline-ramp pair derivations', () => {
+    const result = handler.execute(makeParsed({
+      colors: {
+        primary: {
+          type: 'ramp',
+          anchor: '#3b82f6',
+          pairs: { container: { bg: 100, fg: 800 } },
+        },
+      },
+    }));
+    expect(result.findings.filter(f => f.severity === 'error')).toEqual([]);
+
+    const ds = result.designSystem;
+    const container = ds.colors.get('primary-container');
+    const onContainer = ds.colors.get('on-primary-container');
+    expect(container?.pairRole).toEqual({ pair: 'primary-container', role: 'container' });
+    expect(onContainer?.pairRole).toEqual({ pair: 'primary-container', role: 'on-container' });
+    // The flat alias references the same hex as the underlying step.
+    expect(container?.hex).toBe(ds.colors.get('primary.100')!.hex);
+    expect(onContainer?.hex).toBe(ds.colors.get('primary.800')!.hex);
+  });
+
+  it('flags inline-ramp pairs that reference a step the ramp does not declare', () => {
+    const result = handler.execute(makeParsed({
+      colors: {
+        primary: {
+          type: 'ramp',
+          anchor: '#3b82f6',
+          steps: [100, 500, 900],
+          pairs: { container: { bg: 200, fg: 800 } },
+        },
+      },
+    }));
+    expect(result.findings.some(f => f.severity === 'error' && f.message.includes('does not declare'))).toBe(true);
+  });
+
+  it('flags a ramp with a malformed anchor', () => {
+    const result = handler.execute(makeParsed({
+      colors: { primary: { type: 'ramp', anchor: 'not-a-hex' } },
+    }));
+    expect(result.findings.some(f => f.severity === 'error' && f.path === 'colors.primary.anchor')).toBe(true);
+  });
+});
+
+describe('ModelHandler — pair expansion', () => {
+  it('expands a standalone pair into dotted members and hyphenated aliases', () => {
+    const result = handler.execute(makeParsed({
+      colors: {
+        'surface-info': { type: 'pair', container: '#E0F2FE', onContainer: '#0C4A6E' },
+      },
+    }));
+    expect(result.findings.filter(f => f.severity === 'error')).toEqual([]);
+    const ds = result.designSystem;
+
+    expect(ds.colors.get('surface-info.container')?.hex).toBe('#e0f2fe');
+    expect(ds.colors.get('surface-info.onContainer')?.hex).toBe('#0c4a6e');
+    expect(ds.colors.get('surface-info')?.hex).toBe('#e0f2fe'); // alias = container
+    expect(ds.colors.get('on-surface-info')?.hex).toBe('#0c4a6e'); // alias = on-container
+
+    // Symbol table has every form so any reference style resolves.
+    expect(asColor(ds.symbolTable.get('colors.surface-info.container'))?.hex).toBe('#e0f2fe');
+    expect(asColor(ds.symbolTable.get('colors.surface-info.onContainer'))?.hex).toBe('#0c4a6e');
+    expect(asColor(ds.symbolTable.get('colors.surface-info'))?.hex).toBe('#e0f2fe');
+    expect(asColor(ds.symbolTable.get('colors.on-surface-info'))?.hex).toBe('#0c4a6e');
+  });
+
+  it('records pair metadata in state.colorPairs', () => {
+    const result = handler.execute(makeParsed({
+      colors: {
+        'surface-info': { type: 'pair', container: '#E0F2FE', onContainer: '#0C4A6E', minContrast: 7 },
+      },
+    }));
+    const pair = result.designSystem.colorPairs.get('surface-info');
+    expect(pair).toBeDefined();
+    expect(pair?.minContrast).toBe(7);
+    expect(pair?.container.hex).toBe('#e0f2fe');
+    expect(pair?.onContainer.hex).toBe('#0c4a6e');
+  });
+
+  it('does not error at parse time when pair contrast is poor (rule reports it instead)', () => {
+    // Two near-identical greys will fail any reasonable contrast floor.
+    const result = handler.execute(makeParsed({
+      colors: {
+        muddy: { type: 'pair', container: '#777777', onContainer: '#888888' },
+      },
+    }));
+    // Model accepts the declaration; the lint rule is responsible for emitting findings.
+    expect(result.findings.filter(f => f.severity === 'error')).toEqual([]);
+  });
+
+  it('flags a pair with a malformed member hex', () => {
+    const result = handler.execute(makeParsed({
+      colors: {
+        bad: { type: 'pair', container: 'not-a-hex', onContainer: '#000' },
+      },
+    }));
+    expect(result.findings.some(f => f.severity === 'error' && f.path === 'colors.bad.container')).toBe(true);
+  });
+});
+
+describe('ModelHandler — back-compat with flat colors', () => {
+  it('flat hex colors continue to resolve to the colors map', () => {
+    const result = handler.execute(makeParsed({
+      colors: { neutral: '#F7F5F2' },
+    }));
+    expect(result.designSystem.colors.get('neutral')?.hex).toBe('#f7f5f2');
+    expect(result.designSystem.colorRamps.size).toBe(0);
+    expect(result.designSystem.colorPairs.size).toBe(0);
+  });
+});

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { ParsedDesignSystem } from '../parser/spec.js';
+import type { ParsedDesignSystem, RawColorValue, RawRampDef, RawPairDef } from '../parser/spec.js';
 import type {
   ModelSpec,
   ModelResult,
@@ -22,9 +22,12 @@ import type {
   ResolvedValue,
   ComponentDef,
   Finding,
+  RampDef,
+  PairDef,
 } from './spec.js';
 
 import { isValidColor, isParseableDimension, isTokenReference, parseDimensionParts } from './spec.js';
+import { generateRampSteps, DEFAULT_RAMP_STEPS } from './color-ramp.js';
 
 const MAX_REFERENCE_DEPTH = 10;
 
@@ -43,26 +46,32 @@ export class ModelHandler implements ModelSpec {
       const typography = new Map<string, ResolvedTypography>();
       const rounded = new Map<string, ResolvedDimension>();
       const spacing = new Map<string, ResolvedDimension>();
+      const colorRamps = new Map<string, RampDef>();
+      const colorPairs = new Map<string, PairDef>();
 
       // ── Phase 1: Resolve primitive tokens ──────────────────────────
       // Colors
       if (input.colors) {
         for (const [name, raw] of Object.entries(input.colors)) {
-          if (isTokenReference(raw)) {
-            // Store raw reference for later resolution
-            symbolTable.set(`colors.${name}`, raw);
-          } else if (isValidColor(raw)) {
-            const resolved = parseColor(raw);
-            colors.set(name, resolved);
-            symbolTable.set(`colors.${name}`, resolved);
-          } else {
-            findings.push({
-              severity: 'error',
-              path: `colors.${name}`,
-              message: `'${raw}' is not a valid color. Expected a hex color code (e.g., #ffffff).`,
-            });
-            // Store as-is for fallback
-            symbolTable.set(`colors.${name}`, raw);
+          if (typeof raw === 'string') {
+            if (isTokenReference(raw)) {
+              // Store raw reference for later resolution
+              symbolTable.set(`colors.${name}`, raw);
+            } else if (isValidColor(raw)) {
+              const resolved = parseColor(raw);
+              colors.set(name, resolved);
+              symbolTable.set(`colors.${name}`, resolved);
+            } else {
+              findings.push({
+                severity: 'error',
+                path: `colors.${name}`,
+                message: `'${raw}' is not a valid color. Expected a hex color code (e.g., #ffffff).`,
+              });
+              // Store as-is for fallback
+              symbolTable.set(`colors.${name}`, raw);
+            }
+          } else if (raw && typeof raw === 'object') {
+            expandObjectColor(name, raw, { colors, colorRamps, colorPairs, symbolTable, findings });
           }
         }
       }
@@ -122,7 +131,7 @@ export class ModelHandler implements ModelSpec {
       // Iterate color entries that are still raw references and resolve them
       if (input.colors) {
         for (const [name, raw] of Object.entries(input.colors)) {
-          if (isTokenReference(raw)) {
+          if (typeof raw === 'string' && isTokenReference(raw)) {
             const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
             if (resolved !== null && typeof resolved === 'object' && 'type' in resolved && resolved.type === 'color') {
               colors.set(name, resolved as ResolvedColor);
@@ -207,6 +216,8 @@ export class ModelHandler implements ModelSpec {
           rounded,
           spacing,
           components,
+          colorRamps,
+          colorPairs,
           symbolTable,
           sections: input.sections,
         },
@@ -220,6 +231,8 @@ export class ModelHandler implements ModelSpec {
           rounded: new Map(),
           spacing: new Map(),
           components: new Map(),
+          colorRamps: new Map(),
+          colorPairs: new Map(),
           symbolTable: new Map(),
         },
         findings: [
@@ -233,6 +246,163 @@ export class ModelHandler implements ModelSpec {
     }
   }
 }
+
+// ── Object-shaped color expansion (ramps and pairs) ────────────────
+
+interface ExpansionContext {
+  colors: Map<string, ResolvedColor>;
+  colorRamps: Map<string, RampDef>;
+  colorPairs: Map<string, PairDef>;
+  symbolTable: Map<string, ResolvedValue>;
+  findings: Finding[];
+}
+
+/**
+ * Expand an object-shaped color value (ramp or pair) into the flat colors map
+ * and the symbol table. Emits findings for malformed input or pair contrast
+ * floor violations. Unknown object shapes produce a recoverable error finding.
+ */
+function expandObjectColor(name: string, raw: RawRampDef | RawPairDef, ctx: ExpansionContext): void {
+  if (raw.type === 'ramp') {
+    expandRamp(name, raw, ctx);
+  } else if (raw.type === 'pair') {
+    expandPair(name, raw, ctx);
+  } else {
+    ctx.findings.push({
+      severity: 'error',
+      path: `colors.${name}`,
+      message: `Unknown color shape '${(raw as { type?: string }).type ?? 'object'}'. Expected 'ramp' or 'pair'.`,
+    });
+  }
+}
+
+function expandRamp(name: string, raw: RawRampDef, ctx: ExpansionContext): void {
+  if (typeof raw.anchor !== 'string' || !isValidColor(raw.anchor)) {
+    ctx.findings.push({
+      severity: 'error',
+      path: `colors.${name}.anchor`,
+      message: `'${raw.anchor}' is not a valid hex anchor. Expected a hex color code (e.g., #ffffff).`,
+    });
+    return;
+  }
+  const steps = raw.steps && raw.steps.length > 0 ? raw.steps : [...DEFAULT_RAMP_STEPS];
+  const stepHexes = generateRampSteps(raw.anchor, steps);
+
+  const stepColors = new Map<number, ResolvedColor>();
+  for (const [step, hex] of stepHexes) {
+    const resolved = parseColor(hex);
+    resolved.rampMember = { ramp: name, step };
+    stepColors.set(step, resolved);
+    ctx.colors.set(`${name}.${step}`, resolved);
+    ctx.symbolTable.set(`colors.${name}.${step}`, resolved);
+  }
+
+  // Anchor lives at the bare ramp name. Use the user's literal hex (avoids round-trip drift).
+  const anchorColor = parseColor(raw.anchor);
+  anchorColor.rampMember = { ramp: name, step: 500 };
+  if (raw.humanName) anchorColor.humanName = raw.humanName;
+  ctx.colors.set(name, anchorColor);
+  ctx.symbolTable.set(`colors.${name}`, anchorColor);
+
+  const ramp: RampDef = {
+    name,
+    anchor: anchorColor,
+    steps: stepColors,
+    pairs: new Map(),
+  };
+  if (raw.humanName) ramp.humanName = raw.humanName;
+  if (raw.description) ramp.description = raw.description;
+  ctx.colorRamps.set(name, ramp);
+
+  // Inline pair derivations: synthesize pair entries + flat M3-style aliases.
+  if (raw.pairs) {
+    for (const [pairKey, { bg, fg }] of Object.entries(raw.pairs)) {
+      const bgColor = stepColors.get(bg);
+      const fgColor = stepColors.get(fg);
+      if (!bgColor || !fgColor) {
+        ctx.findings.push({
+          severity: 'error',
+          path: `colors.${name}.pairs.${pairKey}`,
+          message: `Pair '${pairKey}' references step ${!bgColor ? bg : fg}, but the ramp does not declare that step.`,
+        });
+        continue;
+      }
+      ramp.pairs.set(pairKey, { bg, fg });
+
+      const pairName = `${name}-${pairKey}`;
+      const onPairName = `on-${name}-${pairKey}`;
+      // Pair entries are flat aliases for the underlying ramp steps; strip
+      // rampMember so the Tailwind/DTCG exporters and orphaned-tokens treat
+      // them as standalone pair members rather than ramp steps.
+      const { rampMember: _bgStep, ...bgRest } = bgColor;
+      const { rampMember: _fgStep, ...fgRest } = fgColor;
+      const containerEntry: ResolvedColor = { ...bgRest, pairRole: { pair: pairName, role: 'container' } };
+      const onContainerEntry: ResolvedColor = { ...fgRest, pairRole: { pair: pairName, role: 'on-container' } };
+
+      ctx.colors.set(pairName, containerEntry);
+      ctx.colors.set(onPairName, onContainerEntry);
+      ctx.symbolTable.set(`colors.${pairName}`, containerEntry);
+      ctx.symbolTable.set(`colors.${onPairName}`, onContainerEntry);
+
+      const pair: PairDef = {
+        name: pairName,
+        container: containerEntry,
+        onContainer: onContainerEntry,
+        minContrast: WCAG_AA_BODY,
+        derivedFromRamp: name,
+      };
+      ctx.colorPairs.set(pairName, pair);
+    }
+  }
+}
+
+function expandPair(name: string, raw: RawPairDef, ctx: ExpansionContext): void {
+  if (typeof raw.container !== 'string' || !isValidColor(raw.container)) {
+    ctx.findings.push({
+      severity: 'error',
+      path: `colors.${name}.container`,
+      message: `'${raw.container}' is not a valid hex color.`,
+    });
+    return;
+  }
+  if (typeof raw.onContainer !== 'string' || !isValidColor(raw.onContainer)) {
+    ctx.findings.push({
+      severity: 'error',
+      path: `colors.${name}.onContainer`,
+      message: `'${raw.onContainer}' is not a valid hex color.`,
+    });
+    return;
+  }
+
+  const minContrast = typeof raw.minContrast === 'number' ? raw.minContrast : WCAG_AA_BODY;
+  const containerColor = parseColor(raw.container);
+  const onContainerColor = parseColor(raw.onContainer);
+  containerColor.pairRole = { pair: name, role: 'container' };
+  onContainerColor.pairRole = { pair: name, role: 'on-container' };
+
+  // Dotted form: explicit access to either member.
+  ctx.colors.set(`${name}.container`, containerColor);
+  ctx.colors.set(`${name}.onContainer`, onContainerColor);
+  ctx.symbolTable.set(`colors.${name}.container`, containerColor);
+  ctx.symbolTable.set(`colors.${name}.onContainer`, onContainerColor);
+
+  // Flat aliases: the bare pair name resolves to the container, `on-<name>` to the
+  // on-container. Mirrors the M3-style naming used by ramp-derived pairs.
+  ctx.colors.set(name, containerColor);
+  ctx.colors.set(`on-${name}`, onContainerColor);
+  ctx.symbolTable.set(`colors.${name}`, containerColor);
+  ctx.symbolTable.set(`colors.on-${name}`, onContainerColor);
+
+  const pair: PairDef = {
+    name,
+    container: containerColor,
+    onContainer: onContainerColor,
+    minContrast,
+  };
+  ctx.colorPairs.set(name, pair);
+}
+
+const WCAG_AA_BODY = 4.5;
 
 // ── Pure utility functions ─────────────────────────────────────────
 

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -40,6 +40,42 @@ export interface ResolvedColor {
   a?: number;
   /** WCAG relative luminance */
   luminance: number;
+  /** If this color was derived as a ramp step, its provenance. */
+  rampMember?: { ramp: string; step: number };
+  /** If this color is a pair member, the pair name and its role. */
+  pairRole?: { pair: string; role: 'container' | 'on-container' };
+  /** Optional human-readable name (e.g., "Boston Clay") attached to ramp anchors. */
+  humanName?: string;
+}
+
+/**
+ * A ramp's structural metadata after resolution. Step values are also stored
+ * flat in `state.colors` keyed as `<rampName>.<step>`; this map is for rules
+ * and exporters that need the original grouping.
+ */
+export interface RampDef {
+  name: string;
+  anchor: ResolvedColor;
+  humanName?: string;
+  description?: string;
+  steps: Map<number, ResolvedColor>;
+  /** Inline pair derivations declared on the ramp (e.g., container → step 100/800). */
+  pairs: Map<string, { bg: number; fg: number }>;
+}
+
+/**
+ * A pair's structural metadata. Members are also stored flat in `state.colors`
+ * keyed as `<pairName>.container` / `<pairName>.onContainer`. For ramp-inline
+ * pairs, additional flat aliases `<rampName>-<pairKey>` and `on-<rampName>-<pairKey>`
+ * are also synthesized for back-compat with M3-style naming.
+ */
+export interface PairDef {
+  name: string;
+  container: ResolvedColor;
+  onContainer: ResolvedColor;
+  minContrast: number;
+  /** True if this pair was derived inline on a ramp. */
+  derivedFromRamp?: string;
 }
 
 export interface ResolvedDimension {
@@ -70,11 +106,21 @@ export const VALID_COMPONENT_SUB_TOKENS = _VALID_COMPONENT_SUB_TOKENS;
 export interface DesignSystemState {
   name?: string | undefined;
   description?: string | undefined;
+  /**
+   * Flat color map. Anchors live at `<name>`; ramp steps at `<name>.<step>`;
+   * pair members at `<pairName>.container` / `<pairName>.onContainer`; and
+   * inline-pair flat aliases at `<rampName>-<pairKey>` / `on-<rampName>-<pairKey>`.
+   * Each entry's provenance (if any) is on the `ResolvedColor` itself.
+   */
   colors: Map<string, ResolvedColor>;
   typography: Map<string, ResolvedTypography>;
   rounded: Map<string, ResolvedDimension>;
   spacing: Map<string, ResolvedDimension>;
   components: Map<string, ComponentDef>;
+  /** Ramp definitions, keyed by ramp name. */
+  colorRamps: Map<string, RampDef>;
+  /** Pair definitions, keyed by pair name. */
+  colorPairs: Map<string, PairDef>;
   /** Flat lookup: "colors.primary" → ResolvedColor */
   symbolTable: Map<string, ResolvedValue>;
   /** Markdown heading names found in the document */

--- a/packages/cli/src/linter/parser/handler.ts
+++ b/packages/cli/src/linter/parser/handler.ts
@@ -193,7 +193,7 @@ export class ParserHandler implements ParserSpec {
     return {
       name: typeof raw['name'] === 'string' ? raw['name'] : undefined,
       description: typeof raw['description'] === 'string' ? raw['description'] : undefined,
-      colors: raw['colors'] as Record<string, string> | undefined,
+      colors: raw['colors'] as ParsedDesignSystem['colors'],
       typography: raw['typography'] as Record<string, Record<string, string | number>> | undefined,
       rounded: raw['rounded'] as Record<string, string> | undefined,
       spacing: raw['spacing'] as Record<string, string> | undefined,

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -37,11 +37,44 @@ export interface SourceLocation {
   block: 'frontmatter' | number;
 }
 
+/**
+ * A ramp declaration: an anchor color plus a derived scale of steps.
+ * Steps are interpolated in OKLCH from the anchor toward white (lighter steps)
+ * and toward black (darker steps). The anchor occupies step 500 by default.
+ */
+export interface RawRampDef {
+  type: 'ramp';
+  anchor: string;
+  /** Optional human-readable name (e.g., "Boston Clay") used by prose validation. */
+  humanName?: string;
+  description?: string;
+  /** Reserved for future curves (apca, lightness-linear). Default: oklch. */
+  curve?: 'oklch';
+  /** Numeric steps to derive. Default: [50, 100, 200, 300, 400, 500, 600, 700, 800, 900]. */
+  steps?: number[];
+  /** Inline derivation of pair tokens (e.g., container/on-container) from steps. */
+  pairs?: Record<string, { bg: number; fg: number }>;
+}
+
+/**
+ * A pair declaration: a container color and its paired foreground.
+ * The two members satisfy a minimum contrast invariant (`minContrast`).
+ */
+export interface RawPairDef {
+  type: 'pair';
+  container: string;
+  onContainer: string;
+  /** WCAG ratio floor. Default: 4.5 (AA body text). */
+  minContrast?: number;
+}
+
+export type RawColorValue = string | RawRampDef | RawPairDef;
+
 /** Raw, unresolved parsed output — mirrors the YAML schema */
 export interface ParsedDesignSystem {
   name?: string | undefined;
   description?: string | undefined;
-  colors?: Record<string, string> | undefined;
+  colors?: Record<string, RawColorValue> | undefined;
   typography?: Record<string, Record<string, string | number>> | undefined;
   rounded?: Record<string, string> | undefined;
   spacing?: Record<string, string> | undefined;

--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -83,6 +83,31 @@ color_roles:
   - tertiary
   - neutral
 
+# Color value shapes
+# ──────────────────
+# In addition to a flat hex (`primary: "#1A1C1E"`), `colors` accepts two
+# object-shaped forms that the model expands into flat tokens:
+#
+#   primary:                              # ramp: derives 50/100/.../900 in OKLCH
+#     type: ramp
+#     anchor: "#1A1C1E"
+#     humanName: "Boston Clay"
+#     description: "Driver for interaction."
+#     steps: [50, 100, 200, 300, 400, 500, 600, 700, 800, 900]   # optional
+#     pairs:                              # optional inline pair derivations
+#       container: { bg: 100, fg: 800 }   # synthesizes primary-container / on-primary-container
+#
+#   surface-info:                         # pair: foreground/background bound together
+#     type: pair
+#     container:    "#E0F2FE"
+#     onContainer:  "#0C4A6E"
+#     minContrast:  4.5                   # WCAG AA body; 7 for AAA
+#
+# References resolve in dotted form (`{colors.primary.500}`,
+# `{colors.surface-info.container}`) and via flat aliases (`{colors.primary}`
+# for the anchor, `{colors.surface-info}` for the container, `{colors.on-surface-info}`
+# for the on-container, `{colors.primary-container}` for ramp-derived pairs).
+
 recommended_tokens:
   colors:
     - primary

--- a/packages/cli/src/linter/tailwind/handler.test.ts
+++ b/packages/cli/src/linter/tailwind/handler.test.ts
@@ -112,4 +112,58 @@ describe('TailwindEmitterHandler', () => {
       expect(config.theme.extend).toBeDefined();
     });
   });
+
+  // ── Ramps and pairs ───────────────────────────────────────────────
+  describe('ramps and pairs', () => {
+    it('emits ramps as nested objects with DEFAULT and step keys', () => {
+      const state = buildState({
+        colors: { primary: { type: 'ramp', anchor: '#3b82f6', humanName: 'Sky' } },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      const colors = result.data.theme.extend.colors!;
+      const primary = colors['primary'];
+      expect(typeof primary).toBe('object');
+      const ramp = primary as Record<string, string>;
+      expect(ramp['DEFAULT']).toBe('#3b82f6');
+      expect(ramp['500']).toBe('#3b82f6');
+      expect(ramp['50']).toBeDefined();
+      expect(ramp['900']).toBeDefined();
+      // Steps should not also leak as top-level entries.
+      expect(colors['primary.500']).toBeUndefined();
+    });
+
+    it('emits standalone pair members under hyphenated flat keys', () => {
+      const state = buildState({
+        colors: {
+          'surface-info': { type: 'pair', container: '#E0F2FE', onContainer: '#0C4A6E' },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      const colors = result.data.theme.extend.colors!;
+      expect(colors['surface-info']).toBe('#e0f2fe');
+      expect(colors['on-surface-info']).toBe('#0c4a6e');
+      // The dotted-form internal members must not leak as top-level keys.
+      expect(colors['surface-info.container']).toBeUndefined();
+    });
+
+    it('emits inline-ramp pair flat aliases in M3 form', () => {
+      const state = buildState({
+        colors: {
+          primary: {
+            type: 'ramp',
+            anchor: '#3b82f6',
+            humanName: 'Sky',
+            pairs: { container: { bg: 100, fg: 800 } },
+          },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      const colors = result.data.theme.extend.colors!;
+      expect(colors['primary-container']).toBeDefined();
+      expect(colors['on-primary-container']).toBeDefined();
+    });
+  });
 });

--- a/packages/cli/src/linter/tailwind/handler.ts
+++ b/packages/cli/src/linter/tailwind/handler.ts
@@ -37,11 +37,28 @@ export class TailwindEmitterHandler implements TailwindEmitterSpec {
     };
   }
 
-  private mapColors(state: DesignSystemState): Record<string, string> {
-    const result: Record<string, string> = {};
+  private mapColors(state: DesignSystemState): Record<string, string | Record<string, string>> {
+    const result: Record<string, string | Record<string, string>> = {};
+
+    // Ramps emit as nested objects: { DEFAULT: '...', '50': '...', '500': '...', ... }
+    // The flat colors map carries every step plus the anchor; group them by ramp.
+    for (const [rampName, ramp] of state.colorRamps) {
+      const group: Record<string, string> = { DEFAULT: ramp.anchor.hex };
+      for (const [step, color] of [...ramp.steps].sort(([a], [b]) => a - b)) {
+        group[String(step)] = color.hex;
+      }
+      result[rampName] = group;
+    }
+
+    // Flat colors and pair members emit as top-level strings. Skip step entries
+    // (already nested under their ramp), the bare anchor (already in group), and
+    // dotted standalone-pair members (encoded via hyphen flat aliases below).
     for (const [name, color] of state.colors) {
+      if (color.rampMember) continue;
+      if (color.pairRole && name.includes('.')) continue;
       result[name] = color.hex;
     }
+
     return result;
   }
 

--- a/packages/cli/src/linter/tailwind/spec.ts
+++ b/packages/cli/src/linter/tailwind/spec.ts
@@ -17,8 +17,11 @@ import type { Config } from 'tailwindcss';
 import type { DesignSystemState } from '../model/spec.js';
 
 // ── TAILWIND CONFIG SCHEMA ──────────────────────────────────────────
+// Colors can be flat strings (`primary: "#1a1c1e"`) or nested ramp/pair
+// objects (`primary: { DEFAULT: "...", "500": "...", ... }`). Tailwind
+// natively understands both forms.
 export const TailwindThemeExtendSchema = z.object({
-  colors: z.record(z.string()).optional(),
+  colors: z.record(z.union([z.string(), z.record(z.string())])).optional(),
   fontFamily: z.record(z.array(z.string())).optional(),
   fontSize: z.record(z.tuple([z.string(), z.record(z.string())])).optional(),
   borderRadius: z.record(z.string()).optional(),


### PR DESCRIPTION
Closes #1.

Implements the [design doc](https://github.com/joesteinkamp/design.md/issues/1#issuecomment-4320662320). Adds two object-shaped color values that the model expands into the existing flat colors map, plus three rules that enforce the new structure. Flat hex colors keep working unchanged.

## Schema

```yaml
colors:
  primary:                              # ramp
    type: ramp
    anchor: "#1A1C1E"
    humanName: "Boston Clay"
    pairs: { container: { bg: 100, fg: 800 } }

  surface-info:                         # standalone pair
    type: pair
    container: "#E0F2FE"
    onContainer: "#0C4A6E"

  neutral: "#F7F5F2"                    # flat (unchanged)
```

## Behavior

**Ramps** interpolate `50/100/.../900` in OKLCH (pure-TS, no new dep) preserving chroma and hue and varying L from anchor toward white/black. Steps land in `state.colors` at `<ramp>.<step>` and resolve via `{colors.<ramp>.<step>}`; the bare ramp name still resolves to the anchor.

**Pairs** land in `state.colors` as both dotted members (`<pair>.container` / `<pair>.onContainer`) and hyphenated flat aliases (`<pair>` = container, `on-<pair>` = on-container). Inline-ramp pairs synthesize M3-style flat aliases (`primary-container`, `on-primary-container`).

## New rules

- **`pair-contrast`** (error) — every declared pair meets its `minContrast` floor (default 4.5:1, WCAG AA body)
- **`mixed-pair-foreground`** (warning) — a pair container `backgroundColor` must be paired with the matching `on-container` as `textColor`
- **`ramp-anchor-naming`** (warning) — every ramp should declare `humanName` so prose-token-mismatch (#4) can validate `"Boston Clay (#1A1C1E)"` sentences

## Updated rules

- **`orphaned-tokens`** — exempts individual ramp steps and pair members so a single declaration doesn't flood the report; only the anchor / pair surfaces a warning when nothing references the group

## Exporters

- **Tailwind**: ramps emit as nested `{ DEFAULT, '50', ..., '900' }` objects; pair members emit as hyphenated flat keys
- **DTCG**: ramps emit as nested groups with `$extensions['design.md']` vendor metadata and an anchor alias; standalone pairs emit as nested groups with role `$extensions` on each member (first production use of `$extensions`)

## Tests

237 passing (was 203 before). Added: OKLCH conversion tests, model expansion tests, three new rule tests, exporter tests for the new shapes, and an end-to-end fixture (`RAMPS_AND_PAIRS.md`).

## Deferred follow-ups (called out in design doc)

- Spec doc regeneration (renderer support for object-shaped color examples)
- Example migration of `atmospheric-glass` and `paws-and-paths` to ramps/pairs
- Subsection registry for required Colors prose subsections (cross-cutting, planned for #2/#3/#5/#6/#7/#8/#9)

## Test plan

- [x] `bun test` — 237/237 passing
- [x] `bun run build` — clean build
- [x] `npx tsc --skipLibCheck` — no type errors in our source
- [x] CLI smoke: `bun run packages/cli/src/index.ts lint packages/cli/src/linter/fixtures/RAMPS_AND_PAIRS.md` returns clean JSON, no errors
- [x] Back-compat: every existing fixture and example DESIGN.md still lints with the same finding profile

https://claude.ai/code/session_01E3CsAihbbFG354mb8DNuGG

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3CsAihbbFG354mb8DNuGG)_