### PR TITLE
feat: first-class component states with inheritance and a11y rules

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -292,7 +292,12 @@ This section provides style guidance for component atoms within the design syste
 
 The components section defines a collection of design tokens used to ensure consistent styling of common components. It's a map\<string, map\<string, string>> that maps a component identifier to a group of sub token names and values. The design token values may be literal values, or references to previously defined design tokens.
 
-**Variants**. A component may have a variant for different UI states such as active, hover, pressed, etc. Those variant components may be defined under a different but related key, for example, "button-primary", "button-primary-hover", "button-primary-active". The agent will consider all variants and make the appropriate styling decisions.
+**Variants** (configuration: primary/secondary/danger) and **states**
+(transient response to user input: hover/focus/active/disabled/loading) are
+modeled differently. Variants typically appear as separate component entries
+(e.g., `button-primary`, `button-secondary`). States are nested under a
+component's `states:` block and inherit from the base, overriding only the
+properties that change.
 
 ```yaml
 components:
@@ -301,8 +306,18 @@ components:
     textColor: "{colors.primary-20}"
     rounded: "{rounded.md}"
     padding: 12px
-  button-primary-hover:
-    backgroundColor: "{colors.primary-70}"
+    interactive: true
+    states:
+      hover:
+        backgroundColor: "{colors.primary-70}"
+      focus-visible:
+        outline: 2px solid {colors.primary-40}
+      active:
+        opacity: 0.9
+      disabled:
+        backgroundColor: "{colors.surface-variant}"
+        textColor: "{colors.on-surface-variant}"
+        cursor: not-allowed
 ```
 
 ### Component Property Tokens
@@ -317,6 +332,58 @@ Each component has a set of properties that are themselves design tokens:
 - size: \<Dimension\>
 - height: \<Dimension\>
 - width: \<Dimension\>
+- opacity: \<number\>
+- outline: \<string\>
+- boxShadow: \<string\>
+- border: \<string\>
+- cursor: \<string\>
+
+### Interactive States
+
+States express transient responses to user input. They live under a
+component's `states:` block and override only the properties that change from
+the rest state. A component opts in by setting `interactive: true`.
+
+The recognized state vocabulary is opinionated but not closed; novel state
+names produce a warning rather than an error.
+
+#### State hierarchy
+
+Visual weight order, lightest to heaviest: rest < hover < focus-visible
+< active < pressed. Each state communicates a different message — never
+combine them into one undifferentiated lift.
+
+#### Focus-visible discipline
+
+Every interactive component **must** declare a `focus-visible` state. Never
+suppress the native outline (`outline: none`) without supplying a replacement
+signal — `boxShadow`, `border`, or an `outline-offset` ring. Focus rings use
+their own dedicated token, not the hover color.
+
+#### Disabled affordance
+
+A `disabled` state must reduce contrast **and** set `cursor: not-allowed`.
+Opacity-only signaling fails for users who can't see the cursor change and is
+opaque to assistive tech.
+
+#### Hover is desktop-only
+
+Hover state must never be the only signal of interactivity. Touch devices
+skip hover entirely; the rest state must already communicate affordance via
+shape, weight, or color.
+
+#### State vs. variant
+
+A state is a transient response to user input (hover, active). A variant is
+a persistent configuration (primary, secondary, danger). Don't conflate
+them; the explosion `button-primary-hover-disabled` is exactly what the
+nested `states:` block exists to prevent.
+
+#### Loading / busy
+
+Loading is a state, not an absence. The component must remain visible and
+indicate progress — never collapse, hide, or replace it with a spinner that
+shifts surrounding layout.
 
 ## Do's and Don'ts
 

--- a/examples/atmospheric-glass/DESIGN.md
+++ b/examples/atmospheric-glass/DESIGN.md
@@ -113,13 +113,30 @@ components:
     rounded: "{rounded.xl}"
     height: 48px
     padding: 0 24px
-  button-primary-hover:
-    backgroundColor: "{colors.primary-fixed-dim}"
+    interactive: true
+    states:
+      hover:
+        backgroundColor: "{colors.primary-fixed-dim}"
+      focus-visible:
+        outline: "2px solid {colors.secondary}"
+      disabled:
+        backgroundColor: "{colors.surface-variant}"
+        textColor: "{colors.on-surface-variant}"
+        cursor: not-allowed
   button-ghost:
     backgroundColor: rgba(255, 255, 255, 0.05)
     textColor: "{colors.primary}"
     typography: "{typography.label-sm}"
     rounded: "{rounded.xl}"
+    interactive: true
+    states:
+      hover:
+        backgroundColor: rgba(255, 255, 255, 0.15)
+      focus-visible:
+        outline: "2px solid {colors.secondary}"
+      disabled:
+        textColor: "{colors.on-surface-variant}"
+        cursor: not-allowed
   input-field:
     backgroundColor: rgba(255, 255, 255, 0.1)
     textColor: "{colors.primary}"
@@ -127,6 +144,14 @@ components:
     rounded: "{rounded.xl}"
     padding: 20px
     height: 48px
+    interactive: true
+    states:
+      focus-visible:
+        outline: "2px solid {colors.secondary}"
+      disabled:
+        backgroundColor: rgba(255, 255, 255, 0.05)
+        textColor: "{colors.on-surface-variant}"
+        cursor: not-allowed
   weather-display-large:
     textColor: "{colors.primary}"
     typography: "{typography.display-lg}"
@@ -137,8 +162,15 @@ components:
     backgroundColor: transparent
     rounded: "{rounded.md}"
     padding: 12px
-  list-item-interactive-hover:
-    backgroundColor: rgba(255, 255, 255, 0.1)
+    interactive: true
+    states:
+      hover:
+        backgroundColor: rgba(255, 255, 255, 0.1)
+      focus-visible:
+        outline: "2px solid {colors.secondary}"
+      disabled:
+        textColor: "{colors.on-surface-variant}"
+        cursor: not-allowed
 ---
 
 ## Brand & Style

--- a/examples/atmospheric-glass/design_tokens.json
+++ b/examples/atmospheric-glass/design_tokens.json
@@ -1,11 +1,9 @@
 {
-  "name": {
-    "$type": "string",
-    "$value": "Atmospheric Glass"
-  },
-  "colors": {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "$description": "Atmospheric Glass",
+  "color": {
+    "$type": "color",
     "surface": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -17,7 +15,6 @@
       }
     },
     "surface-dim": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -29,7 +26,6 @@
       }
     },
     "surface-bright": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -41,7 +37,6 @@
       }
     },
     "surface-container-lowest": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -53,7 +48,6 @@
       }
     },
     "surface-container-low": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -65,7 +59,6 @@
       }
     },
     "surface-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -77,7 +70,6 @@
       }
     },
     "surface-container-high": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -89,7 +81,6 @@
       }
     },
     "surface-container-highest": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -101,7 +92,6 @@
       }
     },
     "on-surface": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -113,7 +103,6 @@
       }
     },
     "on-surface-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -125,7 +114,6 @@
       }
     },
     "inverse-surface": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -137,7 +125,6 @@
       }
     },
     "inverse-on-surface": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -149,7 +136,6 @@
       }
     },
     "outline": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -161,7 +147,6 @@
       }
     },
     "outline-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -173,7 +158,6 @@
       }
     },
     "surface-tint": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -185,19 +169,17 @@
       }
     },
     "primary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
-          1.0,
-          1.0
+          1,
+          1,
+          1
         ],
         "hex": "#ffffff"
       }
     },
     "on-primary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -209,7 +191,6 @@
       }
     },
     "primary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -221,7 +202,6 @@
       }
     },
     "on-primary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -233,7 +213,6 @@
       }
     },
     "inverse-primary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -245,7 +224,6 @@
       }
     },
     "secondary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -257,7 +235,6 @@
       }
     },
     "on-secondary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -269,7 +246,6 @@
       }
     },
     "secondary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -281,7 +257,6 @@
       }
     },
     "on-secondary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -293,35 +268,32 @@
       }
     },
     "tertiary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
-          1.0,
-          1.0
+          1,
+          1,
+          1
         ],
         "hex": "#ffffff"
       }
     },
     "on-tertiary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.384,
-          0.0,
+          0,
           0.251
         ],
         "hex": "#620040"
       }
     },
     "tertiary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.847,
           0.906
         ],
@@ -329,7 +301,6 @@
       }
     },
     "on-tertiary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -341,11 +312,10 @@
       }
     },
     "error": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.706,
           0.671
         ],
@@ -353,35 +323,32 @@
       }
     },
     "on-error": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.412,
-          0.0,
+          0,
           0.02
         ],
         "hex": "#690005"
       }
     },
     "error-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.576,
-          0.0,
+          0,
           0.039
         ],
         "hex": "#93000a"
       }
     },
     "on-error-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.855,
           0.839
         ],
@@ -389,7 +356,6 @@
       }
     },
     "primary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -401,7 +367,6 @@
       }
     },
     "primary-fixed-dim": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -413,7 +378,6 @@
       }
     },
     "on-primary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -425,7 +389,6 @@
       }
     },
     "on-primary-fixed-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -437,19 +400,17 @@
       }
     },
     "secondary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.816,
           0.894,
-          1.0
+          1
         ],
         "hex": "#d0e4ff"
       }
     },
     "secondary-fixed-dim": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -461,11 +422,10 @@
       }
     },
     "on-secondary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.114,
           0.208
         ],
@@ -473,7 +433,6 @@
       }
     },
     "on-secondary-fixed-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -485,11 +444,10 @@
       }
     },
     "tertiary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.847,
           0.906
         ],
@@ -497,11 +455,10 @@
       }
     },
     "tertiary-fixed-dim": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.686,
           0.827
         ],
@@ -509,19 +466,17 @@
       }
     },
     "on-tertiary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.239,
-          0.0,
+          0,
           0.149
         ],
         "hex": "#3d0026"
       }
     },
     "on-tertiary-fixed-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -533,7 +488,6 @@
       }
     },
     "background": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -545,7 +499,6 @@
       }
     },
     "on-background": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -557,7 +510,6 @@
       }
     },
     "surface-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -566,6 +518,78 @@
           0.286
         ],
         "hex": "#2d3449"
+      }
+    }
+  },
+  "spacing": {
+    "$type": "dimension",
+    "unit": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      }
+    },
+    "container-padding": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      }
+    },
+    "card-gap": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      }
+    },
+    "section-margin": {
+      "$value": {
+        "value": 40,
+        "unit": "px"
+      }
+    },
+    "glass-padding": {
+      "$value": {
+        "value": 20,
+        "unit": "px"
+      }
+    }
+  },
+  "rounded": {
+    "$type": "dimension",
+    "sm": {
+      "$value": {
+        "value": 0.25,
+        "unit": "rem"
+      }
+    },
+    "DEFAULT": {
+      "$value": {
+        "value": 0.5,
+        "unit": "rem"
+      }
+    },
+    "md": {
+      "$value": {
+        "value": 0.75,
+        "unit": "rem"
+      }
+    },
+    "lg": {
+      "$value": {
+        "value": 1,
+        "unit": "rem"
+      }
+    },
+    "xl": {
+      "$value": {
+        "value": 1.5,
+        "unit": "rem"
+      }
+    },
+    "full": {
+      "$value": {
+        "value": 9999,
+        "unit": "px"
       }
     }
   },
@@ -579,14 +603,11 @@
           "unit": "px"
         },
         "fontWeight": 700,
-        "lineHeight": {
-          "value": 90,
-          "unit": "px"
-        },
         "letterSpacing": {
           "value": -0.04,
           "unit": "em"
-        }
+        },
+        "lineHeight": 90
       }
     },
     "headline-lg": {
@@ -598,14 +619,11 @@
           "unit": "px"
         },
         "fontWeight": 600,
-        "lineHeight": {
-          "value": 40,
-          "unit": "px"
-        },
         "letterSpacing": {
           "value": -0.02,
           "unit": "em"
-        }
+        },
+        "lineHeight": 40
       }
     },
     "headline-md": {
@@ -617,10 +635,7 @@
           "unit": "px"
         },
         "fontWeight": 500,
-        "lineHeight": {
-          "value": 32,
-          "unit": "px"
-        }
+        "lineHeight": 32
       }
     },
     "body-lg": {
@@ -632,10 +647,7 @@
           "unit": "px"
         },
         "fontWeight": 400,
-        "lineHeight": {
-          "value": 28,
-          "unit": "px"
-        }
+        "lineHeight": 28
       }
     },
     "body-md": {
@@ -647,10 +659,7 @@
           "unit": "px"
         },
         "fontWeight": 400,
-        "lineHeight": {
-          "value": 24,
-          "unit": "px"
-        }
+        "lineHeight": 24
       }
     },
     "label-sm": {
@@ -662,138 +671,125 @@
           "unit": "px"
         },
         "fontWeight": 600,
-        "lineHeight": {
-          "value": 16,
-          "unit": "px"
-        },
         "letterSpacing": {
           "value": 0.05,
           "unit": "em"
-        }
+        },
+        "lineHeight": 16
       }
     }
   },
-  "rounded": {
-    "sm": {
-      "$type": "dimension",
-      "$value": {
-        "value": 0.25,
-        "unit": "rem"
-      }
-    },
-    "DEFAULT": {
-      "$type": "dimension",
-      "$value": {
-        "value": 0.5,
-        "unit": "rem"
-      }
-    },
-    "md": {
-      "$type": "dimension",
-      "$value": {
-        "value": 0.75,
-        "unit": "rem"
-      }
-    },
-    "lg": {
-      "$type": "dimension",
-      "$value": {
-        "value": 1,
-        "unit": "rem"
-      }
-    },
-    "xl": {
-      "$type": "dimension",
-      "$value": {
-        "value": 1.5,
-        "unit": "rem"
-      }
-    },
-    "full": {
-      "$type": "dimension",
-      "$value": {
-        "value": 9999,
-        "unit": "px"
-      }
-    }
-  },
-  "spacing": {
-    "unit": {
-      "$type": "dimension",
-      "$value": {
-        "value": 8,
-        "unit": "px"
-      }
-    },
-    "container-padding": {
-      "$type": "dimension",
-      "$value": {
-        "value": 24,
-        "unit": "px"
-      }
-    },
-    "card-gap": {
-      "$type": "dimension",
-      "$value": {
-        "value": 16,
-        "unit": "px"
-      }
-    },
-    "section-margin": {
-      "$type": "dimension",
-      "$value": {
-        "value": 40,
-        "unit": "px"
-      }
-    },
-    "glass-padding": {
-      "$type": "dimension",
-      "$value": {
-        "value": 20,
-        "unit": "px"
-      }
-    }
-  },
-  "components": {
+  "component": {
     "glass-card-standard": {
       "backgroundColor": {
+        "$value": "rgba(255, 255, 255, 0.1)"
+      },
+      "textColor": {
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            1.0,
-            1.0,
-            1.0
+            1,
+            1,
+            1
           ],
-          "alpha": 0.1
+          "hex": "#ffffff"
         }
       },
-      "textColor": "{colors.primary}",
-      "rounded": "{rounded.lg}",
-      "padding": "{spacing.glass-padding}"
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 1,
+          "unit": "rem"
+        }
+      },
+      "padding": {
+        "$type": "dimension",
+        "$value": {
+          "value": 20,
+          "unit": "px"
+        }
+      }
     },
     "glass-card-elevated": {
       "backgroundColor": {
+        "$value": "rgba(255, 255, 255, 0.2)"
+      },
+      "textColor": {
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            1.0,
-            1.0,
-            1.0
+            1,
+            1,
+            1
           ],
-          "alpha": 0.2
+          "hex": "#ffffff"
         }
       },
-      "textColor": "{colors.primary}",
-      "rounded": "{rounded.xl}",
-      "padding": "{spacing.glass-padding}"
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 1.5,
+          "unit": "rem"
+        }
+      },
+      "padding": {
+        "$type": "dimension",
+        "$value": {
+          "value": 20,
+          "unit": "px"
+        }
+      }
     },
     "button-primary": {
-      "backgroundColor": "{colors.primary}",
-      "textColor": "{colors.on-primary}",
-      "typography": "{typography.label-sm}",
-      "rounded": "{rounded.xl}",
+      "backgroundColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "hex": "#ffffff"
+        }
+      },
+      "textColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.184,
+            0.192,
+            0.192
+          ],
+          "hex": "#2f3131"
+        }
+      },
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter",
+          "fontSize": {
+            "value": 12,
+            "unit": "px"
+          },
+          "fontWeight": 600,
+          "letterSpacing": {
+            "value": 0.05,
+            "unit": "em"
+          },
+          "lineHeight": 16
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 1.5,
+          "unit": "rem"
+        }
+      },
       "height": {
         "$type": "dimension",
         "$value": {
@@ -802,46 +798,119 @@
         }
       },
       "padding": {
-        "$type": "dimension",
         "$value": "0 24px"
+      },
+      "$extensions": {
+        "design.md": {
+          "states": {
+            "hover": {
+              "backgroundColor": "#c6c6c7"
+            },
+            "focus-visible": {
+              "outline": "2px solid {colors.secondary}"
+            },
+            "disabled": {
+              "backgroundColor": "#2d3449",
+              "textColor": "#c4c7c8",
+              "cursor": "not-allowed"
+            }
+          },
+          "interactive": true
+        }
       }
-    },
-    "button-primary-hover": {
-      "backgroundColor": "{colors.primary-fixed-dim}"
     },
     "button-ghost": {
       "backgroundColor": {
+        "$value": "rgba(255, 255, 255, 0.05)"
+      },
+      "textColor": {
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            1.0,
-            1.0,
-            1.0
+            1,
+            1,
+            1
           ],
-          "alpha": 0.05
+          "hex": "#ffffff"
         }
       },
-      "textColor": "{colors.primary}",
-      "typography": "{typography.label-sm}",
-      "rounded": "{rounded.xl}"
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter",
+          "fontSize": {
+            "value": 12,
+            "unit": "px"
+          },
+          "fontWeight": 600,
+          "letterSpacing": {
+            "value": 0.05,
+            "unit": "em"
+          },
+          "lineHeight": 16
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 1.5,
+          "unit": "rem"
+        }
+      },
+      "$extensions": {
+        "design.md": {
+          "states": {
+            "hover": {
+              "backgroundColor": "rgba(255, 255, 255, 0.15)"
+            },
+            "focus-visible": {
+              "outline": "2px solid {colors.secondary}"
+            },
+            "disabled": {
+              "textColor": "#c4c7c8",
+              "cursor": "not-allowed"
+            }
+          },
+          "interactive": true
+        }
+      }
     },
     "input-field": {
       "backgroundColor": {
+        "$value": "rgba(255, 255, 255, 0.1)"
+      },
+      "textColor": {
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            1.0,
-            1.0,
-            1.0
+            1,
+            1,
+            1
           ],
-          "alpha": 0.1
+          "hex": "#ffffff"
         }
       },
-      "textColor": "{colors.primary}",
-      "typography": "{typography.body-md}",
-      "rounded": "{rounded.xl}",
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter",
+          "fontSize": {
+            "value": 16,
+            "unit": "px"
+          },
+          "fontWeight": 400,
+          "lineHeight": 24
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 1.5,
+          "unit": "rem"
+        }
+      },
       "padding": {
         "$type": "dimension",
         "$value": {
@@ -855,53 +924,116 @@
           "value": 48,
           "unit": "px"
         }
+      },
+      "$extensions": {
+        "design.md": {
+          "states": {
+            "focus-visible": {
+              "outline": "2px solid {colors.secondary}"
+            },
+            "disabled": {
+              "backgroundColor": "rgba(255, 255, 255, 0.05)",
+              "textColor": "#c4c7c8",
+              "cursor": "not-allowed"
+            }
+          },
+          "interactive": true
+        }
       }
     },
     "weather-display-large": {
-      "textColor": "{colors.primary}",
-      "typography": "{typography.display-lg}"
-    },
-    "metric-label": {
-      "textColor": "{colors.on-surface-variant}",
-      "typography": "{typography.label-sm}",
-      "textTransform": {
-        "$type": "string",
-        "$value": "uppercase"
-      }
-    },
-    "list-item-interactive": {
-      "backgroundColor": {
+      "textColor": {
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0,
-            0,
-            0
+            1,
+            1,
+            1
           ],
-          "alpha": 0
+          "hex": "#ffffff"
         }
       },
-      "rounded": "{rounded.md}",
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter",
+          "fontSize": {
+            "value": 84,
+            "unit": "px"
+          },
+          "fontWeight": 700,
+          "letterSpacing": {
+            "value": -0.04,
+            "unit": "em"
+          },
+          "lineHeight": 90
+        }
+      }
+    },
+    "metric-label": {
+      "textColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.769,
+            0.78,
+            0.784
+          ],
+          "hex": "#c4c7c8"
+        }
+      },
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter",
+          "fontSize": {
+            "value": 12,
+            "unit": "px"
+          },
+          "fontWeight": 600,
+          "letterSpacing": {
+            "value": 0.05,
+            "unit": "em"
+          },
+          "lineHeight": 16
+        }
+      }
+    },
+    "list-item-interactive": {
+      "backgroundColor": {
+        "$value": "transparent"
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 0.75,
+          "unit": "rem"
+        }
+      },
       "padding": {
         "$type": "dimension",
         "$value": {
           "value": 12,
           "unit": "px"
         }
-      }
-    },
-    "list-item-interactive-hover": {
-      "backgroundColor": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            1.0,
-            1.0,
-            1.0
-          ],
-          "alpha": 0.1
+      },
+      "$extensions": {
+        "design.md": {
+          "states": {
+            "hover": {
+              "backgroundColor": "rgba(255, 255, 255, 0.1)"
+            },
+            "focus-visible": {
+              "outline": "2px solid {colors.secondary}"
+            },
+            "disabled": {
+              "textColor": "#c4c7c8",
+              "cursor": "not-allowed"
+            }
+          },
+          "interactive": true
         }
       }
     }

--- a/examples/paws-and-paths/DESIGN.md
+++ b/examples/paws-and-paths/DESIGN.md
@@ -115,18 +115,34 @@ components:
     typography: "{typography.label-md}"
     rounded: "{rounded.lg}"
     padding: "{spacing.md}"
-  button-primary-hover:
-    backgroundColor: "{colors.primary-container}"
-    textColor: "{colors.on-primary-container}"
+    interactive: true
+    states:
+      hover:
+        backgroundColor: "{colors.primary-container}"
+        textColor: "{colors.on-primary-container}"
+      focus-visible:
+        outline: "2px solid {colors.primary}"
+      disabled:
+        backgroundColor: "{colors.surface-container-high}"
+        textColor: "{colors.on-surface}"
+        cursor: not-allowed
   button-secondary:
     backgroundColor: "{colors.secondary}"
     textColor: "{colors.on-secondary}"
     typography: "{typography.label-md}"
     rounded: "{rounded.lg}"
     padding: "{spacing.md}"
-  button-secondary-hover:
-    backgroundColor: "{colors.secondary-container}"
-    textColor: "{colors.on-secondary-container}"
+    interactive: true
+    states:
+      hover:
+        backgroundColor: "{colors.secondary-container}"
+        textColor: "{colors.on-secondary-container}"
+      focus-visible:
+        outline: "2px solid {colors.secondary}"
+      disabled:
+        backgroundColor: "{colors.surface-container-high}"
+        textColor: "{colors.on-surface}"
+        cursor: not-allowed
   card-profile:
     backgroundColor: "{colors.surface-container-lowest}"
     rounded: "{rounded.xl}"
@@ -142,12 +158,27 @@ components:
     typography: "{typography.body-md}"
     rounded: "{rounded.DEFAULT}"
     padding: "{spacing.sm}"
+    interactive: true
+    states:
+      focus-visible:
+        outline: "2px solid {colors.primary}"
+      disabled:
+        backgroundColor: "{colors.surface-container-high}"
+        textColor: "{colors.on-surface}"
+        cursor: not-allowed
   list-item-walker:
     backgroundColor: transparent
     padding: "{spacing.sm}"
     rounded: "{rounded.md}"
-  list-item-walker-hover:
-    backgroundColor: "{colors.surface-container-high}"
+    interactive: true
+    states:
+      hover:
+        backgroundColor: "{colors.surface-container-high}"
+      focus-visible:
+        outline: "2px solid {colors.primary}"
+      disabled:
+        textColor: "{colors.on-surface}"
+        cursor: not-allowed
   badge-status:
     backgroundColor: "{colors.tertiary-container}"
     textColor: "{colors.on-tertiary-container}"

--- a/examples/paws-and-paths/design_tokens.json
+++ b/examples/paws-and-paths/design_tokens.json
@@ -1,23 +1,20 @@
 {
-  "name": {
-    "$type": "string",
-    "$value": "Paws & Paths"
-  },
-  "colors": {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "$description": "Paws & Paths",
+  "color": {
+    "$type": "color",
     "surface": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.976,
           0.976,
-          1.0
+          1
         ],
         "hex": "#f9f9ff"
       }
     },
     "surface-dim": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -29,43 +26,39 @@
       }
     },
     "surface-bright": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.976,
           0.976,
-          1.0
+          1
         ],
         "hex": "#f9f9ff"
       }
     },
     "surface-container-lowest": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
-          1.0,
-          1.0
+          1,
+          1,
+          1
         ],
         "hex": "#ffffff"
       }
     },
     "surface-container-low": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.941,
           0.953,
-          1.0
+          1
         ],
         "hex": "#f0f3ff"
       }
     },
     "surface-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -77,7 +70,6 @@
       }
     },
     "surface-container-high": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -89,7 +81,6 @@
       }
     },
     "surface-container-highest": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -101,7 +92,6 @@
       }
     },
     "on-surface": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -113,7 +103,6 @@
       }
     },
     "on-surface-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -125,7 +114,6 @@
       }
     },
     "inverse-surface": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -137,19 +125,17 @@
       }
     },
     "inverse-on-surface": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.922,
           0.945,
-          1.0
+          1
         ],
         "hex": "#ebf1ff"
       }
     },
     "outline": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -161,7 +147,6 @@
       }
     },
     "outline-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -173,43 +158,39 @@
       }
     },
     "surface-tint": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.522,
           0.325,
-          0.0
+          0
         ],
         "hex": "#855300"
       }
     },
     "primary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.522,
           0.325,
-          0.0
+          0
         ],
         "hex": "#855300"
       }
     },
     "on-primary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
-          1.0,
-          1.0
+          1,
+          1,
+          1
         ],
         "hex": "#ffffff"
       }
     },
     "primary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -221,23 +202,21 @@
       }
     },
     "on-primary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.38,
           0.231,
-          0.0
+          0
         ],
         "hex": "#613b00"
       }
     },
     "inverse-primary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.725,
           0.373
         ],
@@ -245,11 +224,10 @@
       }
     },
     "secondary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.345,
           0.745
         ],
@@ -257,19 +235,17 @@
       }
     },
     "on-secondary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
-          1.0,
-          1.0
+          1,
+          1,
+          1
         ],
         "hex": "#ffffff"
       }
     },
     "secondary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -281,23 +257,21 @@
       }
     },
     "on-secondary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.996,
           0.988,
-          1.0
+          1
         ],
         "hex": "#fefcff"
       }
     },
     "tertiary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.396,
           0.545
         ],
@@ -305,35 +279,32 @@
       }
     },
     "on-tertiary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
-          1.0,
-          1.0
+          1,
+          1,
+          1
         ],
         "hex": "#ffffff"
       }
     },
     "tertiary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.102,
           0.741,
-          1.0
+          1
         ],
         "hex": "#1abdff"
       }
     },
     "on-tertiary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.286,
           0.4
         ],
@@ -341,7 +312,6 @@
       }
     },
     "error": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -353,23 +323,21 @@
       }
     },
     "on-error": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
-          1.0,
-          1.0
+          1,
+          1,
+          1
         ],
         "hex": "#ffffff"
       }
     },
     "error-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.855,
           0.839
         ],
@@ -377,23 +345,21 @@
       }
     },
     "on-error-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.576,
-          0.0,
+          0,
           0.039
         ],
         "hex": "#93000a"
       }
     },
     "primary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.867,
           0.722
         ],
@@ -401,11 +367,10 @@
       }
     },
     "primary-fixed-dim": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.725,
           0.373
         ],
@@ -413,59 +378,54 @@
       }
     },
     "on-primary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.165,
           0.09,
-          0.0
+          0
         ],
         "hex": "#2a1700"
       }
     },
     "on-primary-fixed-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.396,
           0.243,
-          0.0
+          0
         ],
         "hex": "#653e00"
       }
     },
     "secondary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.847,
           0.886,
-          1.0
+          1
         ],
         "hex": "#d8e2ff"
       }
     },
     "secondary-fixed-dim": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.678,
           0.776,
-          1.0
+          1
         ],
         "hex": "#adc6ff"
       }
     },
     "on-secondary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.102,
           0.259
         ],
@@ -473,11 +433,10 @@
       }
     },
     "on-secondary-fixed-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.263,
           0.584
         ],
@@ -485,35 +444,32 @@
       }
     },
     "tertiary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.773,
           0.906,
-          1.0
+          1
         ],
         "hex": "#c5e7ff"
       }
     },
     "tertiary-fixed-dim": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.498,
           0.816,
-          1.0
+          1
         ],
         "hex": "#7fd0ff"
       }
     },
     "on-tertiary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.118,
           0.176
         ],
@@ -521,11 +477,10 @@
       }
     },
     "on-tertiary-fixed-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.298,
           0.416
         ],
@@ -533,19 +488,17 @@
       }
     },
     "background": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.976,
           0.976,
-          1.0
+          1
         ],
         "hex": "#f9f9ff"
       }
     },
     "on-background": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -557,7 +510,6 @@
       }
     },
     "surface-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -566,6 +518,96 @@
           0.953
         ],
         "hex": "#dce2f3"
+      }
+    }
+  },
+  "spacing": {
+    "$type": "dimension",
+    "base": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      }
+    },
+    "xs": {
+      "$value": {
+        "value": 4,
+        "unit": "px"
+      }
+    },
+    "sm": {
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      }
+    },
+    "md": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      }
+    },
+    "lg": {
+      "$value": {
+        "value": 40,
+        "unit": "px"
+      }
+    },
+    "xl": {
+      "$value": {
+        "value": 64,
+        "unit": "px"
+      }
+    },
+    "gutter": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      }
+    },
+    "margin": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      }
+    }
+  },
+  "rounded": {
+    "$type": "dimension",
+    "sm": {
+      "$value": {
+        "value": 0.25,
+        "unit": "rem"
+      }
+    },
+    "DEFAULT": {
+      "$value": {
+        "value": 0.5,
+        "unit": "rem"
+      }
+    },
+    "md": {
+      "$value": {
+        "value": 0.75,
+        "unit": "rem"
+      }
+    },
+    "lg": {
+      "$value": {
+        "value": 1,
+        "unit": "rem"
+      }
+    },
+    "xl": {
+      "$value": {
+        "value": 1.5,
+        "unit": "rem"
+      }
+    },
+    "full": {
+      "$value": {
+        "value": 9999,
+        "unit": "px"
       }
     }
   },
@@ -579,14 +621,11 @@
           "unit": "px"
         },
         "fontWeight": 800,
-        "lineHeight": {
-          "value": 52,
-          "unit": "px"
-        },
         "letterSpacing": {
           "value": -0.02,
           "unit": "em"
-        }
+        },
+        "lineHeight": 52
       }
     },
     "headline-lg": {
@@ -598,14 +637,11 @@
           "unit": "px"
         },
         "fontWeight": 700,
-        "lineHeight": {
-          "value": 40,
-          "unit": "px"
-        },
         "letterSpacing": {
           "value": -0.01,
           "unit": "em"
-        }
+        },
+        "lineHeight": 40
       }
     },
     "headline-md": {
@@ -617,10 +653,7 @@
           "unit": "px"
         },
         "fontWeight": 700,
-        "lineHeight": {
-          "value": 32,
-          "unit": "px"
-        }
+        "lineHeight": 32
       }
     },
     "title-lg": {
@@ -632,10 +665,7 @@
           "unit": "px"
         },
         "fontWeight": 600,
-        "lineHeight": {
-          "value": 28,
-          "unit": "px"
-        }
+        "lineHeight": 28
       }
     },
     "body-lg": {
@@ -647,10 +677,7 @@
           "unit": "px"
         },
         "fontWeight": 400,
-        "lineHeight": {
-          "value": 28,
-          "unit": "px"
-        }
+        "lineHeight": 28
       }
     },
     "body-md": {
@@ -662,10 +689,7 @@
           "unit": "px"
         },
         "fontWeight": 400,
-        "lineHeight": {
-          "value": 24,
-          "unit": "px"
-        }
+        "lineHeight": 24
       }
     },
     "label-md": {
@@ -677,14 +701,11 @@
           "unit": "px"
         },
         "fontWeight": 600,
-        "lineHeight": {
-          "value": 20,
-          "unit": "px"
-        },
         "letterSpacing": {
           "value": 0.01,
           "unit": "em"
-        }
+        },
+        "lineHeight": 20
       }
     },
     "label-sm": {
@@ -696,181 +717,383 @@
           "unit": "px"
         },
         "fontWeight": 500,
-        "lineHeight": {
-          "value": 16,
+        "lineHeight": 16
+      }
+    }
+  },
+  "component": {
+    "button-primary": {
+      "backgroundColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.522,
+            0.325,
+            0
+          ],
+          "hex": "#855300"
+        }
+      },
+      "textColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "hex": "#ffffff"
+        }
+      },
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Plus Jakarta Sans",
+          "fontSize": {
+            "value": 14,
+            "unit": "px"
+          },
+          "fontWeight": 600,
+          "letterSpacing": {
+            "value": 0.01,
+            "unit": "em"
+          },
+          "lineHeight": 20
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 1,
+          "unit": "rem"
+        }
+      },
+      "padding": {
+        "$type": "dimension",
+        "$value": {
+          "value": 24,
           "unit": "px"
         }
+      },
+      "$extensions": {
+        "design.md": {
+          "states": {
+            "hover": {
+              "backgroundColor": "#f59e0b",
+              "textColor": "#613b00"
+            },
+            "focus-visible": {
+              "outline": "2px solid {colors.primary}"
+            },
+            "disabled": {
+              "backgroundColor": "#e2e8f8",
+              "textColor": "#151c27",
+              "cursor": "not-allowed"
+            }
+          },
+          "interactive": true
+        }
       }
-    }
-  },
-  "rounded": {
-    "sm": {
-      "$type": "dimension",
-      "$value": {
-        "value": 0.25,
-        "unit": "rem"
-      }
-    },
-    "DEFAULT": {
-      "$type": "dimension",
-      "$value": {
-        "value": 0.5,
-        "unit": "rem"
-      }
-    },
-    "md": {
-      "$type": "dimension",
-      "$value": {
-        "value": 0.75,
-        "unit": "rem"
-      }
-    },
-    "lg": {
-      "$type": "dimension",
-      "$value": {
-        "value": 1,
-        "unit": "rem"
-      }
-    },
-    "xl": {
-      "$type": "dimension",
-      "$value": {
-        "value": 1.5,
-        "unit": "rem"
-      }
-    },
-    "full": {
-      "$type": "dimension",
-      "$value": {
-        "value": 9999,
-        "unit": "px"
-      }
-    }
-  },
-  "spacing": {
-    "base": {
-      "$type": "dimension",
-      "$value": {
-        "value": 8,
-        "unit": "px"
-      }
-    },
-    "xs": {
-      "$type": "dimension",
-      "$value": {
-        "value": 4,
-        "unit": "px"
-      }
-    },
-    "sm": {
-      "$type": "dimension",
-      "$value": {
-        "value": 12,
-        "unit": "px"
-      }
-    },
-    "md": {
-      "$type": "dimension",
-      "$value": {
-        "value": 24,
-        "unit": "px"
-      }
-    },
-    "lg": {
-      "$type": "dimension",
-      "$value": {
-        "value": 40,
-        "unit": "px"
-      }
-    },
-    "xl": {
-      "$type": "dimension",
-      "$value": {
-        "value": 64,
-        "unit": "px"
-      }
-    },
-    "gutter": {
-      "$type": "dimension",
-      "$value": {
-        "value": 16,
-        "unit": "px"
-      }
-    },
-    "margin": {
-      "$type": "dimension",
-      "$value": {
-        "value": 24,
-        "unit": "px"
-      }
-    }
-  },
-  "components": {
-    "button-primary": {
-      "backgroundColor": "{colors.primary}",
-      "textColor": "{colors.on-primary}",
-      "typography": "{typography.label-md}",
-      "rounded": "{rounded.lg}",
-      "padding": "{spacing.md}"
-    },
-    "button-primary-hover": {
-      "backgroundColor": "{colors.primary-container}",
-      "textColor": "{colors.on-primary-container}"
     },
     "button-secondary": {
-      "backgroundColor": "{colors.secondary}",
-      "textColor": "{colors.on-secondary}",
-      "typography": "{typography.label-md}",
-      "rounded": "{rounded.lg}",
-      "padding": "{spacing.md}"
-    },
-    "button-secondary-hover": {
-      "backgroundColor": "{colors.secondary-container}",
-      "textColor": "{colors.on-secondary-container}"
-    },
-    "card-profile": {
-      "backgroundColor": "{colors.surface-container-lowest}",
-      "rounded": "{rounded.xl}",
-      "padding": "{spacing.md}"
-    },
-    "card-walk-stat": {
-      "backgroundColor": "{colors.secondary-container}",
-      "textColor": "{colors.on-secondary-container}",
-      "rounded": "{rounded.md}",
-      "padding": "{spacing.sm}"
-    },
-    "input-field": {
-      "backgroundColor": "{colors.surface-container-low}",
-      "textColor": "{colors.on-surface}",
-      "typography": "{typography.body-md}",
-      "rounded": "{rounded.DEFAULT}",
-      "padding": "{spacing.sm}"
-    },
-    "list-item-walker": {
       "backgroundColor": {
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
           "components": [
             0,
-            0,
-            0
+            0.345,
+            0.745
           ],
-          "alpha": 0
+          "hex": "#0058be"
         }
       },
-      "padding": "{spacing.sm}",
-      "rounded": "{rounded.md}"
+      "textColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "hex": "#ffffff"
+        }
+      },
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Plus Jakarta Sans",
+          "fontSize": {
+            "value": 14,
+            "unit": "px"
+          },
+          "fontWeight": 600,
+          "letterSpacing": {
+            "value": 0.01,
+            "unit": "em"
+          },
+          "lineHeight": 20
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 1,
+          "unit": "rem"
+        }
+      },
+      "padding": {
+        "$type": "dimension",
+        "$value": {
+          "value": 24,
+          "unit": "px"
+        }
+      },
+      "$extensions": {
+        "design.md": {
+          "states": {
+            "hover": {
+              "backgroundColor": "#2170e4",
+              "textColor": "#fefcff"
+            },
+            "focus-visible": {
+              "outline": "2px solid {colors.secondary}"
+            },
+            "disabled": {
+              "backgroundColor": "#e2e8f8",
+              "textColor": "#151c27",
+              "cursor": "not-allowed"
+            }
+          },
+          "interactive": true
+        }
+      }
     },
-    "list-item-walker-hover": {
-      "backgroundColor": "{colors.surface-container-high}"
+    "card-profile": {
+      "backgroundColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            1,
+            1
+          ],
+          "hex": "#ffffff"
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 1.5,
+          "unit": "rem"
+        }
+      },
+      "padding": {
+        "$type": "dimension",
+        "$value": {
+          "value": 24,
+          "unit": "px"
+        }
+      }
+    },
+    "card-walk-stat": {
+      "backgroundColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.129,
+            0.439,
+            0.894
+          ],
+          "hex": "#2170e4"
+        }
+      },
+      "textColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.996,
+            0.988,
+            1
+          ],
+          "hex": "#fefcff"
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 0.75,
+          "unit": "rem"
+        }
+      },
+      "padding": {
+        "$type": "dimension",
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        }
+      }
+    },
+    "input-field": {
+      "backgroundColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.941,
+            0.953,
+            1
+          ],
+          "hex": "#f0f3ff"
+        }
+      },
+      "textColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.082,
+            0.11,
+            0.153
+          ],
+          "hex": "#151c27"
+        }
+      },
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Plus Jakarta Sans",
+          "fontSize": {
+            "value": 16,
+            "unit": "px"
+          },
+          "fontWeight": 400,
+          "lineHeight": 24
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 0.5,
+          "unit": "rem"
+        }
+      },
+      "padding": {
+        "$type": "dimension",
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        }
+      },
+      "$extensions": {
+        "design.md": {
+          "states": {
+            "focus-visible": {
+              "outline": "2px solid {colors.primary}"
+            },
+            "disabled": {
+              "backgroundColor": "#e2e8f8",
+              "textColor": "#151c27",
+              "cursor": "not-allowed"
+            }
+          },
+          "interactive": true
+        }
+      }
+    },
+    "list-item-walker": {
+      "backgroundColor": {
+        "$value": "transparent"
+      },
+      "padding": {
+        "$type": "dimension",
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 0.75,
+          "unit": "rem"
+        }
+      },
+      "$extensions": {
+        "design.md": {
+          "states": {
+            "hover": {
+              "backgroundColor": "#e2e8f8"
+            },
+            "focus-visible": {
+              "outline": "2px solid {colors.primary}"
+            },
+            "disabled": {
+              "textColor": "#151c27",
+              "cursor": "not-allowed"
+            }
+          },
+          "interactive": true
+        }
+      }
     },
     "badge-status": {
-      "backgroundColor": "{colors.tertiary-container}",
-      "textColor": "{colors.on-tertiary-container}",
-      "typography": "{typography.label-sm}",
-      "rounded": "{rounded.full}",
-      "padding": "{spacing.xs}"
+      "backgroundColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.102,
+            0.741,
+            1
+          ],
+          "hex": "#1abdff"
+        }
+      },
+      "textColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0,
+            0.286,
+            0.4
+          ],
+          "hex": "#004966"
+        }
+      },
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Plus Jakarta Sans",
+          "fontSize": {
+            "value": 12,
+            "unit": "px"
+          },
+          "fontWeight": 500,
+          "lineHeight": 16
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 9999,
+          "unit": "px"
+        }
+      },
+      "padding": {
+        "$type": "dimension",
+        "$value": {
+          "value": 4,
+          "unit": "px"
+        }
+      }
     }
   }
 }

--- a/examples/totality-festival/DESIGN.md
+++ b/examples/totality-festival/DESIGN.md
@@ -106,8 +106,16 @@ components:
     rounded: "{rounded.lg}"
     padding: 12px
     height: 48px
-  button-primary-hover:
-    backgroundColor: "{colors.primary-fixed}"
+    interactive: true
+    states:
+      hover:
+        backgroundColor: "{colors.primary-fixed}"
+      focus-visible:
+        outline: "2px solid {colors.secondary}"
+      disabled:
+        backgroundColor: "{colors.surface-container-high}"
+        textColor: "{colors.on-surface}"
+        cursor: not-allowed
   button-secondary:
     backgroundColor: transparent
     textColor: "{colors.secondary}"
@@ -115,25 +123,64 @@ components:
     rounded: "{rounded.lg}"
     padding: 12px
     height: 48px
-  button-secondary-hover:
-    backgroundColor: rgba(0, 227, 253, 0.1)
+    border: "1px solid {colors.secondary}"
+    interactive: true
+    states:
+      hover:
+        backgroundColor: rgba(0, 227, 253, 0.1)
+      focus-visible:
+        outline: "2px solid {colors.secondary}"
+      disabled:
+        textColor: "{colors.on-surface}"
+        border: "1px solid {colors.outline}"
+        cursor: not-allowed
   card-glass-level-2:
     backgroundColor: rgba(52, 52, 58, 0.2)
     rounded: "{rounded.xl}"
     padding: "{spacing.gutter}"
-  card-glass-interactive-hover:
-    backgroundColor: rgba(56, 57, 63, 0.4)
+  card-glass-interactive:
+    backgroundColor: rgba(52, 52, 58, 0.2)
+    rounded: "{rounded.xl}"
+    padding: "{spacing.gutter}"
+    border: "1px solid rgba(255, 255, 255, 0.08)"
+    interactive: true
+    states:
+      hover:
+        backgroundColor: rgba(56, 57, 63, 0.4)
+      focus-visible:
+        outline: "2px solid {colors.secondary}"
+      disabled:
+        cursor: not-allowed
+        textColor: "{colors.on-surface}"
   input-field:
     backgroundColor: "{colors.surface-container-lowest}"
     textColor: "{colors.on-surface}"
     typography: "{typography.body-md}"
     rounded: "{rounded.lg}"
     padding: 12px
-  list-item-hover:
-    backgroundColor: "{colors.surface-container-high}"
-    textColor: "{colors.primary}"
+    interactive: true
+    states:
+      focus-visible:
+        outline: "2px solid {colors.secondary}"
+      disabled:
+        backgroundColor: "{colors.surface-container-high}"
+        textColor: "{colors.on-surface}"
+        cursor: not-allowed
+  list-item:
+    backgroundColor: transparent
+    textColor: "{colors.on-surface}"
     rounded: "{rounded.md}"
     padding: 8px
+    interactive: true
+    states:
+      hover:
+        backgroundColor: "{colors.surface-container-high}"
+        textColor: "{colors.primary}"
+      focus-visible:
+        outline: "2px solid {colors.secondary}"
+      disabled:
+        textColor: "{colors.on-surface}"
+        cursor: not-allowed
   hero-headline:
     textColor: "{colors.primary}"
     typography: "{typography.headline-xl}"

--- a/examples/totality-festival/design_tokens.json
+++ b/examples/totality-festival/design_tokens.json
@@ -1,11 +1,9 @@
 {
-  "name": {
-    "$type": "string",
-    "$value": "Totality Festival Design System"
-  },
-  "colors": {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "$description": "Totality Festival Design System",
+  "color": {
+    "$type": "color",
     "surface": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -17,7 +15,6 @@
       }
     },
     "surface-dim": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -29,7 +26,6 @@
       }
     },
     "surface-bright": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -41,7 +37,6 @@
       }
     },
     "surface-container-lowest": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -53,7 +48,6 @@
       }
     },
     "surface-container-low": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -65,7 +59,6 @@
       }
     },
     "surface-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -77,7 +70,6 @@
       }
     },
     "surface-container-high": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -89,7 +81,6 @@
       }
     },
     "surface-container-highest": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -101,7 +92,6 @@
       }
     },
     "on-surface": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -113,7 +103,6 @@
       }
     },
     "on-surface-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -125,7 +114,6 @@
       }
     },
     "inverse-surface": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -137,7 +125,6 @@
       }
     },
     "inverse-on-surface": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -149,7 +136,6 @@
       }
     },
     "outline": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -161,7 +147,6 @@
       }
     },
     "outline-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -173,23 +158,21 @@
       }
     },
     "surface-tint": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.914,
           0.769,
-          0.0
+          0
         ],
         "hex": "#e9c400"
       }
     },
     "primary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.965,
           0.875
         ],
@@ -197,71 +180,65 @@
       }
     },
     "on-primary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.227,
           0.188,
-          0.0
+          0
         ],
         "hex": "#3a3000"
       }
     },
     "primary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.843,
-          0.0
+          0
         ],
         "hex": "#ffd700"
       }
     },
     "on-primary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.439,
           0.369,
-          0.0
+          0
         ],
         "hex": "#705e00"
       }
     },
     "inverse-primary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.439,
           0.365,
-          0.0
+          0
         ],
         "hex": "#705d00"
       }
     },
     "secondary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.741,
           0.957,
-          1.0
+          1
         ],
         "hex": "#bdf4ff"
       }
     },
     "on-secondary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.212,
           0.239
         ],
@@ -269,11 +246,10 @@
       }
     },
     "secondary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.89,
           0.992
         ],
@@ -281,11 +257,10 @@
       }
     },
     "on-secondary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.38,
           0.427
         ],
@@ -293,19 +268,17 @@
       }
     },
     "tertiary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.988,
           0.953,
-          1.0
+          1
         ],
         "hex": "#fcf3ff"
       }
     },
     "on-tertiary": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -317,19 +290,17 @@
       }
     },
     "tertiary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.906,
           0.82,
-          1.0
+          1
         ],
         "hex": "#e7d1ff"
       }
     },
     "on-tertiary-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -341,11 +312,10 @@
       }
     },
     "error": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.706,
           0.671
         ],
@@ -353,35 +323,32 @@
       }
     },
     "on-error": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.412,
-          0.0,
+          0,
           0.02
         ],
         "hex": "#690005"
       }
     },
     "error-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.576,
-          0.0,
+          0,
           0.039
         ],
         "hex": "#93000a"
       }
     },
     "on-error-container": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.855,
           0.839
         ],
@@ -389,11 +356,10 @@
       }
     },
     "primary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          1.0,
+          1,
           0.882,
           0.427
         ],
@@ -401,59 +367,54 @@
       }
     },
     "primary-fixed-dim": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.914,
           0.769,
-          0.0
+          0
         ],
         "hex": "#e9c400"
       }
     },
     "on-primary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.133,
           0.106,
-          0.0
+          0
         ],
         "hex": "#221b00"
       }
     },
     "on-primary-fixed-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.329,
           0.275,
-          0.0
+          0
         ],
         "hex": "#544600"
       }
     },
     "secondary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.612,
           0.941,
-          1.0
+          1
         ],
         "hex": "#9cf0ff"
       }
     },
     "secondary-fixed-dim": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.855,
           0.953
         ],
@@ -461,11 +422,10 @@
       }
     },
     "on-secondary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.122,
           0.141
         ],
@@ -473,11 +433,10 @@
       }
     },
     "on-secondary-fixed-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
-          0.0,
+          0,
           0.31,
           0.345
         ],
@@ -485,19 +444,17 @@
       }
     },
     "tertiary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
           0.933,
           0.859,
-          1.0
+          1
         ],
         "hex": "#eedbff"
       }
     },
     "tertiary-fixed-dim": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -509,7 +466,6 @@
       }
     },
     "on-tertiary-fixed": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -521,7 +477,6 @@
       }
     },
     "on-tertiary-fixed-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -533,7 +488,6 @@
       }
     },
     "background": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -545,7 +499,6 @@
       }
     },
     "on-background": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -557,7 +510,6 @@
       }
     },
     "surface-variant": {
-      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [
@@ -566,6 +518,78 @@
           0.227
         ],
         "hex": "#34343a"
+      }
+    }
+  },
+  "spacing": {
+    "$type": "dimension",
+    "unit": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      }
+    },
+    "container-max": {
+      "$value": {
+        "value": 1280,
+        "unit": "px"
+      }
+    },
+    "gutter": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      }
+    },
+    "margin-mobile": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      }
+    },
+    "margin-desktop": {
+      "$value": {
+        "value": 64,
+        "unit": "px"
+      }
+    }
+  },
+  "rounded": {
+    "$type": "dimension",
+    "sm": {
+      "$value": {
+        "value": 0.125,
+        "unit": "rem"
+      }
+    },
+    "DEFAULT": {
+      "$value": {
+        "value": 0.25,
+        "unit": "rem"
+      }
+    },
+    "md": {
+      "$value": {
+        "value": 0.375,
+        "unit": "rem"
+      }
+    },
+    "lg": {
+      "$value": {
+        "value": 0.5,
+        "unit": "rem"
+      }
+    },
+    "xl": {
+      "$value": {
+        "value": 0.75,
+        "unit": "rem"
+      }
+    },
+    "full": {
+      "$value": {
+        "value": 9999,
+        "unit": "px"
       }
     }
   },
@@ -579,14 +603,11 @@
           "unit": "px"
         },
         "fontWeight": 700,
-        "lineHeight": {
-          "value": 80,
-          "unit": "px"
-        },
         "letterSpacing": {
           "value": -0.04,
           "unit": "em"
-        }
+        },
+        "lineHeight": 80
       }
     },
     "headline-lg": {
@@ -598,14 +619,11 @@
           "unit": "px"
         },
         "fontWeight": 600,
-        "lineHeight": {
-          "value": 56,
-          "unit": "px"
-        },
         "letterSpacing": {
           "value": -0.02,
           "unit": "em"
-        }
+        },
+        "lineHeight": 56
       }
     },
     "headline-md": {
@@ -617,14 +635,11 @@
           "unit": "px"
         },
         "fontWeight": 600,
-        "lineHeight": {
-          "value": 40,
-          "unit": "px"
-        },
         "letterSpacing": {
           "value": 0,
           "unit": "em"
-        }
+        },
+        "lineHeight": 40
       }
     },
     "body-lg": {
@@ -636,14 +651,11 @@
           "unit": "px"
         },
         "fontWeight": 400,
-        "lineHeight": {
-          "value": 28,
-          "unit": "px"
-        },
         "letterSpacing": {
           "value": 0,
           "unit": "em"
-        }
+        },
+        "lineHeight": 28
       }
     },
     "body-md": {
@@ -655,14 +667,11 @@
           "unit": "px"
         },
         "fontWeight": 400,
-        "lineHeight": {
-          "value": 24,
-          "unit": "px"
-        },
         "letterSpacing": {
           "value": 0,
           "unit": "em"
-        }
+        },
+        "lineHeight": 24
       }
     },
     "label-md": {
@@ -674,104 +683,63 @@
           "unit": "px"
         },
         "fontWeight": 500,
-        "lineHeight": {
-          "value": 20,
-          "unit": "px"
-        },
         "letterSpacing": {
           "value": 0.1,
           "unit": "em"
-        }
+        },
+        "lineHeight": 20
       }
     }
   },
-  "rounded": {
-    "sm": {
-      "$type": "dimension",
-      "$value": {
-        "value": 0.125,
-        "unit": "rem"
-      }
-    },
-    "DEFAULT": {
-      "$type": "dimension",
-      "$value": {
-        "value": 0.25,
-        "unit": "rem"
-      }
-    },
-    "md": {
-      "$type": "dimension",
-      "$value": {
-        "value": 0.375,
-        "unit": "rem"
-      }
-    },
-    "lg": {
-      "$type": "dimension",
-      "$value": {
-        "value": 0.5,
-        "unit": "rem"
-      }
-    },
-    "xl": {
-      "$type": "dimension",
-      "$value": {
-        "value": 0.75,
-        "unit": "rem"
-      }
-    },
-    "full": {
-      "$type": "dimension",
-      "$value": {
-        "value": 9999,
-        "unit": "px"
-      }
-    }
-  },
-  "spacing": {
-    "unit": {
-      "$type": "dimension",
-      "$value": {
-        "value": 8,
-        "unit": "px"
-      }
-    },
-    "container-max": {
-      "$type": "dimension",
-      "$value": {
-        "value": 1280,
-        "unit": "px"
-      }
-    },
-    "gutter": {
-      "$type": "dimension",
-      "$value": {
-        "value": 24,
-        "unit": "px"
-      }
-    },
-    "margin-mobile": {
-      "$type": "dimension",
-      "$value": {
-        "value": 16,
-        "unit": "px"
-      }
-    },
-    "margin-desktop": {
-      "$type": "dimension",
-      "$value": {
-        "value": 64,
-        "unit": "px"
-      }
-    }
-  },
-  "components": {
+  "component": {
     "button-primary": {
-      "backgroundColor": "{colors.primary}",
-      "textColor": "{colors.on-primary}",
-      "typography": "{typography.label-md}",
-      "rounded": "{rounded.lg}",
+      "backgroundColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            0.965,
+            0.875
+          ],
+          "hex": "#fff6df"
+        }
+      },
+      "textColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.227,
+            0.188,
+            0
+          ],
+          "hex": "#3a3000"
+        }
+      },
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Space Grotesk",
+          "fontSize": {
+            "value": 14,
+            "unit": "px"
+          },
+          "fontWeight": 500,
+          "letterSpacing": {
+            "value": 0.1,
+            "unit": "em"
+          },
+          "lineHeight": 20
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 0.5,
+          "unit": "rem"
+        }
+      },
       "padding": {
         "$type": "dimension",
         "$value": {
@@ -785,27 +753,65 @@
           "value": 48,
           "unit": "px"
         }
+      },
+      "$extensions": {
+        "design.md": {
+          "states": {
+            "hover": {
+              "backgroundColor": "#ffe16d"
+            },
+            "focus-visible": {
+              "outline": "2px solid {colors.secondary}"
+            },
+            "disabled": {
+              "backgroundColor": "#292a2f",
+              "textColor": "#e3e1e9",
+              "cursor": "not-allowed"
+            }
+          },
+          "interactive": true
+        }
       }
-    },
-    "button-primary-hover": {
-      "backgroundColor": "{colors.primary-fixed}"
     },
     "button-secondary": {
       "backgroundColor": {
+        "$value": "transparent"
+      },
+      "textColor": {
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0,
-            0,
-            0
+            0.741,
+            0.957,
+            1
           ],
-          "alpha": 0
+          "hex": "#bdf4ff"
         }
       },
-      "textColor": "{colors.secondary}",
-      "typography": "{typography.label-md}",
-      "rounded": "{rounded.lg}",
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Space Grotesk",
+          "fontSize": {
+            "value": 14,
+            "unit": "px"
+          },
+          "fontWeight": 500,
+          "letterSpacing": {
+            "value": 0.1,
+            "unit": "em"
+          },
+          "lineHeight": 20
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 0.5,
+          "unit": "rem"
+        }
+      },
       "padding": {
         "$type": "dimension",
         "$value": {
@@ -819,86 +825,285 @@
           "value": 48,
           "unit": "px"
         }
-      }
-    },
-    "button-secondary-hover": {
-      "backgroundColor": {
-        "$type": "color",
-        "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.0,
-            0.89,
-            0.992
-          ],
-          "alpha": 0.1
+      },
+      "border": {
+        "$value": "1px solid {colors.secondary}"
+      },
+      "$extensions": {
+        "design.md": {
+          "states": {
+            "hover": {
+              "backgroundColor": "rgba(0, 227, 253, 0.1)"
+            },
+            "focus-visible": {
+              "outline": "2px solid {colors.secondary}"
+            },
+            "disabled": {
+              "textColor": "#e3e1e9",
+              "border": "1px solid {colors.outline}",
+              "cursor": "not-allowed"
+            }
+          },
+          "interactive": true
         }
       }
     },
     "card-glass-level-2": {
       "backgroundColor": {
-        "$type": "color",
+        "$value": "rgba(52, 52, 58, 0.2)"
+      },
+      "rounded": {
+        "$type": "dimension",
         "$value": {
-          "colorSpace": "srgb",
-          "components": [
-            0.204,
-            0.204,
-            0.227
-          ],
-          "alpha": 0.2
+          "value": 0.75,
+          "unit": "rem"
         }
       },
-      "rounded": "{rounded.xl}",
-      "padding": "{spacing.gutter}"
+      "padding": {
+        "$type": "dimension",
+        "$value": {
+          "value": 24,
+          "unit": "px"
+        }
+      }
     },
-    "card-glass-interactive-hover": {
+    "card-glass-interactive": {
+      "backgroundColor": {
+        "$value": "rgba(52, 52, 58, 0.2)"
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 0.75,
+          "unit": "rem"
+        }
+      },
+      "padding": {
+        "$type": "dimension",
+        "$value": {
+          "value": 24,
+          "unit": "px"
+        }
+      },
+      "border": {
+        "$value": "1px solid rgba(255, 255, 255, 0.08)"
+      },
+      "$extensions": {
+        "design.md": {
+          "states": {
+            "hover": {
+              "backgroundColor": "rgba(56, 57, 63, 0.4)"
+            },
+            "focus-visible": {
+              "outline": "2px solid {colors.secondary}"
+            },
+            "disabled": {
+              "cursor": "not-allowed",
+              "textColor": "#e3e1e9"
+            }
+          },
+          "interactive": true
+        }
+      }
+    },
+    "input-field": {
       "backgroundColor": {
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
           "components": [
-            0.22,
-            0.224,
-            0.247
+            0.051,
+            0.055,
+            0.075
           ],
-          "alpha": 0.4
+          "hex": "#0d0e13"
         }
-      }
-    },
-    "input-field": {
-      "backgroundColor": "{colors.surface-container-lowest}",
-      "textColor": "{colors.on-surface}",
-      "typography": "{typography.body-md}",
-      "rounded": "{rounded.lg}",
+      },
+      "textColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.89,
+            0.882,
+            0.914
+          ],
+          "hex": "#e3e1e9"
+        }
+      },
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Inter",
+          "fontSize": {
+            "value": 16,
+            "unit": "px"
+          },
+          "fontWeight": 400,
+          "letterSpacing": {
+            "value": 0,
+            "unit": "em"
+          },
+          "lineHeight": 24
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 0.5,
+          "unit": "rem"
+        }
+      },
       "padding": {
         "$type": "dimension",
         "$value": {
           "value": 12,
           "unit": "px"
         }
+      },
+      "$extensions": {
+        "design.md": {
+          "states": {
+            "focus-visible": {
+              "outline": "2px solid {colors.secondary}"
+            },
+            "disabled": {
+              "backgroundColor": "#292a2f",
+              "textColor": "#e3e1e9",
+              "cursor": "not-allowed"
+            }
+          },
+          "interactive": true
+        }
       }
     },
-    "list-item-hover": {
-      "backgroundColor": "{colors.surface-container-high}",
-      "textColor": "{colors.primary}",
-      "rounded": "{rounded.md}",
+    "list-item": {
+      "backgroundColor": {
+        "$value": "transparent"
+      },
+      "textColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.89,
+            0.882,
+            0.914
+          ],
+          "hex": "#e3e1e9"
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 0.375,
+          "unit": "rem"
+        }
+      },
       "padding": {
         "$type": "dimension",
         "$value": {
           "value": 8,
           "unit": "px"
         }
+      },
+      "$extensions": {
+        "design.md": {
+          "states": {
+            "hover": {
+              "backgroundColor": "#292a2f",
+              "textColor": "#fff6df"
+            },
+            "focus-visible": {
+              "outline": "2px solid {colors.secondary}"
+            },
+            "disabled": {
+              "textColor": "#e3e1e9",
+              "cursor": "not-allowed"
+            }
+          },
+          "interactive": true
+        }
       }
     },
     "hero-headline": {
-      "textColor": "{colors.primary}",
-      "typography": "{typography.headline-xl}"
+      "textColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            1,
+            0.965,
+            0.875
+          ],
+          "hex": "#fff6df"
+        }
+      },
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Space Grotesk",
+          "fontSize": {
+            "value": 72,
+            "unit": "px"
+          },
+          "fontWeight": 700,
+          "letterSpacing": {
+            "value": -0.04,
+            "unit": "em"
+          },
+          "lineHeight": 80
+        }
+      }
     },
     "badge-celestial": {
-      "backgroundColor": "{colors.tertiary-container}",
-      "textColor": "{colors.on-tertiary-container}",
-      "typography": "{typography.label-md}",
-      "rounded": "{rounded.full}",
+      "backgroundColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.906,
+            0.82,
+            1
+          ],
+          "hex": "#e7d1ff"
+        }
+      },
+      "textColor": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [
+            0.42,
+            0.333,
+            0.525
+          ],
+          "hex": "#6b5586"
+        }
+      },
+      "typography": {
+        "$type": "typography",
+        "$value": {
+          "fontFamily": "Space Grotesk",
+          "fontSize": {
+            "value": 14,
+            "unit": "px"
+          },
+          "fontWeight": 500,
+          "letterSpacing": {
+            "value": 0.1,
+            "unit": "em"
+          },
+          "lineHeight": 20
+        }
+      },
+      "rounded": {
+        "$type": "dimension",
+        "$value": {
+          "value": 9999,
+          "unit": "px"
+        }
+      },
       "padding": {
         "$type": "dimension",
         "$value": {

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -36,6 +36,11 @@ export default defineCommand({
       description: `Output format: ${FORMATS.join(', ')}`,
       required: true,
     },
+    components: {
+      type: 'boolean',
+      description: 'Include components in the export (currently only the tailwind format projects components, as a plugin block).',
+      default: false,
+    },
   },
   async run({ args }) {
     const format = args.format as string;
@@ -54,7 +59,7 @@ export default defineCommand({
 
     if (format === 'tailwind') {
       const handler = new TailwindEmitterHandler();
-      const result = handler.execute(report.designSystem);
+      const result = handler.execute(report.designSystem, { components: Boolean(args.components) });
 
       if (!result.success) {
         console.error(JSON.stringify({ error: result.error.message }));

--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -89,6 +89,6 @@ describe('spec command', () => {
     const output = JSON.parse(outputStr);
     expect(output.spec).toBeDefined();
     expect(output.rules).toBeDefined();
-    expect(output.rules.length).toBe(8);
+    expect(output.rules.length).toBe(14);
   });
 });

--- a/packages/cli/src/linter/dtcg/handler.test.ts
+++ b/packages/cli/src/linter/dtcg/handler.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, test, expect } from 'bun:test';
 import { DtcgEmitterHandler } from './handler.js';
-import type { DesignSystemState, ResolvedColor, ResolvedDimension, ResolvedTypography } from '../model/spec.js';
+import type { ComponentDef, DesignSystemState, ResolvedColor, ResolvedDimension, ResolvedTypography, ResolvedValue } from '../model/spec.js';
 
 function emptyState(overrides?: Partial<DesignSystemState>): DesignSystemState {
   return {
@@ -168,6 +168,63 @@ describe('DtcgEmitterHandler', () => {
     expect(value['fontWeight']).toBe(700);
     expect(value['lineHeight']).toBe(1.2);
     expect(value['letterSpacing']).toEqual({ value: 0.5, unit: 'px' });
+  });
+
+  test('components → DTCG group with $extensions[design.md].states', () => {
+    const primary = makeColor('#1a1c1e', 0x1A, 0x1C, 0x1E);
+    const accent = makeColor('#ffffff', 255, 255, 255);
+
+    const baseProps = new Map<string, ResolvedValue>([
+      ['backgroundColor', primary],
+      ['padding', makeDim(12, 'px')],
+    ]);
+    const hoverOverrides = new Map<string, ResolvedValue>([
+      ['backgroundColor', accent],
+    ]);
+    const focusOverrides = new Map<string, ResolvedValue>([
+      ['outline', '2px solid #ffffff'],
+    ]);
+
+    const states = new Map<string, Map<string, ResolvedValue>>([
+      ['hover', hoverOverrides],
+      ['focus-visible', focusOverrides],
+    ]);
+    const resolvedStates = new Map<string, Map<string, ResolvedValue>>();
+    for (const [name, overrides] of states) {
+      const merged = new Map<string, ResolvedValue>(baseProps);
+      for (const [k, v] of overrides) merged.set(k, v);
+      resolvedStates.set(name, merged);
+    }
+
+    const btn: ComponentDef = {
+      properties: baseProps,
+      interactive: true,
+      states,
+      resolvedStates,
+      unresolvedRefs: [],
+    };
+
+    const state = emptyState({
+      components: new Map<string, ComponentDef>([['btn', btn]]),
+    });
+
+    const result = handler.execute(state);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const componentGroup = result.data['component'] as Record<string, unknown>;
+    expect(componentGroup).toBeDefined();
+    const btnTok = componentGroup['btn'] as Record<string, unknown>;
+    const bgToken = btnTok['backgroundColor'] as Record<string, unknown>;
+    expect(bgToken['$type']).toBe('color');
+
+    const ext = btnTok['$extensions'] as Record<string, unknown>;
+    expect(ext).toBeDefined();
+    const designMd = ext['design.md'] as Record<string, unknown>;
+    expect(designMd['interactive']).toBe(true);
+    const stateMap = designMd['states'] as Record<string, Record<string, unknown>>;
+    expect(stateMap['hover']?.['backgroundColor']).toBe('#ffffff');
+    expect(stateMap['focus-visible']?.['outline']).toBe('2px solid #ffffff');
   });
 
   test('typography with missing fields omits them from $value', () => {

--- a/packages/cli/src/linter/dtcg/handler.ts
+++ b/packages/cli/src/linter/dtcg/handler.ts
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DtcgEmitterSpec, DtcgEmitterResult, DtcgTokenFile, DtcgToken, DtcgGroup, DtcgColorValue, DtcgDimensionValue, DtcgTypographyValue } from './spec.js';
-import type { DesignSystemState, ResolvedColor, ResolvedDimension, ResolvedTypography } from '../model/spec.js';
+import type { DtcgEmitterSpec, DtcgEmitterResult, DtcgTokenFile, DtcgToken, DtcgGroup, DtcgColorValue, DtcgDimensionValue, DtcgTypographyValue, DesignMdStatesExtension } from './spec.js';
+import type { ComponentDef, DesignSystemState, ResolvedColor, ResolvedDimension, ResolvedTypography, ResolvedValue } from '../model/spec.js';
 
 const DTCG_SCHEMA_URL = 'https://www.designtokens.org/schemas/2025.10/format.json';
+const DESIGN_MD_EXTENSION_KEY = 'design.md';
 
 /**
  * Pure function mapping DesignSystemState → DTCG tokens.json (W3C Design Tokens Format Module 2025.10).
@@ -43,7 +44,81 @@ export class DtcgEmitterHandler implements DtcgEmitterSpec {
     const typographyGroup = this.mapTypography(state);
     if (typographyGroup) file['typography'] = typographyGroup;
 
+    const componentGroup = this.mapComponents(state);
+    if (componentGroup) file['component'] = componentGroup;
+
     return { success: true, data: file as Record<string, unknown> };
+  }
+
+  /**
+   * Project the component map into a DTCG group. DTCG has no native component
+   * concept, so each component becomes a sub-group whose tokens are its base
+   * properties plus a `$extensions['design.md']` block carrying the
+   * `interactive` flag and per-state overrides.
+   */
+  private mapComponents(state: DesignSystemState): DtcgGroup | null {
+    if (state.components.size === 0) return null;
+    const group: DtcgGroup = {};
+    for (const [name, comp] of state.components) {
+      group[name] = this.componentToGroup(comp);
+    }
+    return group;
+  }
+
+  private componentToGroup(comp: ComponentDef): DtcgGroup {
+    const sub: DtcgGroup = {};
+    for (const [propName, value] of comp.properties) {
+      const token = this.componentValueToToken(value);
+      if (token) sub[propName] = token;
+    }
+    const extension = this.buildStatesExtension(comp);
+    if (extension) {
+      sub.$extensions = { [DESIGN_MD_EXTENSION_KEY]: extension };
+    }
+    return sub;
+  }
+
+  private buildStatesExtension(comp: ComponentDef): DesignMdStatesExtension | null {
+    if (comp.states.size === 0 && !comp.interactive) return null;
+    const states: Record<string, Record<string, string | number>> = {};
+    for (const [stateName, overrides] of comp.states) {
+      const flat: Record<string, string | number> = {};
+      for (const [prop, value] of overrides) {
+        flat[prop] = this.flattenForExtension(value);
+      }
+      states[stateName] = flat;
+    }
+    const ext: DesignMdStatesExtension = { states };
+    if (comp.interactive !== undefined) ext.interactive = comp.interactive;
+    return ext;
+  }
+
+  private flattenForExtension(value: ResolvedValue): string | number {
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number') return value;
+    if (typeof value === 'object' && value !== null && 'type' in value) {
+      if (value.type === 'color') return value.hex;
+      if (value.type === 'dimension') return `${value.value}${value.unit}`;
+    }
+    return String(value);
+  }
+
+  private componentValueToToken(value: ResolvedValue): DtcgToken | null {
+    if (typeof value === 'object' && value !== null && 'type' in value) {
+      if (value.type === 'color') {
+        return { $type: 'color', $value: this.colorToValue(value as ResolvedColor) };
+      }
+      if (value.type === 'dimension') {
+        return { $type: 'dimension', $value: this.dimToValue(value as ResolvedDimension) };
+      }
+      if (value.type === 'typography') {
+        return { $type: 'typography', $value: this.typographyToValue(value as ResolvedTypography) };
+      }
+    }
+    if (typeof value === 'string' || typeof value === 'number') {
+      return { $value: value };
+    }
+    return null;
   }
 
   private mapColors(state: DesignSystemState): DtcgGroup | null {

--- a/packages/cli/src/linter/dtcg/spec.ts
+++ b/packages/cli/src/linter/dtcg/spec.ts
@@ -42,17 +42,25 @@ export interface DtcgToken {
   $type?: string;
   $value: DtcgColorValue | DtcgDimensionValue | DtcgTypographyValue | string | number;
   $description?: string;
+  $extensions?: Record<string, unknown>;
 }
 
 export interface DtcgGroup {
   $type?: string;
   $description?: string;
-  [key: string]: DtcgToken | DtcgGroup | string | undefined;
+  $extensions?: Record<string, unknown>;
+  [key: string]: DtcgToken | DtcgGroup | string | Record<string, unknown> | undefined;
 }
 
 /** The complete tokens.json output file. */
 export interface DtcgTokenFile extends DtcgGroup {
   $schema?: string;
+}
+
+/** Per-state overrides surfaced under `$extensions['design.md'].states`. */
+export interface DesignMdStatesExtension {
+  interactive?: boolean;
+  states: Record<string, Record<string, string | number>>;
 }
 
 // ── Result ─────────────────────────────────────────────────────────

--- a/packages/cli/src/linter/fixture.test.ts
+++ b/packages/cli/src/linter/fixture.test.ts
@@ -18,6 +18,30 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 describe('Fixture Test', () => {
+  it('processes STATES.md with nested component states', () => {
+    const path = join(import.meta.dir, 'fixtures', 'STATES.md');
+    const content = readFileSync(path, 'utf-8');
+
+    const result = lint(content);
+
+    const btn = result.designSystem.components.get('button-primary');
+    expect(btn).toBeDefined();
+    expect(btn?.interactive).toBe(true);
+    expect(btn?.states.size).toBe(4);
+
+    // base ⊕ hover override
+    const hover = btn?.resolvedStates.get('hover');
+    expect(hover).toBeDefined();
+    const hoverBg = hover?.get('backgroundColor');
+    expect(typeof hoverBg === 'object' && hoverBg !== null && 'hex' in hoverBg && hoverBg.hex).toBe('#3d3f42');
+    // base padding survives in merged hover state
+    expect(hover?.has('padding')).toBe(true);
+
+    // No errors expected — all states defined, focus-visible present, etc.
+    const errors = result.findings.filter(f => f.severity === 'error');
+    expect(errors).toEqual([]);
+  });
+
   it('processes DESIGN-test.md', () => {
     // Use import.meta.dir to get the current directory in Bun ESM
     const path = join(import.meta.dir, 'fixtures', 'DESIGN-test.md');

--- a/packages/cli/src/linter/fixtures/STATES.md
+++ b/packages/cli/src/linter/fixtures/STATES.md
@@ -1,0 +1,58 @@
+---
+name: States Demo
+colors:
+  primary: "#1A1C1E"
+  on-primary: "#FFFFFF"
+  primary-container: "#3D3F42"
+  surface: "#F7F5F2"
+  on-surface: "#1A1C1E"
+  surface-variant: "#E0E0E0"
+  on-surface-variant: "#5A5A5A"
+  focus-ring: "#0066CC"
+typography:
+  body-md:
+    fontFamily: Inter
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 24px
+rounded:
+  md: 8px
+spacing:
+  md: 16px
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.md}"
+    interactive: true
+    states:
+      hover:
+        backgroundColor: "{colors.primary-container}"
+      focus-visible:
+        outline: "2px solid {colors.focus-ring}"
+      active:
+        opacity: 0.9
+      disabled:
+        backgroundColor: "{colors.surface-variant}"
+        textColor: "{colors.on-surface-variant}"
+        cursor: "not-allowed"
+---
+
+## Overview
+
+A minimal example with a single interactive button using nested states.
+
+## Colors
+
+The palette is grayscale with a single blue focus ring.
+
+## Typography
+
+Inter for body copy.
+
+## Components
+
+The button-primary defines all four canonical interactive states. Focus-visible
+gets a dedicated focus ring color, separate from hover.

--- a/packages/cli/src/linter/index.ts
+++ b/packages/cli/src/linter/index.ts
@@ -43,6 +43,12 @@ export {
   tokenSummary,
   missingSections,
   missingTypography,
+  unchangedState,
+  missingFocusVisible,
+  outlineNoneWithoutReplacement,
+  hoverOnlyAffordance,
+  disabledOpacityOnly,
+  unknownState,
 } from './linter/rules/index.js';
 export { contrastRatio } from './model/handler.js';
 export { TailwindEmitterHandler } from './tailwind/handler.js';

--- a/packages/cli/src/linter/linter/rules/broken-ref.ts
+++ b/packages/cli/src/linter/linter/rules/broken-ref.ts
@@ -18,11 +18,14 @@ import type { RuleDescriptor, RuleFinding } from './types.js';
 
 /**
  * Broken/circular references and unknown component sub-tokens.
+ * Recurses into per-state overrides so a broken ref in `states.hover` is
+ * caught the same as one in the base.
  */
 export function brokenRef(state: DesignSystemState): RuleFinding[] {
   const findings: RuleFinding[] = [];
+  const known = new Set<string>(VALID_COMPONENT_SUB_TOKENS);
   for (const [compName, comp] of state.components) {
-    // Unresolved references
+    // Unresolved references (collected during model build, span base + states)
     for (const ref of comp.unresolvedRefs) {
       findings.push({
         path: `components.${compName}`,
@@ -30,14 +33,27 @@ export function brokenRef(state: DesignSystemState): RuleFinding[] {
       });
     }
 
-    // Unknown component sub-tokens (lower severity override)
+    // Unknown component sub-tokens — base
     for (const [propName] of comp.properties) {
-      if (!(VALID_COMPONENT_SUB_TOKENS as readonly string[]).includes(propName)) {
+      if (!known.has(propName)) {
         findings.push({
           severity: 'warning',
           path: `components.${compName}.${propName}`,
           message: `'${propName}' is not a recognized component sub-token. Valid sub-tokens: ${VALID_COMPONENT_SUB_TOKENS.join(', ')}.`,
         });
+      }
+    }
+
+    // Unknown component sub-tokens — per-state overrides
+    for (const [stateName, overrides] of comp.states) {
+      for (const [propName] of overrides) {
+        if (!known.has(propName)) {
+          findings.push({
+            severity: 'warning',
+            path: `components.${compName}.states.${stateName}.${propName}`,
+            message: `'${propName}' is not a recognized component sub-token. Valid sub-tokens: ${VALID_COMPONENT_SUB_TOKENS.join(', ')}.`,
+          });
+        }
       }
     }
   }

--- a/packages/cli/src/linter/linter/rules/contrast-ratio.ts
+++ b/packages/cli/src/linter/linter/rules/contrast-ratio.ts
@@ -20,28 +20,43 @@ const WCAG_AA_MINIMUM = 4.5;
 
 /**
  * WCAG contrast ratio — warns when component backgroundColor/textColor pairs
- * fall below the AA minimum of 4.5:1.
+ * fall below the AA minimum of 4.5:1, including for each per-state override.
+ * A button whose `disabled` state drops to 2.5:1 will warn.
  */
 export function contrastCheck(state: DesignSystemState): RuleFinding[] {
   const findings: RuleFinding[] = [];
   for (const [compName, comp] of state.components) {
-    const bgValue = comp.properties.get('backgroundColor');
-    const textValue = comp.properties.get('textColor');
-    if (!bgValue || !textValue) continue;
-
-    const bgColor = resolveToColor(bgValue);
-    const textColor = resolveToColor(textValue);
-    if (!bgColor || !textColor) continue;
-
-    const ratio = contrastRatio(bgColor, textColor);
-    if (ratio < WCAG_AA_MINIMUM) {
-      findings.push({
-        path: `components.${compName}`,
-        message: `textColor (${textColor.hex}) on backgroundColor (${bgColor.hex}) has contrast ratio ${ratio.toFixed(2)}:1, below WCAG AA minimum of ${WCAG_AA_MINIMUM}:1.`,
-      });
+    checkPair(compName, null, comp.properties, findings);
+    for (const [stateName, props] of comp.resolvedStates) {
+      checkPair(compName, stateName, props, findings);
     }
   }
   return findings;
+}
+
+function checkPair(
+  compName: string,
+  stateName: string | null,
+  props: Map<string, ResolvedValue>,
+  findings: RuleFinding[],
+): void {
+  const bgValue = props.get('backgroundColor');
+  const textValue = props.get('textColor');
+  if (!bgValue || !textValue) return;
+
+  const bgColor = resolveToColor(bgValue);
+  const textColor = resolveToColor(textValue);
+  if (!bgColor || !textColor) return;
+
+  const ratio = contrastRatio(bgColor, textColor);
+  if (ratio >= WCAG_AA_MINIMUM) return;
+
+  const path = stateName ? `components.${compName}.states.${stateName}` : `components.${compName}`;
+  const where = stateName ? ` (${stateName} state)` : '';
+  findings.push({
+    path,
+    message: `textColor (${textColor.hex}) on backgroundColor (${bgColor.hex})${where} has contrast ratio ${ratio.toFixed(2)}:1, below WCAG AA minimum of ${WCAG_AA_MINIMUM}:1.`,
+  });
 }
 
 function resolveToColor(value: ResolvedValue): ResolvedColor | null {

--- a/packages/cli/src/linter/linter/rules/disabled-opacity-only.test.ts
+++ b/packages/cli/src/linter/linter/rules/disabled-opacity-only.test.ts
@@ -1,0 +1,90 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { disabledOpacityOnly } from './disabled-opacity-only.js';
+import { buildState } from './test-helpers.js';
+
+describe('disabled-opacity-only', () => {
+  it('warns when disabled changes only opacity', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: { disabled: { opacity: 0.5 } },
+        },
+      },
+    });
+    const findings = disabledOpacityOnly(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('components.btn.states.disabled');
+  });
+
+  it('warns when only cursor is set without contrast change', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: { disabled: { opacity: 0.5, cursor: 'not-allowed' } },
+        },
+      },
+    });
+    const findings = disabledOpacityOnly(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain('reduced contrast');
+  });
+
+  it('passes when both cursor and contrast change accompany opacity', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', muted: '#888888' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: {
+            disabled: {
+              opacity: 0.5,
+              cursor: 'not-allowed',
+              backgroundColor: '{colors.muted}',
+            },
+          },
+        },
+      },
+    });
+    expect(disabledOpacityOnly(state)).toEqual([]);
+  });
+
+  it('passes when disabled does not use opacity at all', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', muted: '#888888' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: {
+            disabled: {
+              cursor: 'not-allowed',
+              backgroundColor: '{colors.muted}',
+            },
+          },
+        },
+      },
+    });
+    expect(disabledOpacityOnly(state)).toEqual([]);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/disabled-opacity-only.ts
+++ b/packages/cli/src/linter/linter/rules/disabled-opacity-only.ts
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState, ResolvedValue } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+const CONTRAST_PROPS = ['backgroundColor', 'textColor', 'border'];
+
+/**
+ * `disabled-opacity-only` — flags a `disabled` state that changes opacity
+ * but does not also reduce contrast (backgroundColor/textColor/border) AND
+ * set `cursor: not-allowed`. Opacity alone fails for users who can't see the
+ * cursor change and offers a poor signal to assistive tech.
+ */
+export function disabledOpacityOnly(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  for (const [compName, comp] of state.components) {
+    const disabled = comp.states.get('disabled');
+    if (!disabled) continue;
+    if (!disabled.has('opacity')) continue;
+
+    const cursorValue = disabled.get('cursor');
+    const hasCursor = isNotAllowedCursor(cursorValue);
+    const hasContrastChange = CONTRAST_PROPS.some(p => disabled.has(p));
+
+    if (hasCursor && hasContrastChange) continue;
+
+    const missing: string[] = [];
+    if (!hasContrastChange) missing.push('reduced contrast (backgroundColor/textColor/border)');
+    if (!hasCursor) missing.push("`cursor: not-allowed`");
+
+    findings.push({
+      path: `components.${compName}.states.disabled`,
+      message:
+        `'disabled' uses opacity-only signaling. Add ${missing.join(' and ')} — ` +
+        `opacity alone fails for users who can't see a cursor change.`,
+    });
+  }
+  return findings;
+}
+
+function isNotAllowedCursor(value: ResolvedValue | undefined): boolean {
+  if (value === undefined) return false;
+  if (typeof value !== 'string') return false;
+  return value.trim().toLowerCase() === 'not-allowed';
+}
+
+export const disabledOpacityOnlyRule: RuleDescriptor = {
+  name: 'disabled-opacity-only',
+  severity: 'warning',
+  description: 'disabled state changes opacity without reducing contrast or setting cursor.',
+  run: disabledOpacityOnly,
+};

--- a/packages/cli/src/linter/linter/rules/hover-only-affordance.test.ts
+++ b/packages/cli/src/linter/linter/rules/hover-only-affordance.test.ts
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { hoverOnlyAffordance } from './hover-only-affordance.js';
+import { buildState } from './test-helpers.js';
+
+describe('hover-only-affordance', () => {
+  it('warns when an interactive component matches a non-interactive sibling at rest', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', accent: '#FF0000' },
+      components: {
+        'card-static': {
+          backgroundColor: '{colors.primary}',
+        },
+        'card-button': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: { hover: { backgroundColor: '{colors.accent}' } },
+        },
+      },
+    });
+    const findings = hoverOnlyAffordance(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('components.card-button');
+  });
+
+  it('passes when rest state differs from sibling', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', accent: '#FF0000', surface: '#FFFFFF' },
+      components: {
+        'card-static': {
+          backgroundColor: '{colors.surface}',
+        },
+        'card-button': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: { hover: { backgroundColor: '{colors.accent}' } },
+        },
+      },
+    });
+    expect(hoverOnlyAffordance(state)).toEqual([]);
+  });
+
+  it('passes when there are no non-interactive siblings', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', accent: '#FF0000' },
+      components: {
+        'card-button': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: { hover: { backgroundColor: '{colors.accent}' } },
+        },
+      },
+    });
+    expect(hoverOnlyAffordance(state)).toEqual([]);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/hover-only-affordance.ts
+++ b/packages/cli/src/linter/linter/rules/hover-only-affordance.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { ComponentDef, DesignSystemState, ResolvedValue } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+const AFFORDANCE_PROPS = ['backgroundColor', 'border', 'textColor'] as const;
+
+/**
+ * `hover-only-affordance` — flags an interactive component whose rest state
+ * is visually identical to a non-interactive sibling along the affordance
+ * properties (backgroundColor / border / textColor) and whose only signal of
+ * interactivity is the hover state. Touch users never see hover, so the rest
+ * state must already communicate that the element is interactive.
+ */
+export function hoverOnlyAffordance(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+
+  const interactiveWithHover: Array<{ name: string; comp: ComponentDef }> = [];
+  const nonInteractive: Array<{ name: string; comp: ComponentDef }> = [];
+
+  for (const [name, comp] of state.components) {
+    if (comp.interactive && comp.states.has('hover')) {
+      interactiveWithHover.push({ name, comp });
+    } else if (!comp.interactive) {
+      nonInteractive.push({ name, comp });
+    }
+  }
+
+  if (nonInteractive.length === 0) return findings;
+
+  for (const { name, comp } of interactiveWithHover) {
+    const restAffordance = pickAffordance(comp);
+    if (restAffordance === null) continue;
+
+    for (const sibling of nonInteractive) {
+      const siblingAffordance = pickAffordance(sibling.comp);
+      if (siblingAffordance === null) continue;
+      if (sameAffordance(restAffordance, siblingAffordance)) {
+        findings.push({
+          path: `components.${name}`,
+          message:
+            `Rest state matches non-interactive sibling '${sibling.name}' on backgroundColor/border/textColor. ` +
+            `Touch users see no affordance — the rest state must communicate interactivity, not just hover.`,
+        });
+        break;
+      }
+    }
+  }
+
+  return findings;
+}
+
+function pickAffordance(comp: ComponentDef): Record<string, string> | null {
+  const out: Record<string, string> = {};
+  let any = false;
+  for (const prop of AFFORDANCE_PROPS) {
+    const value = comp.properties.get(prop);
+    if (value === undefined) continue;
+    out[prop] = stringifyValue(value);
+    any = true;
+  }
+  return any ? out : null;
+}
+
+function sameAffordance(a: Record<string, string>, b: Record<string, string>): boolean {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const k of keys) {
+    if (a[k] !== b[k]) return false;
+  }
+  return true;
+}
+
+function stringifyValue(value: ResolvedValue): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object' && value !== null && 'type' in value) {
+    if (value.type === 'color') return value.hex;
+    if (value.type === 'dimension') return `${value.value}${value.unit}`;
+    if (value.type === 'typography') return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+export const hoverOnlyAffordanceRule: RuleDescriptor = {
+  name: 'hover-only-affordance',
+  severity: 'warning',
+  description: 'Interactive component is visually indistinguishable from a sibling at rest.',
+  run: hoverOnlyAffordance,
+};

--- a/packages/cli/src/linter/linter/rules/index.ts
+++ b/packages/cli/src/linter/linter/rules/index.ts
@@ -23,6 +23,12 @@ import { tokenSummaryRule } from './token-summary.js';
 import { missingSectionsRule } from './missing-sections.js';
 import { sectionOrderRule } from './section-order.js';
 import { missingTypographyRule } from './missing-typography.js';
+import { unchangedStateRule } from './unchanged-state.js';
+import { missingFocusVisibleRule } from './missing-focus-visible.js';
+import { outlineNoneWithoutReplacementRule } from './outline-none-without-replacement.js';
+import { hoverOnlyAffordanceRule } from './hover-only-affordance.js';
+import { disabledOpacityOnlyRule } from './disabled-opacity-only.js';
+import { unknownStateRule } from './unknown-state.js';
 
 /** The default set of lint rule descriptors, in order. */
 export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
@@ -34,6 +40,12 @@ export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
   missingSectionsRule,
   missingTypographyRule,
   sectionOrderRule,
+  unchangedStateRule,
+  missingFocusVisibleRule,
+  outlineNoneWithoutReplacementRule,
+  hoverOnlyAffordanceRule,
+  disabledOpacityOnlyRule,
+  unknownStateRule,
 ];
 
 /** Converts a RuleDescriptor into a LintRule by injecting severity into findings. */
@@ -58,4 +70,10 @@ export { tokenSummary } from './token-summary.js';
 export { missingSections } from './missing-sections.js';
 export { missingTypography } from './missing-typography.js';
 export { sectionOrder } from './section-order.js';
+export { unchangedState } from './unchanged-state.js';
+export { missingFocusVisible } from './missing-focus-visible.js';
+export { outlineNoneWithoutReplacement } from './outline-none-without-replacement.js';
+export { hoverOnlyAffordance } from './hover-only-affordance.js';
+export { disabledOpacityOnly } from './disabled-opacity-only.js';
+export { unknownState } from './unknown-state.js';
 export type { LintRule } from './types.js';

--- a/packages/cli/src/linter/linter/rules/missing-focus-visible.test.ts
+++ b/packages/cli/src/linter/linter/rules/missing-focus-visible.test.ts
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { missingFocusVisible } from './missing-focus-visible.js';
+import { buildState } from './test-helpers.js';
+
+describe('missing-focus-visible', () => {
+  it('errors when an interactive component omits focus-visible', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', secondary: '#FFFFFF' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: { hover: { backgroundColor: '{colors.secondary}' } },
+        },
+      },
+    });
+    const findings = missingFocusVisible(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('components.btn.states.focus-visible');
+    expect(findings[0]!.message).toContain('focus-visible');
+  });
+
+  it('passes when an interactive component declares focus-visible', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', secondary: '#FFFFFF' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: {
+            'focus-visible': { outline: '2px solid {colors.secondary}' },
+          },
+        },
+      },
+    });
+    expect(missingFocusVisible(state)).toEqual([]);
+  });
+
+  it('ignores non-interactive components', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E' },
+      components: {
+        'card': { backgroundColor: '{colors.primary}' },
+      },
+    });
+    expect(missingFocusVisible(state)).toEqual([]);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/missing-focus-visible.ts
+++ b/packages/cli/src/linter/linter/rules/missing-focus-visible.ts
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import { INTERACTIVE_REQUIRED_STATES } from '../../spec-config.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * `missing-focus-visible` — every `interactive: true` component MUST declare
+ * each state listed in INTERACTIVE_REQUIRED_STATES (today: `focus-visible`).
+ *
+ * Focus-visible is non-negotiable: keyboard users have no other way to know
+ * which element will receive their next keystroke.
+ */
+export function missingFocusVisible(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  for (const [compName, comp] of state.components) {
+    if (!comp.interactive) continue;
+    for (const required of INTERACTIVE_REQUIRED_STATES) {
+      if (!comp.states.has(required)) {
+        findings.push({
+          path: `components.${compName}.states.${required}`,
+          message: `Interactive component '${compName}' is missing required state '${required}'.`,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+export const missingFocusVisibleRule: RuleDescriptor = {
+  name: 'missing-focus-visible',
+  severity: 'error',
+  description: 'Every interactive component must declare a focus-visible state.',
+  run: missingFocusVisible,
+};

--- a/packages/cli/src/linter/linter/rules/orphaned-tokens.ts
+++ b/packages/cli/src/linter/linter/rules/orphaned-tokens.ts
@@ -17,20 +17,26 @@ import type { RuleDescriptor, RuleFinding } from './types.js';
 
 /**
  * Orphaned tokens — tokens defined but never referenced by any component.
+ * References inside per-state overrides (`states.hover`, etc.) count.
  */
 export function orphanedTokens(state: DesignSystemState): RuleFinding[] {
   if (state.components.size === 0) return [];
 
   const referencedPaths = new Set<string>();
-  for (const [, comp] of state.components) {
-    for (const [, value] of comp.properties) {
-      if (typeof value === 'object' && value !== null && 'type' in value) {
-        for (const [key, symValue] of state.symbolTable) {
-          if (symValue === value) {
-            referencedPaths.add(key);
-          }
+  const collect = (value: unknown) => {
+    if (typeof value === 'object' && value !== null && 'type' in value) {
+      for (const [key, symValue] of state.symbolTable) {
+        if (symValue === value) {
+          referencedPaths.add(key);
         }
       }
+    }
+  };
+
+  for (const [, comp] of state.components) {
+    for (const [, value] of comp.properties) collect(value);
+    for (const [, overrides] of comp.states) {
+      for (const [, value] of overrides) collect(value);
     }
   }
 

--- a/packages/cli/src/linter/linter/rules/outline-none-without-replacement.test.ts
+++ b/packages/cli/src/linter/linter/rules/outline-none-without-replacement.test.ts
@@ -1,0 +1,82 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { outlineNoneWithoutReplacement } from './outline-none-without-replacement.js';
+import { buildState } from './test-helpers.js';
+
+describe('outline-none-without-replacement', () => {
+  it('errors when focus-visible sets outline:none with no replacement', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: { 'focus-visible': { outline: 'none' } },
+        },
+      },
+    });
+    const findings = outlineNoneWithoutReplacement(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('components.btn.states.focus-visible.outline');
+  });
+
+  it('passes when boxShadow replaces the outline', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: {
+            'focus-visible': {
+              outline: 'none',
+              boxShadow: '0 0 0 2px #fff',
+            },
+          },
+        },
+      },
+    });
+    expect(outlineNoneWithoutReplacement(state)).toEqual([]);
+  });
+
+  it('passes when outline is non-zero', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: { 'focus-visible': { outline: '2px solid #fff' } },
+        },
+      },
+    });
+    expect(outlineNoneWithoutReplacement(state)).toEqual([]);
+  });
+
+  it('treats outline: 0 as outline:none', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: { 'focus-visible': { outline: '0' } },
+        },
+      },
+    });
+    expect(outlineNoneWithoutReplacement(state).length).toBe(1);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/outline-none-without-replacement.ts
+++ b/packages/cli/src/linter/linter/rules/outline-none-without-replacement.ts
@@ -1,0 +1,68 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState, ResolvedValue } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * `outline-none-without-replacement` — flags a focus-visible state that
+ * suppresses the native outline without supplying a replacement focus signal
+ * (boxShadow, border, or non-zero outline-offset ring).
+ */
+export function outlineNoneWithoutReplacement(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  for (const [compName, comp] of state.components) {
+    const focus = comp.states.get('focus-visible');
+    if (!focus) continue;
+
+    const outline = focus.get('outline');
+    if (!isNoneOutline(outline)) continue;
+
+    const hasReplacement =
+      focus.has('boxShadow') ||
+      focus.has('border') ||
+      focus.has('outline-offset');
+    if (hasReplacement) continue;
+
+    findings.push({
+      path: `components.${compName}.states.focus-visible.outline`,
+      message:
+        `focus-visible declares 'outline: none' (or 0) without a replacement signal ` +
+        `(boxShadow, border, or outline-offset). Keyboard users will lose all focus indication.`,
+    });
+  }
+  return findings;
+}
+
+function isNoneOutline(value: ResolvedValue | undefined): boolean {
+  if (value === undefined) return false;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'none' || normalized === '0') return true;
+    // Match "0px solid …", "0 …" — the leading width is the only cue we need.
+    if (/^0(?:\.0+)?(?:px|rem|em)?\b/.test(normalized)) return true;
+    return false;
+  }
+  if (typeof value === 'object' && value !== null && 'type' in value && value.type === 'dimension') {
+    return value.value === 0;
+  }
+  return false;
+}
+
+export const outlineNoneWithoutReplacementRule: RuleDescriptor = {
+  name: 'outline-none-without-replacement',
+  severity: 'error',
+  description: 'focus-visible state declares outline: none without a replacement signal.',
+  run: outlineNoneWithoutReplacement,
+};

--- a/packages/cli/src/linter/linter/rules/types.test.ts
+++ b/packages/cli/src/linter/linter/rules/types.test.ts
@@ -40,7 +40,7 @@ describe('LintRule type', () => {
   });
 
   it('has all rules in DEFAULT_RULE_DESCRIPTORS', () => {
-    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(8);
+    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(14);
     DEFAULT_RULE_DESCRIPTORS.forEach((rule: RuleDescriptor) => {
       expect(rule.name).toBeTruthy();
       expect(rule.severity).toBeTruthy();

--- a/packages/cli/src/linter/linter/rules/unchanged-state.test.ts
+++ b/packages/cli/src/linter/linter/rules/unchanged-state.test.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { unchangedState } from './unchanged-state.js';
+import { buildState } from './test-helpers.js';
+
+describe('unchanged-state', () => {
+  it('flags a state with no overrides', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: { hover: {} },
+        },
+      },
+    });
+    const findings = unchangedState(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('components.btn.states.hover');
+  });
+
+  it('passes when state has at least one override', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', secondary: '#FFFFFF' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: { hover: { backgroundColor: '{colors.secondary}' } },
+        },
+      },
+    });
+    expect(unchangedState(state)).toEqual([]);
+  });
+
+  it('passes when no states are declared', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E' },
+      components: {
+        'btn': { backgroundColor: '{colors.primary}' },
+      },
+    });
+    expect(unchangedState(state)).toEqual([]);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/unchanged-state.ts
+++ b/packages/cli/src/linter/linter/rules/unchanged-state.ts
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * `unchanged-state` — flags a declared state that does not override any
+ * property from the base. A state with zero overrides is, with extremely
+ * high probability, an authoring mistake.
+ */
+export function unchangedState(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  for (const [compName, comp] of state.components) {
+    for (const [stateName, overrides] of comp.states) {
+      if (overrides.size === 0) {
+        findings.push({
+          path: `components.${compName}.states.${stateName}`,
+          message: `State '${stateName}' declares no property overrides — likely an authoring mistake.`,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+export const unchangedStateRule: RuleDescriptor = {
+  name: 'unchanged-state',
+  severity: 'warning',
+  description: 'Flags a declared state that does not override any property from the base.',
+  run: unchangedState,
+};

--- a/packages/cli/src/linter/linter/rules/unknown-state.test.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-state.test.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { unknownState } from './unknown-state.js';
+import { buildState } from './test-helpers.js';
+
+describe('unknown-state', () => {
+  it('warns when a state name is not in the recognized vocabulary', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', accent: '#FFFFFF' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: { 'loading-error': { backgroundColor: '{colors.accent}' } },
+        },
+      },
+    });
+    const findings = unknownState(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('components.btn.states.loading-error');
+  });
+
+  it('passes for canonical states', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', accent: '#FFFFFF' },
+      components: {
+        'btn': {
+          backgroundColor: '{colors.primary}',
+          interactive: true,
+          states: { hover: { backgroundColor: '{colors.accent}' } },
+        },
+      },
+    });
+    expect(unknownState(state)).toEqual([]);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/unknown-state.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-state.ts
@@ -1,0 +1,48 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import { VALID_COMPONENT_STATES } from '../../spec-config.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+const KNOWN_STATES = new Set<string>(VALID_COMPONENT_STATES);
+
+/**
+ * `unknown-state` — warns when a state name is not in COMPONENT_STATES.
+ * The vocabulary is opinionated but not closed; novel states like
+ * `loading-error` are accepted with a warning so authors can see the
+ * canonical names at a glance.
+ */
+export function unknownState(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  for (const [compName, comp] of state.components) {
+    for (const stateName of comp.states.keys()) {
+      if (!KNOWN_STATES.has(stateName)) {
+        findings.push({
+          path: `components.${compName}.states.${stateName}`,
+          message:
+            `'${stateName}' is not a recognized component state. Known states: ${VALID_COMPONENT_STATES.join(', ')}.`,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+export const unknownStateRule: RuleDescriptor = {
+  name: 'unknown-state',
+  severity: 'warning',
+  description: 'Warns when a state name is not in the recognized state vocabulary.',
+  run: unknownState,
+};

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -245,6 +245,64 @@ describe('ModelHandler', () => {
     });
   });
 
+  describe('component states', () => {
+    it('parses interactive flag and produces resolvedStates merged from base', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#1A1C1E', accent: '#FF0000' },
+        components: {
+          'btn': {
+            backgroundColor: '{colors.primary}',
+            padding: '12px',
+            interactive: true,
+            states: {
+              hover: { backgroundColor: '{colors.accent}' },
+            },
+          },
+        },
+      }));
+      const btn = result.designSystem.components.get('btn');
+      expect(btn).toBeDefined();
+      expect(btn?.interactive).toBe(true);
+      expect(btn?.states.size).toBe(1);
+      const hover = btn?.resolvedStates.get('hover');
+      expect(hover).toBeDefined();
+      // Merged: base padding survives, hover backgroundColor overrides base
+      expect(hover?.has('padding')).toBe(true);
+      const bg = hover?.get('backgroundColor');
+      expect(typeof bg === 'object' && bg !== null && 'hex' in bg && bg.hex).toBe('#ff0000');
+    });
+
+    it('records unresolved refs from inside state overrides', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#1A1C1E' },
+        components: {
+          'btn': {
+            backgroundColor: '{colors.primary}',
+            interactive: true,
+            states: {
+              hover: { backgroundColor: '{colors.does-not-exist}' },
+            },
+          },
+        },
+      }));
+      const btn = result.designSystem.components.get('btn');
+      expect(btn?.unresolvedRefs).toContain('{colors.does-not-exist}');
+    });
+
+    it('omits states when none are declared', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#1A1C1E' },
+        components: {
+          'btn': { backgroundColor: '{colors.primary}' },
+        },
+      }));
+      const btn = result.designSystem.components.get('btn');
+      expect(btn?.states.size).toBe(0);
+      expect(btn?.resolvedStates.size).toBe(0);
+      expect(btn?.interactive).toBeUndefined();
+    });
+  });
+
   describe('return signature', () => {
     it('returns findings array', () => {
       const result = handler.execute(makeParsed({

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -173,28 +173,52 @@ export class ModelHandler implements ModelSpec {
       if (input.components) {
         for (const [compName, props] of Object.entries(input.components)) {
           const properties = new Map<string, ResolvedValue>();
+          const states = new Map<string, Map<string, ResolvedValue>>();
+          const resolvedStates = new Map<string, Map<string, ResolvedValue>>();
           const unresolvedRefs: string[] = [];
+          let interactive: boolean | undefined;
 
           for (const [propName, rawValue] of Object.entries(props)) {
-            if (isTokenReference(rawValue)) {
-              const refPath = rawValue.slice(1, -1);
-              const resolved = resolveReference(symbolTable, refPath, new Set());
-              if (resolved !== null) {
-                properties.set(propName, resolved);
-              } else {
-                unresolvedRefs.push(rawValue);
-                properties.set(propName, rawValue);
+            if (propName === 'interactive') {
+              if (typeof rawValue === 'boolean') {
+                interactive = rawValue;
               }
-            } else if (isValidColor(rawValue)) {
-              properties.set(propName, parseColor(rawValue));
-            } else if (isParseableDimension(rawValue)) {
-              properties.set(propName, parseDimension(rawValue));
-            } else {
-              properties.set(propName, rawValue);
+              continue;
             }
+            if (propName === 'states') {
+              if (rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue)) {
+                for (const [stateName, stateProps] of Object.entries(rawValue as Record<string, unknown>)) {
+                  if (!stateProps || typeof stateProps !== 'object' || Array.isArray(stateProps)) continue;
+                  const overrides = new Map<string, ResolvedValue>();
+                  for (const [sPropName, sRawValue] of Object.entries(stateProps as Record<string, unknown>)) {
+                    const resolved = resolveComponentValue(
+                      sRawValue,
+                      symbolTable,
+                      unresolvedRefs,
+                    );
+                    overrides.set(sPropName, resolved);
+                  }
+                  states.set(stateName, overrides);
+                }
+              }
+              continue;
+            }
+            const resolved = resolveComponentValue(rawValue, symbolTable, unresolvedRefs);
+            properties.set(propName, resolved);
           }
 
-          components.set(compName, { properties, unresolvedRefs });
+          // Build resolvedStates: base ⊕ state overrides
+          for (const [stateName, overrides] of states) {
+            const merged = new Map<string, ResolvedValue>(properties);
+            for (const [propName, value] of overrides) {
+              merged.set(propName, value);
+            }
+            resolvedStates.set(stateName, merged);
+          }
+
+          const def: ComponentDef = { properties, states, resolvedStates, unresolvedRefs };
+          if (interactive !== undefined) def.interactive = interactive;
+          components.set(compName, def);
         }
       }
 
@@ -235,6 +259,36 @@ export class ModelHandler implements ModelSpec {
 }
 
 // ── Pure utility functions ─────────────────────────────────────────
+
+/**
+ * Resolve a single component property value (string/number/boolean) into
+ * a ResolvedValue, mutating `unresolvedRefs` for any reference that fails.
+ * Numbers and booleans are returned coerced to string so the existing
+ * downstream consumers (which handle `string` as the catch-all) keep working,
+ * but only when the source value is a primitive non-reference scalar.
+ */
+function resolveComponentValue(
+  rawValue: unknown,
+  symbolTable: Map<string, ResolvedValue>,
+  unresolvedRefs: string[],
+): ResolvedValue {
+  if (typeof rawValue === 'number' || typeof rawValue === 'boolean') {
+    return String(rawValue);
+  }
+  if (typeof rawValue !== 'string') {
+    return String(rawValue);
+  }
+  if (isTokenReference(rawValue)) {
+    const refPath = rawValue.slice(1, -1);
+    const resolved = resolveReference(symbolTable, refPath, new Set());
+    if (resolved !== null) return resolved;
+    unresolvedRefs.push(rawValue);
+    return rawValue;
+  }
+  if (isValidColor(rawValue)) return parseColor(rawValue);
+  if (isParseableDimension(rawValue)) return parseDimension(rawValue);
+  return rawValue;
+}
 
 /**
  * Parse a hex color string into a ResolvedColor with RGB + WCAG luminance.

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -82,7 +82,21 @@ export interface DesignSystemState {
 }
 
 export interface ComponentDef {
+  /** Base property values (rest state). */
   properties: Map<string, ResolvedValue>;
+  /** Whether the component is interactive (drives state requirements). */
+  interactive?: boolean | undefined;
+  /**
+   * State-only overrides. Each entry maps a state name to the properties that
+   * differ from the base.
+   */
+  states: Map<string, Map<string, ResolvedValue>>;
+  /**
+   * Effective property maps per state — `properties` ⊕ each state's overrides.
+   * Computed once during model build so downstream rules and exporters do
+   * not reimplement merging.
+   */
+  resolvedStates: Map<string, Map<string, ResolvedValue>>;
   /** Unresolved references that failed to resolve */
   unresolvedRefs: string[];
 }

--- a/packages/cli/src/linter/parser/handler.ts
+++ b/packages/cli/src/linter/parser/handler.ts
@@ -197,7 +197,7 @@ export class ParserHandler implements ParserSpec {
       typography: raw['typography'] as Record<string, Record<string, string | number>> | undefined,
       rounded: raw['rounded'] as Record<string, string> | undefined,
       spacing: raw['spacing'] as Record<string, string> | undefined,
-      components: raw['components'] as Record<string, Record<string, string>> | undefined,
+      components: raw['components'] as ParsedDesignSystem['components'],
       sourceMap,
       sections,
       documentSections,

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -37,6 +37,18 @@ export interface SourceLocation {
   block: 'frontmatter' | number;
 }
 
+/**
+ * A raw component property value as it appears in YAML.
+ * Most properties are scalars; `states` is a nested map of state-name →
+ * state-property-map (each property a primitive); `interactive` is a boolean.
+ * The recursive shape covers both layers without losing strictness.
+ */
+export type RawComponentValue =
+  | string
+  | number
+  | boolean
+  | { [key: string]: RawComponentValue };
+
 /** Raw, unresolved parsed output — mirrors the YAML schema */
 export interface ParsedDesignSystem {
   name?: string | undefined;
@@ -45,7 +57,7 @@ export interface ParsedDesignSystem {
   typography?: Record<string, Record<string, string | number>> | undefined;
   rounded?: Record<string, string> | undefined;
   spacing?: Record<string, string> | undefined;
-  components?: Record<string, Record<string, string>> | undefined;
+  components?: Record<string, Record<string, RawComponentValue>> | undefined;
   sourceMap: Map<string, SourceLocation>;
   /** Markdown heading names found in the document (e.g., 'Colors', 'Typography') */
   sections?: string[] | undefined;

--- a/packages/cli/src/linter/spec-config.ts
+++ b/packages/cli/src/linter/spec-config.ts
@@ -38,6 +38,26 @@ const PropertyDefSchema = z.object({
   description: z.string().optional(),
 });
 
+const ComponentStateDefSchema = z.object({
+  name: z.string(),
+  interaction: z.enum(['pointer-only', 'keyboard', 'any']),
+  required: z.boolean().optional(),
+  description: z.string().optional(),
+});
+
+/**
+ * Component example values. Each property is a primitive (string/number/boolean)
+ * or a nested map (for `states:` and similar grouped overrides).
+ */
+const ComponentExampleValueSchema: z.ZodType<unknown> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.record(z.string(), ComponentExampleValueSchema),
+  ])
+);
+
 const ConfigSchema = z.object({
   version: z.string(),
   units: z.array(z.string()).min(1),
@@ -47,12 +67,13 @@ const ConfigSchema = z.object({
   })).min(1),
   typography_properties: z.array(PropertyDefSchema).min(1),
   component_sub_tokens: z.array(PropertyDefSchema).min(1),
+  component_states: z.array(ComponentStateDefSchema).min(1),
   color_roles: z.array(z.string()).min(1),
   recommended_tokens: z.record(z.string(), z.array(z.string())),
   examples: z.object({
     colors: z.record(z.string(), z.string()),
     typography: z.record(z.string(), z.record(z.string(), z.union([z.string(), z.number()]))),
-    components: z.record(z.string(), z.record(z.string(), z.string())),
+    components: z.record(z.string(), z.record(z.string(), ComponentExampleValueSchema)),
   }),
 });
 
@@ -108,6 +129,17 @@ export interface ComponentSubTokenDef {
   description?: string | undefined;
 }
 
+export interface ComponentStateDef {
+  /** Canonical state name (e.g., 'hover', 'focus-visible'). */
+  name: string;
+  /** What kind of input triggers the state. */
+  interaction: 'pointer-only' | 'keyboard' | 'any';
+  /** True if every interactive component MUST declare this state. */
+  required?: boolean | undefined;
+  /** Extended description for the spec. */
+  description?: string | undefined;
+}
+
 // ── Constant exports ─────────────────────────────────────────────────
 // These are eagerly initialized from the lazy singleton on first import.
 // The singleton cache ensures the YAML file is read exactly once.
@@ -126,6 +158,14 @@ export const SECTIONS = config.sections;
 export const TYPOGRAPHY_PROPERTIES: readonly TypographyPropertyDef[] = config.typography_properties;
 
 export const COMPONENT_SUB_TOKENS: readonly ComponentSubTokenDef[] = config.component_sub_tokens;
+
+/** Known component states with declared semantics. */
+export const COMPONENT_STATES: readonly ComponentStateDef[] = config.component_states;
+
+/** State names that every interactive component MUST declare. */
+export const INTERACTIVE_REQUIRED_STATES: readonly string[] = config.component_states
+  .filter(s => s.required)
+  .map(s => s.name);
 
 /** Core color roles that every design system should define. */
 export const CORE_COLOR_ROLES = config.color_roles;
@@ -159,6 +199,9 @@ export const VALID_TYPOGRAPHY_PROPS = TYPOGRAPHY_PROPERTIES.map(p => p.name);
 /** Valid component sub-token names (for linter validation). */
 export const VALID_COMPONENT_SUB_TOKENS = COMPONENT_SUB_TOKENS.map(p => p.name);
 
+/** Valid component state names (for linter validation). */
+export const VALID_COMPONENT_STATES = COMPONENT_STATES.map(s => s.name);
+
 // ── Aggregate type ────────────────────────────────────────────────────
 
 /** All config values bundled as a single object for renderer injection. */
@@ -168,6 +211,7 @@ export interface SpecConfig {
   SECTIONS: typeof SECTIONS;
   TYPOGRAPHY_PROPERTIES: typeof TYPOGRAPHY_PROPERTIES;
   COMPONENT_SUB_TOKENS: typeof COMPONENT_SUB_TOKENS;
+  COMPONENT_STATES: typeof COMPONENT_STATES;
   CORE_COLOR_ROLES: typeof CORE_COLOR_ROLES;
   RECOMMENDED_TOKENS: typeof RECOMMENDED_TOKENS;
   EXAMPLES: typeof EXAMPLES;
@@ -180,6 +224,7 @@ export const SPEC_CONFIG: SpecConfig = {
   SECTIONS,
   TYPOGRAPHY_PROPERTIES,
   COMPONENT_SUB_TOKENS,
+  COMPONENT_STATES,
   CORE_COLOR_ROLES,
   RECOMMENDED_TOKENS,
   EXAMPLES,

--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -76,6 +76,39 @@ component_sub_tokens:
     type: Dimension
   - name: width
     type: Dimension
+  - name: opacity
+    type: number
+  - name: outline
+    type: string
+  - name: boxShadow
+    type: string
+  - name: border
+    type: string
+  - name: cursor
+    type: string
+
+# Interactive component states. The vocabulary is opinionated but not closed
+# (unknown states warn rather than error).
+component_states:
+  - name: hover
+    interaction: pointer-only
+    description: "Pointer hover; never the only affordance signal."
+  - name: focus-visible
+    interaction: keyboard
+    required: true
+    description: "Visible focus ring; never `outline: none` without a replacement."
+  - name: active
+    interaction: any
+    description: "Currently being pressed or otherwise actuated."
+  - name: pressed
+    interaction: any
+    description: "Toggle-style components in the on/selected position."
+  - name: disabled
+    interaction: any
+    description: "Both reduced contrast AND `cursor: not-allowed`. Never opacity-only."
+  - name: loading
+    interaction: any
+    description: "Component remains visible; indicates progress."
 
 color_roles:
   - primary
@@ -140,5 +173,15 @@ examples:
       textColor: "{colors.primary-20}"
       rounded: "{rounded.md}"
       padding: 12px
-    button-primary-hover:
-      backgroundColor: "{colors.primary-70}"
+      interactive: true
+      states:
+        hover:
+          backgroundColor: "{colors.primary-70}"
+        focus-visible:
+          outline: "2px solid {colors.primary-40}"
+        active:
+          opacity: 0.9
+        disabled:
+          backgroundColor: "{colors.surface-variant}"
+          textColor: "{colors.on-surface-variant}"
+          cursor: "not-allowed"

--- a/packages/cli/src/linter/spec-gen/renderers.ts
+++ b/packages/cli/src/linter/spec-gen/renderers.ts
@@ -34,11 +34,18 @@ function yamlEntries(entries: Record<string, string>, indent = 2): string[] {
   );
 }
 
-function yamlObject(entries: Record<string, string | number>, indent = 4): string[] {
-  return Object.entries(entries).map(([k, v]) => {
-    const val = typeof v === 'string' && v.startsWith('{') ? `"${v}"` : v;
-    return `${' '.repeat(indent)}${k}: ${val}`;
-  });
+function yamlObject(entries: Record<string, unknown>, indent = 4): string[] {
+  const lines: string[] = [];
+  for (const [k, v] of Object.entries(entries)) {
+    if (v !== null && typeof v === 'object') {
+      lines.push(`${' '.repeat(indent)}${k}:`);
+      lines.push(...yamlObject(v as Record<string, unknown>, indent + 2));
+    } else {
+      const val = typeof v === 'string' && v.startsWith('{') ? `"${v}"` : v;
+      lines.push(`${' '.repeat(indent)}${k}: ${val}`);
+    }
+  }
+  return lines;
 }
 
 // ── Public renderers ────────────────────────────────────────────
@@ -56,7 +63,7 @@ export function frontmatterExample(config: SpecConfig): string {
     ),
     'typography:',
     `  ${typoName}:`,
-    ...yamlObject(typoProps as Record<string, string | number>),
+    ...yamlObject(typoProps as Record<string, unknown>),
     '---',
   ]);
 }
@@ -71,7 +78,7 @@ export function typographyExample(config: SpecConfig): string {
   const lines = ['typography:'];
   for (const [name, props] of Object.entries(config.EXAMPLES.typography)) {
     lines.push(`  ${name}:`);
-    lines.push(...yamlObject(props as Record<string, string | number>));
+    lines.push(...yamlObject(props as Record<string, unknown>));
   }
   return yamlBlock(lines);
 }
@@ -81,7 +88,7 @@ export function componentsExample(config: SpecConfig): string {
   const lines = ['components:'];
   for (const [name, props] of Object.entries(config.EXAMPLES.components)) {
     lines.push(`  ${name}:`);
-    lines.push(...yamlObject(props as Record<string, string | number>));
+    lines.push(...yamlObject(props as Record<string, unknown>));
   }
   return yamlBlock(lines);
 }

--- a/packages/cli/src/linter/spec-gen/spec.mdx
+++ b/packages/cli/src/linter/spec-gen/spec.mdx
@@ -236,7 +236,12 @@ This section provides style guidance for component atoms within the design syste
 
 The components section defines a collection of design tokens used to ensure consistent styling of common components. It's a map\<string, map\<string, string\>\> that maps a component identifier to a group of sub token names and values. The design token values may be literal values, or references to previously defined design tokens.
 
-**Variants**. A component may have a variant for different UI states such as active, hover, pressed, etc. Those variant components may be defined under a different but related key, for example, "button-primary", "button-primary-hover", "button-primary-active". The agent will consider all variants and make the appropriate styling decisions.
+**Variants** (configuration: primary/secondary/danger) and **states**
+(transient response to user input: hover/focus/active/disabled/loading) are
+modeled differently. Variants typically appear as separate component entries
+(e.g., `button-primary`, `button-secondary`). States are nested under a
+component's `states:` block and inherit from the base, overriding only the
+properties that change.
 
 {componentsExample()}
 
@@ -245,6 +250,53 @@ The components section defines a collection of design tokens used to ensure cons
 Each component has a set of properties that are themselves design tokens:
 
 {componentSubTokenList()}
+
+### Interactive States
+
+States express transient responses to user input. They live under a
+component's `states:` block and override only the properties that change from
+the rest state. A component opts in by setting `interactive: true`.
+
+The recognized state vocabulary is opinionated but not closed; novel state
+names produce a warning rather than an error.
+
+#### State hierarchy
+
+Visual weight order, lightest to heaviest: rest &lt; hover &lt; focus-visible
+&lt; active &lt; pressed. Each state communicates a different message — never
+combine them into one undifferentiated lift.
+
+#### Focus-visible discipline
+
+Every interactive component **must** declare a `focus-visible` state. Never
+suppress the native outline (`outline: none`) without supplying a replacement
+signal — `boxShadow`, `border`, or an `outline-offset` ring. Focus rings use
+their own dedicated token, not the hover color.
+
+#### Disabled affordance
+
+A `disabled` state must reduce contrast **and** set `cursor: not-allowed`.
+Opacity-only signaling fails for users who can't see the cursor change and is
+opaque to assistive tech.
+
+#### Hover is desktop-only
+
+Hover state must never be the only signal of interactivity. Touch devices
+skip hover entirely; the rest state must already communicate affordance via
+shape, weight, or color.
+
+#### State vs. variant
+
+A state is a transient response to user input (hover, active). A variant is
+a persistent configuration (primary, secondary, danger). Don't conflate
+them; the explosion `button-primary-hover-disabled` is exactly what the
+nested `states:` block exists to prevent.
+
+#### Loading / busy
+
+Loading is a state, not an absence. The component must remain visible and
+indicate progress — never collapse, hide, or replace it with a spinner that
+shifts surrounding layout.
 
 ## Do's and Don'ts
 

--- a/packages/cli/src/linter/tailwind/handler.test.ts
+++ b/packages/cli/src/linter/tailwind/handler.test.ts
@@ -112,4 +112,47 @@ describe('TailwindEmitterHandler', () => {
       expect(config.theme.extend).toBeDefined();
     });
   });
+
+  describe('components plugin (opt-in)', () => {
+    it('omits the plugin block by default', () => {
+      const state = buildState({
+        colors: { primary: '#1A1C1E' },
+        components: { 'btn': { backgroundColor: '{colors.primary}' } },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      expect(result.data.plugin).toBeUndefined();
+    });
+
+    it('emits a plugin object with state variants when opted in', () => {
+      const state = buildState({
+        colors: { primary: '#1A1C1E', accent: '#FFFFFF' },
+        components: {
+          'btn': {
+            backgroundColor: '{colors.primary}',
+            interactive: true,
+            states: {
+              hover: { backgroundColor: '{colors.accent}' },
+              'focus-visible': { outline: '2px solid {colors.accent}' },
+              disabled: { cursor: 'not-allowed' },
+            },
+          },
+        },
+      });
+      const result = emitter.execute(state, { components: true });
+      if (!result.success) throw new Error('Expected success');
+
+      const plugin = result.data.plugin as Record<string, Record<string, unknown>>;
+      expect(plugin).toBeDefined();
+      const btn = plugin['.btn'];
+      expect(btn).toBeDefined();
+      expect(btn?.['background-color']).toBe('#1a1c1e');
+      const hover = btn?.['&:hover'] as Record<string, unknown>;
+      expect(hover?.['background-color']).toBe('#ffffff');
+      const focus = btn?.['&:focus-visible'] as Record<string, unknown>;
+      expect(focus?.['outline']).toContain('solid');
+      const disabled = btn?.['&:disabled, &[aria-disabled="true"]'] as Record<string, unknown>;
+      expect(disabled?.['cursor']).toBe('not-allowed');
+    });
+  });
 });

--- a/packages/cli/src/linter/tailwind/handler.ts
+++ b/packages/cli/src/linter/tailwind/handler.ts
@@ -12,16 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { TailwindEmitterSpec, TailwindEmitterResult } from './spec.js';
-import type { DesignSystemState, ResolvedDimension } from '../model/spec.js';
+import type {
+  TailwindEmitterSpec,
+  TailwindEmitterResult,
+  TailwindEmitterOptions,
+  TailwindComponentRule,
+} from './spec.js';
+import type { ComponentDef, DesignSystemState, ResolvedDimension, ResolvedValue } from '../model/spec.js';
+
+const STATE_TO_VARIANT: Record<string, string> = {
+  hover: '&:hover',
+  'focus-visible': '&:focus-visible',
+  active: '&:active',
+  pressed: '&[aria-pressed="true"]',
+  disabled: '&:disabled, &[aria-disabled="true"]',
+  loading: '&[aria-busy="true"]',
+};
+
+const PROPERTY_TO_CSS: Record<string, string | string[]> = {
+  backgroundColor: 'background-color',
+  textColor: 'color',
+  rounded: 'border-radius',
+  padding: 'padding',
+  height: 'height',
+  width: 'width',
+  size: ['width', 'height'],
+  outline: 'outline',
+  boxShadow: 'box-shadow',
+  border: 'border',
+  cursor: 'cursor',
+  opacity: 'opacity',
+};
 
 /**
  * Pure function mapping DesignSystemState → Tailwind theme.extend config.
  * No side effects.
+ *
+ * With `options.components: true`, additionally emits a `plugin` object whose
+ * shape is what `tailwindcss/plugin`'s `addComponents()` expects: each
+ * component becomes a `.<name>` class with its base styles plus per-state
+ * nested rules under `&:hover`, `&:focus-visible`, etc.
  */
 export class TailwindEmitterHandler implements TailwindEmitterSpec {
-  execute(state: DesignSystemState): TailwindEmitterResult {
-    return {
+  execute(state: DesignSystemState, options?: TailwindEmitterOptions): TailwindEmitterResult {
+    const result: TailwindEmitterResult = {
       success: true,
       data: {
         theme: {
@@ -35,6 +69,59 @@ export class TailwindEmitterHandler implements TailwindEmitterSpec {
         },
       }
     };
+
+    if (options?.components && state.components.size > 0) {
+      result.data.plugin = this.mapComponents(state);
+    }
+
+    return result;
+  }
+
+  private mapComponents(state: DesignSystemState): Record<string, TailwindComponentRule> {
+    const components: Record<string, TailwindComponentRule> = {};
+    for (const [name, comp] of state.components) {
+      components[`.${name}`] = this.componentRule(comp);
+    }
+    return components;
+  }
+
+  private componentRule(comp: ComponentDef): TailwindComponentRule {
+    const rule: TailwindComponentRule = {};
+    for (const [prop, value] of comp.properties) {
+      this.assignProperty(rule, prop, value);
+    }
+    for (const [stateName, overrides] of comp.states) {
+      const variant = STATE_TO_VARIANT[stateName] ?? `&[data-state="${stateName}"]`;
+      const nested: TailwindComponentRule = {};
+      for (const [prop, value] of overrides) {
+        this.assignProperty(nested, prop, value);
+      }
+      rule[variant] = nested;
+    }
+    return rule;
+  }
+
+  private assignProperty(target: TailwindComponentRule, prop: string, value: ResolvedValue): void {
+    const cssNames = PROPERTY_TO_CSS[prop];
+    const stringValue = this.toCssValue(value);
+    if (cssNames === undefined) {
+      target[prop] = stringValue;
+      return;
+    }
+    if (Array.isArray(cssNames)) {
+      for (const css of cssNames) target[css] = stringValue;
+    } else {
+      target[cssNames] = stringValue;
+    }
+  }
+
+  private toCssValue(value: ResolvedValue): string {
+    if (typeof value === 'string') return value;
+    if (typeof value === 'object' && value !== null && 'type' in value) {
+      if (value.type === 'color') return value.hex;
+      if (value.type === 'dimension') return `${value.value}${value.unit}`;
+    }
+    return String(value);
   }
 
   private mapColors(state: DesignSystemState): Record<string, string> {

--- a/packages/cli/src/linter/tailwind/spec.ts
+++ b/packages/cli/src/linter/tailwind/spec.ts
@@ -27,7 +27,20 @@ export const TailwindThemeExtendSchema = z.object({
 
 export type TailwindThemeExtend = z.infer<typeof TailwindThemeExtendSchema>;
 
+/**
+ * A Tailwind plugin component definition. Maps a class selector (e.g., `.btn-primary`)
+ * to its base styles plus per-state nested rules under `&:hover`, `&:focus-visible`,
+ * `&:active`, `&:disabled`. Shape mirrors what Tailwind's `addComponents()` accepts.
+ */
+export type TailwindComponentRule = {
+  [property: string]: string | TailwindComponentRule;
+};
 
+export const TailwindEmitterOptionsSchema = z.object({
+  /** When true, emit a `plugin` array with component rules including state variants. */
+  components: z.boolean().optional(),
+});
+export type TailwindEmitterOptions = z.infer<typeof TailwindEmitterOptionsSchema>;
 
 export const TailwindEmitterResultSchema = z.discriminatedUnion('success', [
   z.object({
@@ -35,7 +48,8 @@ export const TailwindEmitterResultSchema = z.discriminatedUnion('success', [
     data: z.object({
       theme: z.object({
         extend: TailwindThemeExtendSchema
-      })
+      }),
+      plugin: z.record(z.unknown()).optional(),
     })
   }),
   z.object({
@@ -51,5 +65,5 @@ export type TailwindEmitterResult = z.infer<typeof TailwindEmitterResultSchema>;
 
 // ── INTERFACE ──────────────────────────────────────────────────────
 export interface TailwindEmitterSpec {
-  execute(state: DesignSystemState): TailwindEmitterResult;
+  execute(state: DesignSystemState, options?: TailwindEmitterOptions): TailwindEmitterResult;
 }


### PR DESCRIPTION
Implements the design plan from #3: lifts hover/focus-visible/active/pressed/disabled/loading from a flat `*-hover` sibling convention into a first-class nested `states:` block under each component, with inheritance, validation, and accessibility-aware lint rules.

Closes #3.

## Summary

- **Schema** — components grow `interactive: true` and a `states:` block. `spec-config.yaml` adds `component_states` (vocabulary with declared semantics + a `required` flag for `focus-visible`) and new sub-tokens needed for state overrides (`opacity`, `outline`, `boxShadow`, `border`, `cursor`).
- **Model** — `ComponentDef` gains `interactive`, `states`, and `resolvedStates` (base ⊕ overrides pre-merged so downstream rules and exporters do not reimplement merging). The parser surfaces nested raw values; broken refs in state overrides are collected the same as base refs.
- **New linter rules**
  - `unchanged-state` (warn) — state declares no overrides
  - `missing-focus-visible` (error) — interactive component lacks `focus-visible`
  - `outline-none-without-replacement` (error) — focus-visible suppresses outline without `boxShadow` / `border` / `outline-offset` replacement
  - `hover-only-affordance` (warn) — interactive rest state visually identical to a non-interactive sibling
  - `disabled-opacity-only` (warn) — `disabled` uses opacity without reducing contrast and setting `cursor: not-allowed`
  - `unknown-state` (warn) — state name outside the recognized vocabulary (vocabulary is opinionated but not closed)
- **Updated rules** — `broken-ref`, `contrast-ratio`, `orphaned-tokens` recurse into per-state overrides. A button whose `disabled` state drops below WCAG AA now surfaces.
- **Exporters**
  - Tailwind: opt-in `--components` flag emits a `plugin` object mapping each component to a Tailwind plugin rule with nested `&:hover`, `&:focus-visible`, `&:active`, `&:disabled` blocks (the shape `addComponents()` accepts).
  - DTCG: components project into a `component` group; per-state overrides live under `$extensions['design.md'].states` (DTCG has no native state concept, so this is the canonical extension point).
- **Examples migrated** — `atmospheric-glass`, `paws-and-paths`, and `totality-festival` move every `*-hover` flat sibling into nested `states.hover`, with `focus-visible` and `disabled` added (their absence would otherwise surface real `missing-focus-visible` errors). Derived `design_tokens.json` regenerated.
- **Spec doc** — `docs/spec.md` regenerated with a new "Interactive States" subsection (state hierarchy, focus-visible discipline, disabled affordance, hover-is-desktop-only, state vs variant, loading) and a refreshed components example.
- **Tests** — new unit tests for every new and updated rule (28 added), `STATES.md` fixture, model handler tests for state merge / unresolved-ref-in-state, Tailwind plugin shape under `--components`, DTCG `$extensions.states` shape. 229/229 tests pass.

## Test plan

- [x] `bun test` (229/229 pass)
- [x] `bun packages/cli/src/index.ts lint examples/{atmospheric-glass,paws-and-paths,totality-festival}/DESIGN.md` — 0 errors each
- [x] `bun packages/cli/src/index.ts export examples/atmospheric-glass/DESIGN.md --format tailwind --components` — emits the new `plugin` block with state variants
- [x] `bun packages/cli/src/index.ts export examples/atmospheric-glass/DESIGN.md --format dtcg` — components include `$extensions['design.md'].states`
- [x] `bun run --cwd packages/cli spec:gen` — regenerates `docs/spec.md` cleanly

https://claude.ai/code/session_018VrVVrSx1PAEnrtNwywhjq

---
_Generated by [Claude Code](https://claude.ai/code/session_018VrVVrSx1PAEnrtNwywhjq)_