### PR TITLE
feat(linter): expand component property vocabulary (#2)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -244,6 +244,28 @@ Depth is achieved through **Tonal Layers** rather than heavy shadows. The
 background uses a soft off-white or very light green, while primary content sits on pure white cards.
 ```
 
+### Design Tokens
+
+The `elevation` section defines semantic shadow tokens. Elevation is a
+*meaning* (resting, raised, overlay, modal) rather than a decoration —
+each level should map to a specific z-index intent (resting=0, raised=10,
+overlay=100, modal=1000).
+
+It is a map\<string, ShadowValue>.
+
+```yaml
+elevation:
+  resting: "0 1px 2px rgba(0,0,0,0.06)"
+  raised:  "0 4px 8px rgba(0,0,0,0.08)"
+  overlay: "0 12px 24px rgba(0,0,0,0.12)"
+  modal:   "0 24px 48px rgba(0,0,0,0.16)"
+```
+
+Components reference elevation via `shadow: "{elevation.raised}"` or the
+shorthand `elevation: raised`. Linter rule `elevation-without-semantics`
+nudges authors toward references when literal shadow values are used in
+components.
+
 ## Shapes
 
 This section describes how visual elements are shaped.
@@ -317,6 +339,43 @@ Each component has a set of properties that are themselves design tokens:
 - size: \<Dimension\>
 - height: \<Dimension\>
 - width: \<Dimension\>
+- border: \<BorderShorthand\>
+- borderColor: \<Color\>
+- borderWidth: \<Dimension\>
+- shadow: \<ShadowValue\>
+- elevation: \<ElevationLevel\>
+- gap: \<Dimension\>
+- iconSize: \<Dimension | "auto"\>
+- opacity: \<Number\>
+- transition: \<TransitionShorthand\>
+
+### Authoring Rules
+
+The Components section is also the place where the design system explains
+*how* its visual properties combine. The linter checks the structural
+shape; the prose carries the rationale. Cover at least:
+
+* **Separation hierarchy** — when to use border vs shadow vs background
+  contrast for visual separation. Pick **one** strategy per surface;
+  combining all three reads as visual noise (`triple-separation` rule).
+* **Elevation semantics** — elevation is a meaning, not a decoration.
+  Map every shadow to a semantic level (resting, raised, overlay,
+  modal). Reach for `{elevation.*}` references rather than literal
+  shadows (`elevation-without-semantics` rule).
+* **Opacity discipline** — opacity expresses *state* (disabled, loading).
+  Tint with color tokens, never with opacity. Never stack opacity layers
+  on top of an already-translucent backgroundColor (`opacity-stacking`
+  rule).
+* **Transitions** — animate `transform` and `opacity`. Animating
+  `width`, `height`, `padding`, or `margin` triggers layout on every
+  frame and is flagged by `animating-layout-property`. Always honor
+  `prefers-reduced-motion`.
+* **Icon sizing** — `iconSize: auto` follows the nearest text size and is
+  the right default. Override only when the icon is the primary
+  affordance for the component.
+* **Border usage** — borders communicate input affordances and dividers.
+  Borders should not be the primary visual identity of a surface —
+  reach for color or elevation first.
 
 ## Do's and Don'ts
 
@@ -351,5 +410,6 @@ When a DESIGN.md consumer encounters content not defined by this spec:
 | Unknown color token name | Accept if value is valid | `surface-container-high: '#ede7dd'` |
 | Unknown typography token name | Accept as valid typography | `telemetry-data` |
 | Unknown spacing value | Accept; store as string if not a valid dimension | `grid-columns: '5'` |
-| Unknown component property | Accept with warning | `borderColor` |
+| Unknown component property | Accept with warning | `myCustomProp` |
+| Typed component property with malformed value | Reject with error | `opacity: 2` |
 | Duplicate section heading | Error; reject the file | Two `## Colors` headings |

--- a/examples/atmospheric-glass/DESIGN.md
+++ b/examples/atmospheric-glass/DESIGN.md
@@ -95,38 +95,52 @@ spacing:
   card-gap: 16px
   section-margin: 40px
   glass-padding: 20px
+elevation:
+  resting: "0 1px 2px rgba(0,0,0,0.20)"
+  raised: "0 8px 24px rgba(0,0,0,0.25)"
+  overlay: "0 12px 32px rgba(0,0,0,0.40)"
+  modal: "0 24px 48px rgba(0,0,0,0.50)"
 components:
   glass-card-standard:
-    backgroundColor: rgba(255, 255, 255, 0.1)
+    backgroundColor: "#ffffff1a"
     textColor: "{colors.primary}"
     rounded: "{rounded.lg}"
     padding: "{spacing.glass-padding}"
+    gap: "{spacing.card-gap}"
+    shadow: "{elevation.raised}"
   glass-card-elevated:
-    backgroundColor: rgba(255, 255, 255, 0.2)
+    backgroundColor: "#ffffff33"
     textColor: "{colors.primary}"
     rounded: "{rounded.xl}"
     padding: "{spacing.glass-padding}"
+    gap: "{spacing.card-gap}"
+    shadow: "{elevation.overlay}"
   button-primary:
     backgroundColor: "{colors.primary}"
     textColor: "{colors.on-primary}"
     typography: "{typography.label-sm}"
     rounded: "{rounded.xl}"
     height: 48px
-    padding: 0 24px
+    padding: 0px 24px
+    transition: "opacity 150ms ease-out"
   button-primary-hover:
     backgroundColor: "{colors.primary-fixed-dim}"
   button-ghost:
-    backgroundColor: rgba(255, 255, 255, 0.05)
+    backgroundColor: "#ffffff0d"
     textColor: "{colors.primary}"
     typography: "{typography.label-sm}"
     rounded: "{rounded.xl}"
+    border: "1px solid #ffffff33"
+    transition: "opacity 150ms ease-out"
   input-field:
-    backgroundColor: rgba(255, 255, 255, 0.1)
+    backgroundColor: "#ffffff1a"
     textColor: "{colors.primary}"
     typography: "{typography.body-md}"
     rounded: "{rounded.xl}"
     padding: 20px
     height: 48px
+    border: "1px solid #ffffff33"
+    iconSize: auto
   weather-display-large:
     textColor: "{colors.primary}"
     typography: "{typography.display-lg}"
@@ -134,11 +148,12 @@ components:
     textColor: "{colors.on-surface-variant}"
     typography: "{typography.label-sm}"
   list-item-interactive:
-    backgroundColor: transparent
+    backgroundColor: "#ffffff00"
     rounded: "{rounded.md}"
     padding: 12px
+    transition: "opacity 100ms ease-in"
   list-item-interactive-hover:
-    backgroundColor: rgba(255, 255, 255, 0.1)
+    backgroundColor: "#ffffff1a"
 ---
 
 ## Brand & Style
@@ -178,10 +193,11 @@ Depth in this design system is not achieved through darkness, but through the ph
 
 - **The Glass Stack:**
   - **Level 1 (Base):** Dynamic background gradient with a slight grain texture.
-  - **Level 2 (Standard Card):** `backdrop-filter: blur(20px)`, `background: rgba(255, 255, 255, 0.1)`.
-  - **Level 3 (Elevated/Modals):** `backdrop-filter: blur(40px)`, `background: rgba(255, 255, 255, 0.2)`.
-- **Edge Definition:** Every glass surface must have a 1px solid border at `rgba(255, 255, 255, 0.2)`. A secondary inner "shine" border (top and left only) can be used to simulate a light source.
-- **Shadows:** Use extremely soft, spread-out shadows (`box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.1)`) to separate the glass layers from the background without making the UI feel "heavy."
+  - **Level 2 (Standard Card):** `backdrop-filter: blur(20px)`, `background: #ffffff1a`, `shadow: {elevation.raised}`.
+  - **Level 3 (Elevated/Modals):** `backdrop-filter: blur(40px)`, `background: #ffffff33`, `shadow: {elevation.overlay}`.
+- **Edge Definition:** Glass surfaces use a single `border: 1px solid #ffffff33` to simulate light refraction on the edges. **Pick one** separator per surface — a card uses either its border *or* an elevation shadow, never both stacked on top of a tinted background.
+- **Elevation tokens:** The semantic `resting` / `raised` / `overlay` / `modal` levels map physical depth to z-index intent. Components reference them via `shadow: "{elevation.raised}"`; literal `box-shadow` values are flagged by the linter as a nudge toward semantic elevation.
+- **Opacity discipline:** Translucent surfaces are encoded as 8-digit hex colors (e.g., `#ffffff1a` for 10% white). Components never combine `opacity` with a translucent `backgroundColor` — that would stack alpha and break the WCAG contrast budget.
 
 ## Shapes
 
@@ -203,7 +219,9 @@ Buttons use the `rounded-xl` setting to maintain a soft, organic feel. Primary b
 
 ### Inputs & Interaction
 
-Interactive list items and text inputs use subtle hover states and light blurs rather than solid color changes, preserving the "crystalline" transparency of the UI.
+Interactive list items and text inputs use subtle hover states and light blurs rather than solid color changes, preserving the "crystalline" transparency of the UI. The `input-field` component uses `iconSize: auto` so leading icons follow the body-md text size; only override that when the icon is the primary affordance.
+
+State changes use `transition: opacity 150ms ease-out` — opacity and transform are the only properties we animate. Width, height, padding, and margin are off-limits because animating them forces a re-layout on every frame.
 
 ### Typography Application
 

--- a/examples/paws-and-paths/DESIGN.md
+++ b/examples/paws-and-paths/DESIGN.md
@@ -108,6 +108,11 @@ spacing:
   xl: 64px
   gutter: 16px
   margin: 24px
+elevation:
+  resting: "0 1px 2px rgba(133,83,0,0.06)"
+  raised: "0 4px 12px rgba(133,83,0,0.10)"
+  overlay: "0 12px 24px rgba(133,83,0,0.14)"
+  modal: "0 24px 48px rgba(133,83,0,0.18)"
 components:
   button-primary:
     backgroundColor: "{colors.primary}"
@@ -115,6 +120,7 @@ components:
     typography: "{typography.label-md}"
     rounded: "{rounded.lg}"
     padding: "{spacing.md}"
+    transition: "opacity 150ms ease-out"
   button-primary-hover:
     backgroundColor: "{colors.primary-container}"
     textColor: "{colors.on-primary-container}"
@@ -124,6 +130,7 @@ components:
     typography: "{typography.label-md}"
     rounded: "{rounded.lg}"
     padding: "{spacing.md}"
+    transition: "opacity 150ms ease-out"
   button-secondary-hover:
     backgroundColor: "{colors.secondary-container}"
     textColor: "{colors.on-secondary-container}"
@@ -131,21 +138,27 @@ components:
     backgroundColor: "{colors.surface-container-lowest}"
     rounded: "{rounded.xl}"
     padding: "{spacing.md}"
+    gap: "{spacing.sm}"
+    shadow: "{elevation.raised}"
   card-walk-stat:
     backgroundColor: "{colors.secondary-container}"
     textColor: "{colors.on-secondary-container}"
     rounded: "{rounded.md}"
     padding: "{spacing.sm}"
+    shadow: "{elevation.resting}"
   input-field:
     backgroundColor: "{colors.surface-container-low}"
     textColor: "{colors.on-surface}"
     typography: "{typography.body-md}"
     rounded: "{rounded.DEFAULT}"
     padding: "{spacing.sm}"
+    border: "1px solid {colors.outline-variant}"
+    iconSize: auto
   list-item-walker:
-    backgroundColor: transparent
+    backgroundColor: "#00000000"
     padding: "{spacing.sm}"
     rounded: "{rounded.md}"
+    transition: "opacity 100ms ease-in"
   list-item-walker-hover:
     backgroundColor: "{colors.surface-container-high}"
   badge-status:
@@ -192,8 +205,9 @@ The layout follows a **Fixed Grid** model for mobile-first consistency, utilizin
 This design system uses **Ambient Shadows** and **Tonal Layers** to define the interface's verticality.
 
 - **Surfaces:** Main backgrounds use the lightest neutral tint. Interactive cards sit one level above on a pure white surface.
-- **Shadows:** Shadows are highly diffused and soft (Blur: 20px-40px, Opacity: 4-8%) with a subtle hint of the primary orange or secondary blue mixed into the shadow color to prevent a "dirty" gray look.
-- **Interactions:** Elements should subtly lift on hover or tap, increasing shadow spread to provide tactile feedback.
+- **Shadows:** Shadows are highly diffused and soft (Blur: 20px-40px, Opacity: 4-8%) with a subtle hint of the primary orange mixed into the shadow color to prevent a "dirty" gray look.
+- **Elevation tokens:** The four semantic levels are defined in the `elevation:` block — `resting` for content cards, `raised` for the hero `card-profile`, `overlay` for transient surfaces, `modal` for the highest-z dialogs. Reference them from components via `shadow: "{elevation.raised}"` rather than hand-rolling shadow values.
+- **Interactions:** Hover lifts elements one elevation level by transitioning to the next-higher token. Animate `opacity` and `transform`; never animate `width`, `height`, `padding`, or `margin`.
 
 ## Shapes
 
@@ -212,7 +226,7 @@ Buttons use `rounded-lg` (12px) to feel substantial and friendly, while form fie
 
 ### Cards & Elevation
 
-The `card-profile` is the hero container, utilizing `rounded-xl` and a tinted ambient shadow to create a "lifted" appearance against the `surface` background. Use `card-walk-stat` for high-contrast data visualization within the blue secondary palette.
+The `card-profile` is the hero container, utilizing `rounded-xl` and `shadow: {elevation.raised}` to create a "lifted" appearance against the `surface` background. `card-walk-stat` sits at `{elevation.resting}` and relies on its blue secondary backgroundColor for separation — pick **one** strategy per surface (`triple-separation` keeps us honest). The `input-field` is the only component that combines a `border` with a tonal background; it intentionally has no shadow.
 
 ### Lists & Navigation
 

--- a/examples/totality-festival/DESIGN.md
+++ b/examples/totality-festival/DESIGN.md
@@ -109,20 +109,20 @@ components:
   button-primary-hover:
     backgroundColor: "{colors.primary-fixed}"
   button-secondary:
-    backgroundColor: transparent
+    backgroundColor: "#00000000"
     textColor: "{colors.secondary}"
     typography: "{typography.label-md}"
     rounded: "{rounded.lg}"
     padding: 12px
     height: 48px
   button-secondary-hover:
-    backgroundColor: rgba(0, 227, 253, 0.1)
+    backgroundColor: "#00e3fd1a"
   card-glass-level-2:
-    backgroundColor: rgba(52, 52, 58, 0.2)
+    backgroundColor: "#34343a33"
     rounded: "{rounded.xl}"
     padding: "{spacing.gutter}"
   card-glass-interactive-hover:
-    backgroundColor: rgba(56, 57, 63, 0.4)
+    backgroundColor: "#38393f66"
   input-field:
     backgroundColor: "{colors.surface-container-lowest}"
     textColor: "{colors.on-surface}"

--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -89,6 +89,6 @@ describe('spec command', () => {
     const output = JSON.parse(outputStr);
     expect(output.spec).toBeDefined();
     expect(output.rules).toBeDefined();
-    expect(output.rules.length).toBe(8);
+    expect(output.rules.length).toBe(12);
   });
 });

--- a/packages/cli/src/linter/component-validators.test.ts
+++ b/packages/cli/src/linter/component-validators.test.ts
@@ -1,0 +1,183 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import {
+  validateColor,
+  validateDimension,
+  validatePaddingShorthand,
+  validateOpacity,
+  validateIconSize,
+  validateBorder,
+  validateShadow,
+  validateElevation,
+  validateTransition,
+  COMPONENT_SUB_TOKEN_VALIDATORS,
+  TYPED_COMPONENT_SUB_TOKENS,
+} from './component-validators.js';
+
+describe('validateColor', () => {
+  it('accepts hex colors', () => {
+    expect(validateColor('#000').ok).toBe(true);
+    expect(validateColor('#abc123').ok).toBe(true);
+    expect(validateColor('#ffffff80').ok).toBe(true);
+  });
+  it('accepts token references', () => {
+    expect(validateColor('{colors.primary}').ok).toBe(true);
+  });
+  it('rejects garbage', () => {
+    expect(validateColor('red').ok).toBe(false);
+    expect(validateColor('rgb(0,0,0)').ok).toBe(false);
+  });
+});
+
+describe('validateDimension', () => {
+  it('accepts dimensions', () => {
+    expect(validateDimension('12px').ok).toBe(true);
+    expect(validateDimension('1.5rem').ok).toBe(true);
+  });
+  it('rejects bare numbers', () => {
+    expect(validateDimension('12').ok).toBe(false);
+  });
+});
+
+describe('validatePaddingShorthand', () => {
+  it('accepts 1–4 dimensions', () => {
+    expect(validatePaddingShorthand('12px').ok).toBe(true);
+    expect(validatePaddingShorthand('12px 16px').ok).toBe(true);
+    expect(validatePaddingShorthand('12px 16px 12px').ok).toBe(true);
+    expect(validatePaddingShorthand('12px 16px 12px 16px').ok).toBe(true);
+  });
+  it('rejects 5+ tokens', () => {
+    expect(validatePaddingShorthand('1px 2px 3px 4px 5px').ok).toBe(false);
+  });
+  it('rejects malformed parts', () => {
+    expect(validatePaddingShorthand('12px nope').ok).toBe(false);
+  });
+});
+
+describe('validateOpacity', () => {
+  it('accepts 0..1', () => {
+    expect(validateOpacity('0').ok).toBe(true);
+    expect(validateOpacity('0.5').ok).toBe(true);
+    expect(validateOpacity('1').ok).toBe(true);
+  });
+  it('rejects out-of-range', () => {
+    expect(validateOpacity('1.5').ok).toBe(false);
+    expect(validateOpacity('-0.1').ok).toBe(false);
+    expect(validateOpacity('2').ok).toBe(false);
+  });
+  it('rejects non-numeric values', () => {
+    expect(validateOpacity('half').ok).toBe(false);
+    expect(validateOpacity('50%').ok).toBe(false);
+  });
+});
+
+describe('validateIconSize', () => {
+  it('accepts auto', () => {
+    expect(validateIconSize('auto').ok).toBe(true);
+  });
+  it('accepts dimensions', () => {
+    expect(validateIconSize('24px').ok).toBe(true);
+  });
+  it('accepts token references', () => {
+    expect(validateIconSize('{typography.body-md}').ok).toBe(true);
+  });
+  it('rejects garbage', () => {
+    expect(validateIconSize('big').ok).toBe(false);
+  });
+});
+
+describe('validateBorder', () => {
+  it('accepts CSS shorthand', () => {
+    expect(validateBorder('1px solid #000').ok).toBe(true);
+    expect(validateBorder('2px dashed {colors.outline}').ok).toBe(true);
+  });
+  it('accepts none', () => {
+    expect(validateBorder('none').ok).toBe(true);
+  });
+  it('rejects unknown style', () => {
+    expect(validateBorder('1px squiggly #000').ok).toBe(false);
+  });
+  it('rejects bad width', () => {
+    expect(validateBorder('thick solid #000').ok).toBe(false);
+  });
+  it('rejects bad color', () => {
+    expect(validateBorder('1px solid red').ok).toBe(false);
+  });
+});
+
+describe('validateShadow', () => {
+  it('accepts CSS shadow with hex color', () => {
+    expect(validateShadow('0 4px 8px #00000020').ok).toBe(true);
+  });
+  it('accepts CSS shadow with rgba', () => {
+    expect(validateShadow('0 4px 8px rgba(0,0,0,0.1)').ok).toBe(true);
+  });
+  it('accepts inset shadows', () => {
+    expect(validateShadow('inset 0 1px 0 rgba(255,255,255,0.2)').ok).toBe(true);
+  });
+  it('accepts elevation references', () => {
+    expect(validateShadow('{elevation.raised}').ok).toBe(true);
+  });
+  it('accepts none', () => {
+    expect(validateShadow('none').ok).toBe(true);
+  });
+  it('rejects shadows without a color', () => {
+    expect(validateShadow('0 4px 8px').ok).toBe(false);
+  });
+});
+
+describe('validateElevation', () => {
+  it('accepts {elevation.*} reference', () => {
+    expect(validateElevation('{elevation.raised}').ok).toBe(true);
+  });
+  it('accepts bare semantic name', () => {
+    expect(validateElevation('raised').ok).toBe(true);
+  });
+  it('rejects whitespace-laden values', () => {
+    expect(validateElevation('1px solid #000').ok).toBe(false);
+  });
+});
+
+describe('validateTransition', () => {
+  it('accepts shorthand with duration in ms', () => {
+    expect(validateTransition('opacity 200ms ease-out').ok).toBe(true);
+  });
+  it('accepts shorthand with duration in s', () => {
+    expect(validateTransition('transform 0.3s ease-in-out').ok).toBe(true);
+  });
+  it('rejects missing duration', () => {
+    expect(validateTransition('opacity').ok).toBe(false);
+  });
+  it('rejects non-time duration unit', () => {
+    expect(validateTransition('opacity 200px ease-out').ok).toBe(false);
+  });
+});
+
+describe('COMPONENT_SUB_TOKEN_VALIDATORS map', () => {
+  it('covers the core eight original sub-tokens', () => {
+    for (const name of ['backgroundColor', 'textColor', 'typography', 'rounded', 'padding', 'size', 'height', 'width']) {
+      expect(COMPONENT_SUB_TOKEN_VALIDATORS.has(name)).toBe(true);
+    }
+  });
+  it('covers the new typed sub-tokens', () => {
+    for (const name of ['border', 'borderColor', 'borderWidth', 'shadow', 'elevation', 'gap', 'iconSize', 'opacity', 'transition']) {
+      expect(COMPONENT_SUB_TOKEN_VALIDATORS.has(name)).toBe(true);
+    }
+  });
+  it('TYPED_COMPONENT_SUB_TOKENS lists every keyed validator', () => {
+    expect(TYPED_COMPONENT_SUB_TOKENS.length).toBe(COMPONENT_SUB_TOKEN_VALIDATORS.size);
+  });
+});

--- a/packages/cli/src/linter/component-validators.ts
+++ b/packages/cli/src/linter/component-validators.ts
@@ -1,0 +1,211 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Per-property value validators for typed component sub-tokens.
+ *
+ * Hand-rolled (no zod dependency at this layer) to keep the surface tight.
+ * Each validator takes the *raw* author-provided value (as parsed from YAML)
+ * and returns an `ok` flag with an optional error message.
+ *
+ * Token references (`{path.to.token}`) are passed through unvalidated — the
+ * model resolves them and validates the resolved value separately.
+ */
+
+import {
+  isValidColor,
+  isParseableDimension,
+  isTokenReference,
+  parseDimensionParts,
+} from './model/spec.js';
+
+export interface ValidatorResult {
+  ok: boolean;
+  /** Human-readable error message when `ok` is false. */
+  error?: string;
+}
+
+export type ValueValidator = (raw: string) => ValidatorResult;
+
+const ok: ValidatorResult = { ok: true };
+const fail = (error: string): ValidatorResult => ({ ok: false, error });
+
+const isRef = (raw: string) => isTokenReference(raw);
+
+/** Color values: hex literal or token reference. */
+export const validateColor: ValueValidator = (raw) => {
+  if (isRef(raw)) return ok;
+  if (isValidColor(raw)) return ok;
+  return fail(`'${raw}' is not a valid color (expected a hex code or a {colors.*} reference).`);
+};
+
+/** Dimension values: any parseable CSS length, or a token reference. */
+export const validateDimension: ValueValidator = (raw) => {
+  if (isRef(raw)) return ok;
+  if (isParseableDimension(raw)) return ok;
+  return fail(`'${raw}' is not a valid dimension.`);
+};
+
+/**
+ * `padding` accepts a single Dimension or a CSS shorthand of 2-4 Dimensions
+ * (`12px`, `12px 16px`, `12px 16px 12px`, `12px 16px 12px 16px`).
+ * Token references are accepted as-is.
+ */
+export const validatePaddingShorthand: ValueValidator = (raw) => {
+  if (isRef(raw)) return ok;
+  const parts = raw.trim().split(/\s+/);
+  if (parts.length < 1 || parts.length > 4) {
+    return fail(`'${raw}' is not a valid padding (expected 1–4 dimension values).`);
+  }
+  for (const p of parts) {
+    if (!isParseableDimension(p)) {
+      return fail(`'${raw}' contains an invalid dimension '${p}'.`);
+    }
+  }
+  return ok;
+};
+
+/** Opacity must be a unitless number in [0, 1]. */
+export const validateOpacity: ValueValidator = (raw) => {
+  if (isRef(raw)) return ok;
+  const trimmed = raw.trim();
+  if (!/^-?\d*\.?\d+$/.test(trimmed)) {
+    return fail(`'${raw}' is not a valid opacity (expected a unitless number between 0 and 1).`);
+  }
+  const n = parseFloat(trimmed);
+  if (Number.isNaN(n) || n < 0 || n > 1) {
+    return fail(`opacity ${n} is out of range (must be between 0 and 1).`);
+  }
+  return ok;
+};
+
+/** `iconSize` accepts a Dimension, the literal `"auto"`, or a token reference. */
+export const validateIconSize: ValueValidator = (raw) => {
+  if (isRef(raw)) return ok;
+  if (raw.trim() === 'auto') return ok;
+  if (isParseableDimension(raw)) return ok;
+  return fail(`'${raw}' is not a valid iconSize (expected a dimension, "auto", or a token reference).`);
+};
+
+const BORDER_STYLES = new Set(['none', 'solid', 'dashed', 'dotted', 'double', 'groove', 'ridge', 'inset', 'outset']);
+
+/**
+ * Border shorthand: `<width> <style> <color>` (any order is *not* supported —
+ * the conventional CSS order is enforced for clarity), e.g.:
+ *   `1px solid #000`
+ *   `2px dashed {colors.outline}`
+ * A bare token reference is also accepted.
+ */
+export const validateBorder: ValueValidator = (raw) => {
+  if (isRef(raw)) return ok;
+  if (raw.trim() === 'none') return ok;
+  const parts = raw.trim().split(/\s+/);
+  if (parts.length !== 3) {
+    return fail(`'${raw}' is not a valid border shorthand (expected '<width> <style> <color>').`);
+  }
+  const [width, style, color] = parts as [string, string, string];
+  if (!isParseableDimension(width) && !isRef(width)) {
+    return fail(`border width '${width}' is not a valid dimension.`);
+  }
+  if (!BORDER_STYLES.has(style)) {
+    return fail(`border style '${style}' is not recognized (expected one of: ${[...BORDER_STYLES].join(', ')}).`);
+  }
+  if (!isValidColor(color) && !isRef(color)) {
+    return fail(`border color '${color}' is not a valid color.`);
+  }
+  return ok;
+};
+
+/**
+ * Shadow value: a CSS shadow shorthand `<x> <y> <blur> [<spread>] <color>`,
+ * or a reference to an `{elevation.*}` token, or `none`.
+ *
+ * We deliberately keep parsing loose — full CSS shadow grammar (rgba, hsl,
+ * `inset` keyword, comma-separated stacks) is broad. The validator catches
+ * obvious mistakes (e.g., `red`) while permitting common author input.
+ */
+export const validateShadow: ValueValidator = (raw) => {
+  if (isRef(raw)) return ok;
+  const trimmed = raw.trim();
+  if (trimmed === 'none') return ok;
+  // Strip leading `inset ` keyword.
+  const body = trimmed.replace(/^inset\s+/i, '');
+  // The shadow must contain at least 3 whitespace-separated tokens
+  // (x, y, color at minimum) OR it must contain a paren-color like rgba(...).
+  const hasColor = /#[0-9a-fA-F]{3,8}\b/.test(body) || /\b(rgba?|hsla?)\s*\(/i.test(body);
+  if (!hasColor) {
+    return fail(`'${raw}' is not a valid shadow (expected a CSS shadow shorthand or a {elevation.*} reference).`);
+  }
+  return ok;
+};
+
+/** `elevation` only accepts a reference to `{elevation.*}` or a bare semantic name. */
+export const validateElevation: ValueValidator = (raw) => {
+  if (isRef(raw)) return ok;
+  // Bare semantic names like `resting`, `raised`, `overlay`, `modal` are
+  // accepted — the model will try to resolve them against the elevation map.
+  if (/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(raw.trim())) return ok;
+  return fail(`'${raw}' is not a valid elevation (expected an {elevation.*} reference or a semantic name).`);
+};
+
+/**
+ * Transition shorthand: `<property> <duration> <easing>`, e.g.
+ *   `opacity 200ms ease-out`
+ * Until motion tokens land (#5), literal values are accepted; the surrounding
+ * lint rule warns on layout-thrash properties.
+ */
+export const validateTransition: ValueValidator = (raw) => {
+  if (isRef(raw)) return ok;
+  const parts = raw.trim().split(/\s+/);
+  if (parts.length < 2 || parts.length > 3) {
+    return fail(`'${raw}' is not a valid transition (expected '<property> <duration> [easing]').`);
+  }
+  const duration = parts[1]!;
+  const dimParts = parseDimensionParts(duration);
+  if (!dimParts || (dimParts.unit !== 'ms' && dimParts.unit !== 's')) {
+    return fail(`transition duration '${duration}' must be a value in ms or s.`);
+  }
+  return ok;
+};
+
+/**
+ * Validators keyed by component sub-token name. Sub-tokens not present here
+ * are treated as opaque strings — the existing "accept with warning" path in
+ * the linter still applies for genuinely unknown property names.
+ */
+export const COMPONENT_SUB_TOKEN_VALIDATORS: ReadonlyMap<string, ValueValidator> = new Map([
+  ['backgroundColor', validateColor],
+  ['textColor', validateColor],
+  // typography is resolved against a token reference; a literal here is
+  // ambiguous so we only sanity-check that it's a reference.
+  ['typography', (raw: string) => (isRef(raw) ? ok : fail(`'${raw}' must be a {typography.*} reference.`))],
+  ['rounded', validateDimension],
+  ['padding', validatePaddingShorthand],
+  ['size', validateDimension],
+  ['height', validateDimension],
+  ['width', validateDimension],
+  ['border', validateBorder],
+  ['borderColor', validateColor],
+  ['borderWidth', validateDimension],
+  ['shadow', validateShadow],
+  ['elevation', validateElevation],
+  ['gap', validateDimension],
+  ['iconSize', validateIconSize],
+  ['opacity', validateOpacity],
+  ['transition', validateTransition],
+]);
+
+/** Property names that have a typed validator (i.e., are not opaque). */
+export const TYPED_COMPONENT_SUB_TOKENS: readonly string[] =
+  Array.from(COMPONENT_SUB_TOKEN_VALIDATORS.keys());

--- a/packages/cli/src/linter/dtcg/handler.test.ts
+++ b/packages/cli/src/linter/dtcg/handler.test.ts
@@ -22,6 +22,7 @@ function emptyState(overrides?: Partial<DesignSystemState>): DesignSystemState {
     typography: new Map(),
     rounded: new Map(),
     spacing: new Map(),
+    elevation: new Map(),
     components: new Map(),
     symbolTable: new Map(),
     ...overrides,
@@ -34,6 +35,10 @@ function makeColor(hex: string, r: number, g: number, b: number): ResolvedColor 
 
 function makeDim(value: number, unit: string): ResolvedDimension {
   return { type: 'dimension', value, unit };
+}
+
+function makeShadow(raw: string) {
+  return { type: 'shadow' as const, raw };
 }
 
 describe('DtcgEmitterHandler', () => {
@@ -168,6 +173,25 @@ describe('DtcgEmitterHandler', () => {
     expect(value['fontWeight']).toBe(700);
     expect(value['lineHeight']).toBe(1.2);
     expect(value['letterSpacing']).toEqual({ value: 0.5, unit: 'px' });
+  });
+
+  test('elevation → DTCG shadow group with raw shadow strings', () => {
+    const state = emptyState({
+      elevation: new Map([
+        ['raised', makeShadow('0 4px 8px rgba(0,0,0,0.08)')],
+        ['modal', makeShadow('0 24px 48px rgba(0,0,0,0.16)')],
+      ]),
+    });
+
+    const result = handler.execute(state);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const elevationGroup = result.data['elevation'] as Record<string, unknown>;
+    expect(elevationGroup['$type']).toBe('shadow');
+
+    const raised = elevationGroup['raised'] as Record<string, unknown>;
+    expect(raised['$value']).toBe('0 4px 8px rgba(0,0,0,0.08)');
   });
 
   test('typography with missing fields omits them from $value', () => {

--- a/packages/cli/src/linter/dtcg/handler.ts
+++ b/packages/cli/src/linter/dtcg/handler.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import type { DtcgEmitterSpec, DtcgEmitterResult, DtcgTokenFile, DtcgToken, DtcgGroup, DtcgColorValue, DtcgDimensionValue, DtcgTypographyValue } from './spec.js';
-import type { DesignSystemState, ResolvedColor, ResolvedDimension, ResolvedTypography } from '../model/spec.js';
+import type { DesignSystemState, ResolvedColor, ResolvedDimension, ResolvedShadow, ResolvedTypography } from '../model/spec.js';
 
 const DTCG_SCHEMA_URL = 'https://www.designtokens.org/schemas/2025.10/format.json';
 
@@ -43,7 +43,31 @@ export class DtcgEmitterHandler implements DtcgEmitterSpec {
     const typographyGroup = this.mapTypography(state);
     if (typographyGroup) file['typography'] = typographyGroup;
 
+    const elevationGroup = this.mapElevation(state);
+    if (elevationGroup) file['elevation'] = elevationGroup;
+
     return { success: true, data: file as Record<string, unknown> };
+  }
+
+  private mapElevation(state: DesignSystemState): DtcgGroup | null {
+    if (state.elevation.size === 0) return null;
+    const group: DtcgGroup = { $type: 'shadow' };
+    for (const [name, shadow] of state.elevation) {
+      group[name] = {
+        $value: this.shadowToValue(shadow),
+      } as DtcgToken;
+    }
+    return group;
+  }
+
+  /**
+   * Emit the raw CSS shadow string. Round-tripping the full DTCG composite
+   * shadow grammar (offset / blur / spread / color objects) is intentionally
+   * deferred — the raw string preserves all author intent and works with
+   * downstream consumers that pass shadows through verbatim.
+   */
+  private shadowToValue(shadow: ResolvedShadow): string {
+    return shadow.raw;
   }
 
   private mapColors(state: DesignSystemState): DtcgGroup | null {

--- a/packages/cli/src/linter/index.ts
+++ b/packages/cli/src/linter/index.ts
@@ -43,6 +43,10 @@ export {
   tokenSummary,
   missingSections,
   missingTypography,
+  opacityStacking,
+  animatingLayoutProperty,
+  elevationWithoutSemantics,
+  tripleSeparation,
 } from './linter/rules/index.js';
 export { contrastRatio } from './model/handler.js';
 export { TailwindEmitterHandler } from './tailwind/handler.js';

--- a/packages/cli/src/linter/linter/rules/animating-layout-property.test.ts
+++ b/packages/cli/src/linter/linter/rules/animating-layout-property.test.ts
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { animatingLayoutProperty, animatingLayoutPropertyRule } from './animating-layout-property.js';
+import { buildState } from './test-helpers.js';
+
+describe('animatingLayoutProperty', () => {
+  it('flags a transition that animates width', () => {
+    const state = buildState({
+      components: {
+        card: { transition: 'width 200ms ease-out' },
+      },
+    });
+    const findings = animatingLayoutProperty(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain('width');
+  });
+
+  it('flags height, padding, margin', () => {
+    const state = buildState({
+      components: {
+        a: { transition: 'height 200ms ease-out' },
+        b: { transition: 'padding 200ms ease-out' },
+        c: { transition: 'margin 200ms ease-out' },
+      },
+    });
+    expect(animatingLayoutProperty(state).length).toBe(3);
+  });
+
+  it('does not flag transform or opacity transitions', () => {
+    const state = buildState({
+      components: {
+        a: { transition: 'transform 200ms ease-out' },
+        b: { transition: 'opacity 200ms ease-out' },
+      },
+    });
+    expect(animatingLayoutProperty(state).length).toBe(0);
+  });
+
+  it('has a valid descriptor', () => {
+    expect(animatingLayoutPropertyRule.name).toBe('animating-layout-property');
+    expect(animatingLayoutPropertyRule.severity).toBe('warning');
+  });
+});

--- a/packages/cli/src/linter/linter/rules/animating-layout-property.ts
+++ b/packages/cli/src/linter/linter/rules/animating-layout-property.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+const LAYOUT_PROPERTIES = new Set(['width', 'height', 'padding', 'margin', 'top', 'left', 'right', 'bottom']);
+
+/**
+ * Animating layout-affecting properties (width, height, padding, margin)
+ * forces the browser to reflow on every frame — janky and battery-hostile.
+ * The compositor-friendly alternatives are `transform` and `opacity`.
+ */
+export function animatingLayoutProperty(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  for (const [compName, comp] of state.components) {
+    const transition = comp.properties.get('transition');
+    if (typeof transition !== 'string') continue;
+    // First whitespace-separated token of the transition shorthand is the
+    // animated property. References are skipped — they're inspected once
+    // motion tokens land in #5.
+    const propertyName = transition.trim().split(/\s+/)[0];
+    if (propertyName && LAYOUT_PROPERTIES.has(propertyName)) {
+      findings.push({
+        path: `components.${compName}.transition`,
+        message: `Avoid animating '${propertyName}' — it triggers layout on every frame. Animate 'transform' or 'opacity' instead.`,
+      });
+    }
+  }
+  return findings;
+}
+
+export const animatingLayoutPropertyRule: RuleDescriptor = {
+  name: 'animating-layout-property',
+  severity: 'warning',
+  description: 'Animating layout property — flags transitions that animate width / height / padding / margin.',
+  run: animatingLayoutProperty,
+};

--- a/packages/cli/src/linter/linter/rules/broken-ref.test.ts
+++ b/packages/cli/src/linter/linter/rules/broken-ref.test.ts
@@ -38,7 +38,7 @@ describe('brokenRef', () => {
   it('emits warning (not error) for unknown component sub-tokens', () => {
     const state = buildState({
       colors: { primary: '#ff0000' },
-      components: { button: { borderColor: '#ff0000' } },
+      components: { button: { mysteryProp: '#ff0000' } },
     });
     const findings = brokenRef(state);
     const subTokenDiag = findings.find(d => d.message.includes('not a recognized'));

--- a/packages/cli/src/linter/linter/rules/broken-ref.ts
+++ b/packages/cli/src/linter/linter/rules/broken-ref.ts
@@ -30,13 +30,15 @@ export function brokenRef(state: DesignSystemState): RuleFinding[] {
       });
     }
 
-    // Unknown component sub-tokens (lower severity override)
+    // Unknown component sub-tokens (lower severity override).
+    // The hint message lists the full valid set so authors discover the
+    // current vocabulary without having to consult the spec.
     for (const [propName] of comp.properties) {
       if (!(VALID_COMPONENT_SUB_TOKENS as readonly string[]).includes(propName)) {
         findings.push({
           severity: 'warning',
           path: `components.${compName}.${propName}`,
-          message: `'${propName}' is not a recognized component sub-token. Valid sub-tokens: ${VALID_COMPONENT_SUB_TOKENS.join(', ')}.`,
+          message: `'${propName}' is not a recognized component sub-token. Recognized: ${VALID_COMPONENT_SUB_TOKENS.join(', ')}.`,
         });
       }
     }

--- a/packages/cli/src/linter/linter/rules/elevation-without-semantics.test.ts
+++ b/packages/cli/src/linter/linter/rules/elevation-without-semantics.test.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { elevationWithoutSemantics, elevationWithoutSemanticsRule } from './elevation-without-semantics.js';
+import { buildState } from './test-helpers.js';
+
+describe('elevationWithoutSemantics', () => {
+  it('flags a literal shadow when elevation tokens exist', () => {
+    const state = buildState({
+      elevation: { raised: '0 4px 8px rgba(0,0,0,0.08)' },
+      components: {
+        card: { shadow: '0 2px 4px rgba(0,0,0,0.1)' },
+      },
+    });
+    const findings = elevationWithoutSemantics(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain('literal shadow');
+  });
+
+  it('does not flag a referenced elevation token', () => {
+    const state = buildState({
+      elevation: { raised: '0 4px 8px rgba(0,0,0,0.08)' },
+      components: {
+        card: { shadow: '{elevation.raised}' },
+      },
+    });
+    expect(elevationWithoutSemantics(state).length).toBe(0);
+  });
+
+  it('does not flag when no elevation tokens are defined', () => {
+    const state = buildState({
+      components: {
+        card: { shadow: '0 4px 8px rgba(0,0,0,0.08)' },
+      },
+    });
+    expect(elevationWithoutSemantics(state).length).toBe(0);
+  });
+
+  it('has a valid descriptor', () => {
+    expect(elevationWithoutSemanticsRule.name).toBe('elevation-without-semantics');
+    expect(elevationWithoutSemanticsRule.severity).toBe('info');
+  });
+});

--- a/packages/cli/src/linter/linter/rules/elevation-without-semantics.ts
+++ b/packages/cli/src/linter/linter/rules/elevation-without-semantics.ts
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Components that set a literal `shadow` value (instead of referencing an
+ * `{elevation.*}` token) bypass the semantic resting / raised / overlay /
+ * modal vocabulary. Nudge authors toward semantic elevation.
+ */
+export function elevationWithoutSemantics(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  if (state.elevation.size === 0) return findings;
+
+  for (const [compName, comp] of state.components) {
+    const shadow = comp.properties.get('shadow');
+    if (!shadow) continue;
+    // A resolved {elevation.*} reference is a ResolvedShadow object. A
+    // string here means the author wrote a literal CSS shadow (and the
+    // model didn't resolve it against any token).
+    if (typeof shadow === 'string') {
+      findings.push({
+        path: `components.${compName}.shadow`,
+        message: `'${compName}' uses a literal shadow value. Reference an {elevation.*} token (e.g., resting / raised / overlay / modal) for semantic elevation.`,
+      });
+    }
+  }
+  return findings;
+}
+
+export const elevationWithoutSemanticsRule: RuleDescriptor = {
+  name: 'elevation-without-semantics',
+  severity: 'info',
+  description: 'Elevation without semantics — flags literal shadow values when elevation tokens are available.',
+  run: elevationWithoutSemantics,
+};

--- a/packages/cli/src/linter/linter/rules/index.ts
+++ b/packages/cli/src/linter/linter/rules/index.ts
@@ -23,6 +23,10 @@ import { tokenSummaryRule } from './token-summary.js';
 import { missingSectionsRule } from './missing-sections.js';
 import { sectionOrderRule } from './section-order.js';
 import { missingTypographyRule } from './missing-typography.js';
+import { opacityStackingRule } from './opacity-stacking.js';
+import { animatingLayoutPropertyRule } from './animating-layout-property.js';
+import { elevationWithoutSemanticsRule } from './elevation-without-semantics.js';
+import { tripleSeparationRule } from './triple-separation.js';
 
 /** The default set of lint rule descriptors, in order. */
 export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
@@ -34,6 +38,10 @@ export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
   missingSectionsRule,
   missingTypographyRule,
   sectionOrderRule,
+  opacityStackingRule,
+  animatingLayoutPropertyRule,
+  elevationWithoutSemanticsRule,
+  tripleSeparationRule,
 ];
 
 /** Converts a RuleDescriptor into a LintRule by injecting severity into findings. */
@@ -58,4 +66,8 @@ export { tokenSummary } from './token-summary.js';
 export { missingSections } from './missing-sections.js';
 export { missingTypography } from './missing-typography.js';
 export { sectionOrder } from './section-order.js';
+export { opacityStacking } from './opacity-stacking.js';
+export { animatingLayoutProperty } from './animating-layout-property.js';
+export { elevationWithoutSemantics } from './elevation-without-semantics.js';
+export { tripleSeparation } from './triple-separation.js';
 export type { LintRule } from './types.js';

--- a/packages/cli/src/linter/linter/rules/opacity-stacking.test.ts
+++ b/packages/cli/src/linter/linter/rules/opacity-stacking.test.ts
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { opacityStacking, opacityStackingRule } from './opacity-stacking.js';
+import { buildState } from './test-helpers.js';
+
+describe('opacityStacking', () => {
+  it('flags opacity layered on a translucent backgroundColor', () => {
+    const state = buildState({
+      colors: { glass: '#ffffff1a' },
+      components: {
+        card: {
+          backgroundColor: '{colors.glass}',
+          opacity: '0.5',
+        },
+      },
+    });
+    const findings = opacityStacking(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain('stacks');
+  });
+
+  it('does not flag opacity alone', () => {
+    const state = buildState({
+      components: {
+        card: { opacity: '0.5' },
+      },
+    });
+    expect(opacityStacking(state).length).toBe(0);
+  });
+
+  it('does not flag opacity on opaque backgroundColor', () => {
+    const state = buildState({
+      colors: { solid: '#000000' },
+      components: {
+        card: {
+          backgroundColor: '{colors.solid}',
+          opacity: '0.5',
+        },
+      },
+    });
+    expect(opacityStacking(state).length).toBe(0);
+  });
+
+  it('has a valid descriptor', () => {
+    expect(opacityStackingRule.name).toBe('opacity-stacking');
+    expect(opacityStackingRule.severity).toBe('warning');
+    expect(opacityStackingRule.run).toBe(opacityStacking);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/opacity-stacking.ts
+++ b/packages/cli/src/linter/linter/rules/opacity-stacking.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState, ResolvedColor } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Opacity is for *state* (disabled, loading) — never for tinting.
+ * A component that declares both `opacity` and a non-opaque
+ * `backgroundColor` is almost certainly stacking transparency, which yields
+ * unpredictable visual contrast and breaks WCAG calculations.
+ */
+export function opacityStacking(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  for (const [compName, comp] of state.components) {
+    const hasOpacity = comp.properties.has('opacity');
+    if (!hasOpacity) continue;
+
+    const bg = comp.properties.get('backgroundColor');
+    if (bg && typeof bg === 'object' && 'type' in bg && bg.type === 'color') {
+      const color = bg as ResolvedColor;
+      if (color.a !== undefined && color.a < 1) {
+        findings.push({
+          path: `components.${compName}`,
+          message: `'${compName}' stacks 'opacity' on top of a non-opaque backgroundColor (alpha=${color.a}). Use a single tinted token instead — never stack opacity layers.`,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+export const opacityStackingRule: RuleDescriptor = {
+  name: 'opacity-stacking',
+  severity: 'warning',
+  description: "Opacity stacking — flags components that combine opacity with a non-opaque backgroundColor.",
+  run: opacityStacking,
+};

--- a/packages/cli/src/linter/linter/rules/triple-separation.test.ts
+++ b/packages/cli/src/linter/linter/rules/triple-separation.test.ts
@@ -1,0 +1,82 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { tripleSeparation, tripleSeparationRule } from './triple-separation.js';
+import { buildState } from './test-helpers.js';
+
+describe('tripleSeparation', () => {
+  it('flags components with border + shadow + backgroundColor', () => {
+    const state = buildState({
+      colors: { surface: '#ffffff' },
+      elevation: { raised: '0 4px 8px rgba(0,0,0,0.1)' },
+      components: {
+        card: {
+          backgroundColor: '{colors.surface}',
+          border: '1px solid #000000',
+          shadow: '{elevation.raised}',
+        },
+      },
+    });
+    const findings = tripleSeparation(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain('Pick one strategy');
+  });
+
+  it('does not flag border + shadow without backgroundColor', () => {
+    const state = buildState({
+      elevation: { raised: '0 4px 8px rgba(0,0,0,0.1)' },
+      components: {
+        card: {
+          border: '1px solid #000000',
+          shadow: '{elevation.raised}',
+        },
+      },
+    });
+    expect(tripleSeparation(state).length).toBe(0);
+  });
+
+  it('does not flag border + backgroundColor without shadow (input pattern)', () => {
+    const state = buildState({
+      colors: { surface: '#ffffff' },
+      components: {
+        input: {
+          backgroundColor: '{colors.surface}',
+          border: '1px solid #000000',
+        },
+      },
+    });
+    expect(tripleSeparation(state).length).toBe(0);
+  });
+
+  it('treats elevation as equivalent to shadow', () => {
+    const state = buildState({
+      colors: { surface: '#ffffff' },
+      elevation: { raised: '0 4px 8px rgba(0,0,0,0.1)' },
+      components: {
+        card: {
+          backgroundColor: '{colors.surface}',
+          borderWidth: '1px',
+          elevation: 'raised',
+        },
+      },
+    });
+    expect(tripleSeparation(state).length).toBe(1);
+  });
+
+  it('has a valid descriptor', () => {
+    expect(tripleSeparationRule.name).toBe('triple-separation');
+    expect(tripleSeparationRule.severity).toBe('warning');
+  });
+});

--- a/packages/cli/src/linter/linter/rules/triple-separation.ts
+++ b/packages/cli/src/linter/linter/rules/triple-separation.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Pick one separation strategy per surface — never combine border + shadow
+ * (or elevation) + a contrasting backgroundColor. The combination almost
+ * always reads as visual noise.
+ */
+export function tripleSeparation(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  for (const [compName, comp] of state.components) {
+    const hasBorder =
+      comp.properties.has('border') ||
+      comp.properties.has('borderWidth') ||
+      comp.properties.has('borderColor');
+    const hasShadow =
+      comp.properties.has('shadow') || comp.properties.has('elevation');
+    const hasBackground = comp.properties.has('backgroundColor');
+
+    if (hasBorder && hasShadow && hasBackground) {
+      findings.push({
+        path: `components.${compName}`,
+        message: `'${compName}' uses border + shadow/elevation + backgroundColor for separation. Pick one strategy per surface.`,
+      });
+    }
+  }
+  return findings;
+}
+
+export const tripleSeparationRule: RuleDescriptor = {
+  name: 'triple-separation',
+  severity: 'warning',
+  description: 'Triple separation — flags components combining border + shadow + backgroundColor.',
+  run: tripleSeparation,
+};

--- a/packages/cli/src/linter/linter/rules/types.test.ts
+++ b/packages/cli/src/linter/linter/rules/types.test.ts
@@ -24,6 +24,7 @@ describe('LintRule type', () => {
       typography: new Map(),
       rounded: new Map(),
       spacing: new Map(),
+      elevation: new Map(),
       components: new Map(),
       symbolTable: new Map(),
     })).toEqual([]);
@@ -40,7 +41,7 @@ describe('LintRule type', () => {
   });
 
   it('has all rules in DEFAULT_RULE_DESCRIPTORS', () => {
-    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(8);
+    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(12);
     DEFAULT_RULE_DESCRIPTORS.forEach((rule: RuleDescriptor) => {
       expect(rule.name).toBeTruthy();
       expect(rule.severity).toBeTruthy();

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -356,4 +356,96 @@ describe('ModelHandler', () => {
       }
     });
   });
+
+  // ── Issue #2: typed component sub-token validation ───────────────
+  describe('typed component sub-token validation', () => {
+    it('emits error for opacity > 1', () => {
+      const result = handler.execute(makeParsed({
+        components: { card: { opacity: '2' } },
+      }));
+      const errs = result.findings.filter(f => f.severity === 'error');
+      expect(errs.length).toBe(1);
+      expect(errs[0]!.path).toBe('components.card.opacity');
+    });
+
+    it('emits error for malformed border shorthand', () => {
+      const result = handler.execute(makeParsed({
+        components: { card: { border: '1px squiggly #000' } },
+      }));
+      const errs = result.findings.filter(f => f.severity === 'error');
+      expect(errs.length).toBe(1);
+      expect(errs[0]!.path).toBe('components.card.border');
+    });
+
+    it('emits error for shadow without a color', () => {
+      const result = handler.execute(makeParsed({
+        components: { card: { shadow: '0 4px 8px' } },
+      }));
+      const errs = result.findings.filter(f => f.severity === 'error');
+      expect(errs.length).toBe(1);
+    });
+
+    it('emits error for transition with non-time duration', () => {
+      const result = handler.execute(makeParsed({
+        components: { card: { transition: 'opacity 200px ease-out' } },
+      }));
+      const errs = result.findings.filter(f => f.severity === 'error');
+      expect(errs.length).toBe(1);
+    });
+
+    it('accepts iconSize: auto', () => {
+      const result = handler.execute(makeParsed({
+        components: { card: { iconSize: 'auto' } },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error').length).toBe(0);
+    });
+
+    it('accepts padding shorthand (12px 16px)', () => {
+      const result = handler.execute(makeParsed({
+        components: { card: { padding: '12px 16px' } },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error').length).toBe(0);
+    });
+
+    it('skips validation for token references', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#ff0000' },
+        components: { card: { borderColor: '{colors.primary}' } },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error').length).toBe(0);
+    });
+  });
+
+  describe('elevation token group', () => {
+    it('parses elevation entries into the state', () => {
+      const result = handler.execute(makeParsed({
+        elevation: {
+          raised: '0 4px 8px rgba(0,0,0,0.08)',
+          modal: '0 24px 48px rgba(0,0,0,0.16)',
+        },
+      }));
+      expect(result.designSystem.elevation.size).toBe(2);
+      const raised = result.designSystem.elevation.get('raised');
+      expect(raised?.type).toBe('shadow');
+      expect(raised?.raw).toBe('0 4px 8px rgba(0,0,0,0.08)');
+    });
+
+    it('resolves component shadow via {elevation.*} reference', () => {
+      const result = handler.execute(makeParsed({
+        elevation: { raised: '0 4px 8px rgba(0,0,0,0.08)' },
+        components: { card: { shadow: '{elevation.raised}' } },
+      }));
+      const shadow = result.designSystem.components.get('card')?.properties.get('shadow');
+      expect(typeof shadow === 'object' && shadow !== null && 'type' in shadow && shadow.type === 'shadow').toBe(true);
+    });
+
+    it('resolves bare elevation: raised against the elevation map', () => {
+      const result = handler.execute(makeParsed({
+        elevation: { raised: '0 4px 8px rgba(0,0,0,0.08)' },
+        components: { card: { elevation: 'raised' } },
+      }));
+      const elevation = result.designSystem.components.get('card')?.properties.get('elevation');
+      expect(typeof elevation === 'object' && elevation !== null && 'type' in elevation && elevation.type === 'shadow').toBe(true);
+    });
+  });
 });

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -19,12 +19,14 @@ import type {
   ResolvedColor,
   ResolvedDimension,
   ResolvedTypography,
+  ResolvedShadow,
   ResolvedValue,
   ComponentDef,
   Finding,
 } from './spec.js';
 
 import { isValidColor, isParseableDimension, isTokenReference, parseDimensionParts } from './spec.js';
+import { COMPONENT_SUB_TOKEN_VALIDATORS } from '../component-validators.js';
 
 const MAX_REFERENCE_DEPTH = 10;
 
@@ -43,6 +45,7 @@ export class ModelHandler implements ModelSpec {
       const typography = new Map<string, ResolvedTypography>();
       const rounded = new Map<string, ResolvedDimension>();
       const spacing = new Map<string, ResolvedDimension>();
+      const elevation = new Map<string, ResolvedShadow>();
 
       // ── Phase 1: Resolve primitive tokens ──────────────────────────
       // Colors
@@ -118,6 +121,22 @@ export class ModelHandler implements ModelSpec {
         }
       }
 
+      // Elevation — semantic shadow tokens (resting / raised / overlay / modal).
+      // Values are CSS shadow strings; validation is generous to match the
+      // wide CSS shadow grammar.
+      if (input.elevation) {
+        for (const [name, raw] of Object.entries(input.elevation)) {
+          if (typeof raw !== 'string') continue;
+          if (isTokenReference(raw)) {
+            symbolTable.set(`elevation.${name}`, raw);
+          } else {
+            const shadow: ResolvedShadow = { type: 'shadow', raw };
+            elevation.set(name, shadow);
+            symbolTable.set(`elevation.${name}`, shadow);
+          }
+        }
+      }
+
       // ── Phase 2: Resolve chained color references ──────────────────
       // Iterate color entries that are still raw references and resolve them
       if (input.colors) {
@@ -168,6 +187,24 @@ export class ModelHandler implements ModelSpec {
         }
       }
 
+      // Resolve chained elevation references
+      if (input.elevation) {
+        for (const [name, raw] of Object.entries(input.elevation)) {
+          if (typeof raw === 'string' && isTokenReference(raw)) {
+            const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
+            if (
+              resolved !== null &&
+              typeof resolved === 'object' &&
+              'type' in resolved &&
+              resolved.type === 'shadow'
+            ) {
+              elevation.set(name, resolved as ResolvedShadow);
+              symbolTable.set(`elevation.${name}`, resolved);
+            }
+          }
+        }
+      }
+
       // ── Phase 3: Build components ──────────────────────────────────
       const components = new Map<string, ComponentDef>();
       if (input.components) {
@@ -176,6 +213,33 @@ export class ModelHandler implements ModelSpec {
           const unresolvedRefs: string[] = [];
 
           for (const [propName, rawValue] of Object.entries(props)) {
+            // Validate the raw author input against the typed schema.
+            // Token references and resolution failures are not validated
+            // here — those are handled by the broken-ref rule.
+            const validator = COMPONENT_SUB_TOKEN_VALIDATORS.get(propName);
+            if (validator && typeof rawValue === 'string') {
+              const result = validator(rawValue);
+              if (!result.ok) {
+                findings.push({
+                  severity: 'error',
+                  path: `components.${compName}.${propName}`,
+                  message: result.error ?? `Invalid value for '${propName}'.`,
+                });
+              }
+            }
+
+            // `elevation: raised` (bare semantic name) → look up in the
+            // elevation map even though the author didn't write a {ref}.
+            if (propName === 'elevation' && typeof rawValue === 'string'
+                && !isTokenReference(rawValue) && !isValidColor(rawValue)
+                && !isParseableDimension(rawValue)) {
+              const resolved = symbolTable.get(`elevation.${rawValue.trim()}`);
+              if (resolved !== undefined) {
+                properties.set(propName, resolved);
+                continue;
+              }
+            }
+
             if (isTokenReference(rawValue)) {
               const refPath = rawValue.slice(1, -1);
               const resolved = resolveReference(symbolTable, refPath, new Set());
@@ -206,6 +270,7 @@ export class ModelHandler implements ModelSpec {
           typography,
           rounded,
           spacing,
+          elevation,
           components,
           symbolTable,
           sections: input.sections,
@@ -219,6 +284,7 @@ export class ModelHandler implements ModelSpec {
           typography: new Map(),
           rounded: new Map(),
           spacing: new Map(),
+          elevation: new Map(),
           components: new Map(),
           symbolTable: new Map(),
         },

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -60,7 +60,33 @@ export interface ResolvedTypography {
   fontVariation?: string | undefined;
 }
 
-export type ResolvedValue = ResolvedColor | ResolvedDimension | ResolvedTypography | string;
+/**
+ * Semantic elevation token — a CSS shadow string (e.g., "0 4px 8px rgba(0,0,0,0.08)").
+ * Components reference elevation via `shadow: "{elevation.raised}"` or `elevation: raised`.
+ */
+export interface ResolvedShadow {
+  type: 'shadow';
+  /** The raw CSS shadow string. */
+  raw: string;
+}
+
+/** Resolved CSS border shorthand `<width> <style> <color>`. */
+export interface ResolvedBorder {
+  type: 'border';
+  width: ResolvedDimension;
+  style: string;
+  color: ResolvedColor;
+  /** The original raw shorthand string, preserved for exporters. */
+  raw: string;
+}
+
+export type ResolvedValue =
+  | ResolvedColor
+  | ResolvedDimension
+  | ResolvedTypography
+  | ResolvedShadow
+  | ResolvedBorder
+  | string;
 
 // ── Re-exported from spec-config (single source of truth) ─────────
 export const VALID_TYPOGRAPHY_PROPS = _VALID_TYPOGRAPHY_PROPS;
@@ -74,6 +100,11 @@ export interface DesignSystemState {
   typography: Map<string, ResolvedTypography>;
   rounded: Map<string, ResolvedDimension>;
   spacing: Map<string, ResolvedDimension>;
+  /**
+   * Semantic elevation tokens. Keys are typically `resting`, `raised`,
+   * `overlay`, `modal`. Values carry the raw CSS shadow string.
+   */
+  elevation: Map<string, ResolvedShadow>;
   components: Map<string, ComponentDef>;
   /** Flat lookup: "colors.primary" → ResolvedColor */
   symbolTable: Map<string, ResolvedValue>;

--- a/packages/cli/src/linter/parser/handler.ts
+++ b/packages/cli/src/linter/parser/handler.ts
@@ -197,6 +197,7 @@ export class ParserHandler implements ParserSpec {
       typography: raw['typography'] as Record<string, Record<string, string | number>> | undefined,
       rounded: raw['rounded'] as Record<string, string> | undefined,
       spacing: raw['spacing'] as Record<string, string> | undefined,
+      elevation: raw['elevation'] as Record<string, string> | undefined,
       components: raw['components'] as Record<string, Record<string, string>> | undefined,
       sourceMap,
       sections,

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -45,6 +45,12 @@ export interface ParsedDesignSystem {
   typography?: Record<string, Record<string, string | number>> | undefined;
   rounded?: Record<string, string> | undefined;
   spacing?: Record<string, string> | undefined;
+  /**
+   * Semantic elevation tokens (resting / raised / overlay / modal). Values
+   * are CSS shadow strings; component `shadow` props reference them via
+   * `{elevation.<name>}`.
+   */
+  elevation?: Record<string, string> | undefined;
   components?: Record<string, Record<string, string>> | undefined;
   sourceMap: Map<string, SourceLocation>;
   /** Markdown heading names found in the document (e.g., 'Colors', 'Typography') */

--- a/packages/cli/src/linter/spec-config.ts
+++ b/packages/cli/src/linter/spec-config.ts
@@ -51,6 +51,7 @@ const ConfigSchema = z.object({
   recommended_tokens: z.record(z.string(), z.array(z.string())),
   examples: z.object({
     colors: z.record(z.string(), z.string()),
+    elevation: z.record(z.string(), z.string()).optional(),
     typography: z.record(z.string(), z.record(z.string(), z.union([z.string(), z.number()]))),
     components: z.record(z.string(), z.record(z.string(), z.string())),
   }),

--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -70,12 +70,37 @@ component_sub_tokens:
     type: Dimension
   - name: padding
     type: Dimension
+    description: "Accepts a single Dimension (`12px`) or a CSS shorthand of two-to-four Dimensions (`12px 16px`)."
   - name: size
     type: Dimension
   - name: height
     type: Dimension
   - name: width
     type: Dimension
+  - name: border
+    type: BorderShorthand
+    description: "CSS shorthand `<width> <style> <color>` (e.g., `1px solid {colors.outline}`) or a Color/Dimension token reference."
+  - name: borderColor
+    type: Color
+  - name: borderWidth
+    type: Dimension
+  - name: shadow
+    type: ShadowValue
+    description: "CSS shorthand `<offsetX> <offsetY> <blur> [<spread>] <color>` or a reference to an `{elevation.*}` token."
+  - name: elevation
+    type: ElevationLevel
+    description: "Reference to an `{elevation.*}` token (semantic: resting, raised, overlay, modal)."
+  - name: gap
+    type: Dimension
+  - name: iconSize
+    type: "Dimension | \"auto\""
+    description: "`auto` (the default) follows the nearest text size. Otherwise a Dimension or `{typography.*}` reference."
+  - name: opacity
+    type: Number
+    description: "A unitless number between 0 and 1. Use for state (disabled, loading), not for tinting."
+  - name: transition
+    type: TransitionShorthand
+    description: "CSS shorthand `<property> <duration> <easing>`. Until motion tokens land, literal values are accepted with a warning."
 
 color_roles:
   - primary
@@ -116,6 +141,11 @@ examples:
     secondary: "#6C7278"
     tertiary: "#B8422E"
     neutral: "#F7F5F2"
+  elevation:
+    resting: "0 1px 2px rgba(0,0,0,0.06)"
+    raised: "0 4px 8px rgba(0,0,0,0.08)"
+    overlay: "0 12px 24px rgba(0,0,0,0.12)"
+    modal: "0 24px 48px rgba(0,0,0,0.16)"
   typography:
     h1:
       fontFamily: Public Sans

--- a/packages/cli/src/linter/spec-gen/spec.mdx
+++ b/packages/cli/src/linter/spec-gen/spec.mdx
@@ -188,6 +188,28 @@ Depth is achieved through **Tonal Layers** rather than heavy shadows. The
 background uses a soft off-white or very light green, while primary content sits on pure white cards.
 ```
 
+### Design Tokens
+
+The `elevation` section defines semantic shadow tokens. Elevation is a
+*meaning* (resting, raised, overlay, modal) rather than a decoration —
+each level should map to a specific z-index intent (resting=0, raised=10,
+overlay=100, modal=1000).
+
+It is a map\<string, ShadowValue\>.
+
+```yaml
+elevation:
+  resting: "0 1px 2px rgba(0,0,0,0.06)"
+  raised:  "0 4px 8px rgba(0,0,0,0.08)"
+  overlay: "0 12px 24px rgba(0,0,0,0.12)"
+  modal:   "0 24px 48px rgba(0,0,0,0.16)"
+```
+
+Components reference elevation via `shadow: "{elevation.raised}"` or the
+shorthand `elevation: raised`. Linter rule `elevation-without-semantics`
+nudges authors toward references when literal shadow values are used in
+components.
+
 ## Shapes
 
 This section describes how visual elements are shaped.
@@ -246,6 +268,34 @@ Each component has a set of properties that are themselves design tokens:
 
 {componentSubTokenList()}
 
+### Authoring Rules
+
+The Components section is also the place where the design system explains
+*how* its visual properties combine. The linter checks the structural
+shape; the prose carries the rationale. Cover at least:
+
+- **Separation hierarchy** — when to use border vs shadow vs background
+  contrast for visual separation. Pick **one** strategy per surface;
+  combining all three reads as visual noise (`triple-separation` rule).
+- **Elevation semantics** — elevation is a meaning, not a decoration.
+  Map every shadow to a semantic level (resting, raised, overlay,
+  modal). Reach for `{elevation.*}` references rather than literal
+  shadows (`elevation-without-semantics` rule).
+- **Opacity discipline** — opacity expresses *state* (disabled, loading).
+  Tint with color tokens, never with opacity. Never stack opacity layers
+  on top of an already-translucent backgroundColor (`opacity-stacking`
+  rule).
+- **Transitions** — animate `transform` and `opacity`. Animating
+  `width`, `height`, `padding`, or `margin` triggers layout on every
+  frame and is flagged by `animating-layout-property`. Always honor
+  `prefers-reduced-motion`.
+- **Icon sizing** — `iconSize: auto` follows the nearest text size and is
+  the right default. Override only when the icon is the primary
+  affordance for the component.
+- **Border usage** — borders communicate input affordances and dividers.
+  Borders should not be the primary visual identity of a surface —
+  reach for color or elevation first.
+
 ## Do's and Don'ts
 
 This section provides practical guidelines and common pitfalls. These act as guardrails when creating designs.
@@ -275,5 +325,6 @@ When a DESIGN.md consumer encounters content not defined by this spec:
 | Unknown color token name | Accept if value is valid | `surface-container-high: '#ede7dd'` |
 | Unknown typography token name | Accept as valid typography | `telemetry-data` |
 | Unknown spacing value | Accept; store as string if not a valid dimension | `grid-columns: '5'` |
-| Unknown component property | Accept with warning | `borderColor` |
+| Unknown component property | Accept with warning | `myCustomProp` |
+| Typed component property with malformed value | Reject with error | `opacity: 2` |
 | Duplicate section heading | Error; reject the file | Two `## Colors` headings |

--- a/packages/cli/src/linter/tailwind/handler.test.ts
+++ b/packages/cli/src/linter/tailwind/handler.test.ts
@@ -112,4 +112,20 @@ describe('TailwindEmitterHandler', () => {
       expect(config.theme.extend).toBeDefined();
     });
   });
+
+  // ── Issue #2: elevation → boxShadow ──────────────────────────────
+  describe('elevation mapping', () => {
+    it('maps elevation tokens to theme.extend.boxShadow', () => {
+      const state = buildState({
+        elevation: {
+          resting: '0 1px 2px rgba(0,0,0,0.06)',
+          raised: '0 4px 8px rgba(0,0,0,0.08)',
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      expect(result.data.theme.extend.boxShadow?.['resting']).toBe('0 1px 2px rgba(0,0,0,0.06)');
+      expect(result.data.theme.extend.boxShadow?.['raised']).toBe('0 4px 8px rgba(0,0,0,0.08)');
+    });
+  });
 });

--- a/packages/cli/src/linter/tailwind/handler.ts
+++ b/packages/cli/src/linter/tailwind/handler.ts
@@ -31,10 +31,19 @@ export class TailwindEmitterHandler implements TailwindEmitterSpec {
             fontSize: this.mapFontSizes(state),
             borderRadius: this.mapDimensions(state.rounded),
             spacing: this.mapDimensions(state.spacing),
+            boxShadow: this.mapElevation(state),
           },
         },
       }
     };
+  }
+
+  private mapElevation(state: DesignSystemState): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const [name, shadow] of state.elevation) {
+      result[name] = shadow.raw;
+    }
+    return result;
   }
 
   private mapColors(state: DesignSystemState): Record<string, string> {

--- a/packages/cli/src/linter/tailwind/spec.ts
+++ b/packages/cli/src/linter/tailwind/spec.ts
@@ -23,6 +23,8 @@ export const TailwindThemeExtendSchema = z.object({
   fontSize: z.record(z.tuple([z.string(), z.record(z.string())])).optional(),
   borderRadius: z.record(z.string()).optional(),
   spacing: z.record(z.string()).optional(),
+  /** Map of elevation token name → CSS box-shadow string. */
+  boxShadow: z.record(z.string()).optional(),
 });
 
 export type TailwindThemeExtend = z.infer<typeof TailwindThemeExtendSchema>;


### PR DESCRIPTION
Closes #2.

## Summary

Promotes nine properties — `border`, `borderColor`, `borderWidth`, `shadow`, `elevation`, `gap`, `iconSize`, `opacity`, `transition` — from "accept with warning" to typed component sub-tokens with per-property value validation. Adds an `elevation` top-level token group for semantic shadows (resting / raised / overlay / modal). Wires four new lint rules that enforce the prose guidelines from the Components section.

## Schema

`packages/cli/src/linter/spec-config.yaml` lists the new sub-tokens with their types and inline guidance. `packages/cli/src/linter/component-validators.ts` provides hand-rolled validators (no zod runtime cost):
- `validateColor`, `validateDimension`, `validatePaddingShorthand`, `validateOpacity` (0..1), `validateIconSize` (`auto` | Dimension | ref), `validateBorder` (`<width> <style> <color>`), `validateShadow`, `validateElevation`, `validateTransition` (`<property> <duration> <easing>`).

The model handler runs these validators in Phase 3 of component build; malformed values produce errors keyed to `components.<name>.<prop>`. Token references skip validation (the model resolves them and the broken-ref rule catches dangling refs).

## Elevation token group

A new top-level YAML group:

```yaml
elevation:
  resting: "0 1px 2px rgba(0,0,0,0.06)"
  raised:  "0 4px 8px rgba(0,0,0,0.08)"
  overlay: "0 12px 24px rgba(0,0,0,0.12)"
  modal:   "0 24px 48px rgba(0,0,0,0.16)"
```

Components reference elevation via `shadow: "{elevation.raised}"` or the shorthand `elevation: raised`. `DesignSystemState` gains an `elevation: Map<string, ResolvedShadow>` field.

## New lint rules

- **opacity-stacking** (warning) — opacity layered on a non-opaque backgroundColor.
- **animating-layout-property** (warning) — transitions that animate width / height / padding / margin.
- **elevation-without-semantics** (info) — literal shadow values when elevation tokens are available.
- **triple-separation** (warning) — components combining border + shadow + backgroundColor.

The existing `broken-ref` hint now lists the larger sub-token vocabulary so authors discover the new properties.

## Exporters

- **Tailwind**: `theme.extend.boxShadow` is now populated from elevation tokens.
- **DTCG**: emits an `elevation` group with `$type: "shadow"` and the raw shadow string as `$value`.

## Examples

`atmospheric-glass`, `paws-and-paths`, and `totality-festival` are migrated to the new vocabulary: each defines an `elevation:` block, components reference it via `shadow:` / `elevation:`, translucent surface colors are encoded as 8-digit hex (`#ffffff1a`) instead of `rgba(...)` literals, inputs adopt the `border` shorthand, and interactive components declare `transition` with compositor-friendly properties only. Prose subsections explain the new authoring rules.

## Test plan

- [x] `bun test` — 268 pass (was 203; 65 new tests covering validators, new rules, and exporter behavior).
- [x] `bun run spec:gen` — `docs/spec.md` regenerated with new sub-tokens, elevation guidance, and authoring rules.
- [x] All three example DESIGN.md files lint with 0 errors.
- [x] No TypeScript errors (`tsc --noEmit --skipLibCheck`).

## Out of scope (per design doc)

- `transition` value validation against motion tokens — depends on #5; accepts literal values with the existing duration check until then.
- `invalid-property-value` as a standalone lint rule — already surfaced via model-level validators (the rule was redundant; findings carry the same severity and path).
- DTCG composite border type — deferred; borders today flow through as opaque component values.

https://claude.ai/code/session_01DLsGxzVXmTAwKWY4JZNn2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLsGxzVXmTAwKWY4JZNn2U)_