### PR TITLE
feat(linter): add prose-token-mismatch rule with suppression directives

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -413,3 +413,43 @@ When a DESIGN.md consumer encounters content not defined by this spec:
 | Unknown component property | Accept with warning | `myCustomProp` |
 | Typed component property with malformed value | Reject with error | `opacity: 2` |
 | Duplicate section heading | Error; reject the file | Two `## Colors` headings |
+
+# Linting
+
+The active linting rules are listed in the rules table emitted by `design.md spec --rules`.
+
+### Why `prose-token-mismatch`
+
+A DESIGN.md typically describes its palette in two places: the YAML tokens
+under `colors:`, and the prose under `## Colors` (e.g.
+*"Boston Clay (#B8422E) is the sole driver for interaction"*). When a
+designer recolors a token, the prose can silently fall out of sync. The
+existing `broken-ref` rule validates `{colors.tertiary}`-style references
+but cannot see hex literals embedded in sentences.
+
+`prose-token-mismatch` scans markdown prose for hex literals and verifies
+that each one resolves to a defined token's value. When an inline anchor
+is present — a backticked token key (`` `tertiary` ``, `` `colors.tertiary` ``)
+or a ramp anchor's `humanName` — the rule additionally checks that the hex
+matches *that specific token's* current value, catching renames and
+recolors as well as deletions.
+
+### Suppression Directives
+
+Linter findings can be suppressed inline with HTML comment directives.
+This is useful when prose intentionally cites a historical, external, or
+OS-default color that should not match a token.
+
+```markdown
+<!-- design.md disable-next-line prose-token-mismatch -->
+The legacy logo used Boston Red (#C8102E).
+
+<!-- design.md disable prose-token-mismatch -->
+External examples (#FF6700) appear throughout this section.
+<!-- design.md enable prose-token-mismatch -->
+
+<!-- design.md disable-file prose-token-mismatch -->
+```
+
+Use `*` as the rule name to suppress every rule. Multiple rules may be
+listed, separated by commas (e.g. `disable-next-line rule-a, rule-b`).

--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -89,6 +89,6 @@ describe('spec command', () => {
     const output = JSON.parse(outputStr);
     expect(output.spec).toBeDefined();
     expect(output.rules).toBeDefined();
-    expect(output.rules.length).toBe(15);
+    expect(output.rules.length).toBe(16);
   });
 });

--- a/packages/cli/src/linter/dtcg/handler.test.ts
+++ b/packages/cli/src/linter/dtcg/handler.test.ts
@@ -29,6 +29,7 @@ function emptyState(overrides?: Partial<DesignSystemState>): DesignSystemState {
     colorRamps: new Map(),
     colorPairs: new Map(),
     symbolTable: new Map(),
+    colorIndex: new Map(),
     ...overrides,
   };
 }

--- a/packages/cli/src/linter/lint.ts
+++ b/packages/cli/src/linter/lint.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { ParserHandler } from './parser/handler.js';
-import type { ParsedDesignSystem } from './parser/spec.js';
+import type { ParsedDesignSystem, DocumentSection } from './parser/spec.js';
 import { ModelHandler } from './model/handler.js';
 import { runLinter } from './linter/runner.js';
 import { TailwindEmitterHandler } from './tailwind/handler.js';
@@ -39,7 +39,7 @@ export interface LintReport {
   /** Markdown heading names found in the document. */
   sections: string[];
   /** The partitioned document sections. */
-  documentSections: Array<{ heading: string; content: string }>;
+  documentSections: DocumentSection[];
 }
 
 /**
@@ -114,13 +114,24 @@ export function lint(content: string, options?: LintOptions): LintReport {
  * Extract document sections from raw markdown content by finding H2 headings.
  * Used as a fallback when the parser cannot extract YAML.
  */
-function extractSectionsFromContent(content: string): Array<{ heading: string; content: string }> {
+function extractSectionsFromContent(content: string): DocumentSection[] {
   const lines = content.split('\n');
-  const sections: Array<{ heading: string; content: string }> = [];
+  const sections: DocumentSection[] = [];
   const headingPattern = /^## (.+)$/;
 
   let currentStart = 0;
   let currentHeading = '';
+
+  const pushSection = (heading: string, startIdx: number, endIdx: number) => {
+    sections.push({
+      heading,
+      content: lines.slice(startIdx, endIdx).join('\n'),
+      startLine: startIdx + 1,
+      endLine: endIdx,
+      suppressions: [],
+      codeBlockRanges: [],
+    });
+  };
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -130,10 +141,7 @@ function extractSectionsFromContent(content: string): Array<{ heading: string; c
     if (match) {
       // Push previous section
       if (i > 0) {
-        sections.push({
-          heading: currentHeading,
-          content: lines.slice(currentStart, i).join('\n'),
-        });
+        pushSection(currentHeading, currentStart, i);
       }
       currentHeading = match[1] ?? '';
       currentStart = i;
@@ -141,10 +149,7 @@ function extractSectionsFromContent(content: string): Array<{ heading: string; c
   }
 
   // Push final section
-  sections.push({
-    heading: currentHeading,
-    content: lines.slice(currentStart).join('\n'),
-  });
+  pushSection(currentHeading, currentStart, lines.length);
 
   return sections;
 }

--- a/packages/cli/src/linter/linter/rules/index.ts
+++ b/packages/cli/src/linter/linter/rules/index.ts
@@ -30,6 +30,7 @@ import { tripleSeparationRule } from './triple-separation.js';
 import { pairContrastRule } from './pair-contrast.js';
 import { mixedPairForegroundRule } from './mixed-pair-foreground.js';
 import { rampAnchorNamingRule } from './ramp-anchor-naming.js';
+import { proseTokenMismatchRule } from './prose-token-mismatch.js';
 
 /** The default set of lint rule descriptors, in order. */
 export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
@@ -48,6 +49,7 @@ export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
   animatingLayoutPropertyRule,
   elevationWithoutSemanticsRule,
   tripleSeparationRule,
+  proseTokenMismatchRule,
 ];
 
 /** Converts a RuleDescriptor into a LintRule by injecting severity into findings. */
@@ -79,4 +81,5 @@ export { tripleSeparation } from './triple-separation.js';
 export { pairContrast } from './pair-contrast.js';
 export { mixedPairForeground } from './mixed-pair-foreground.js';
 export { rampAnchorNaming } from './ramp-anchor-naming.js';
+export { proseTokenMismatch } from './prose-token-mismatch.js';
 export type { LintRule } from './types.js';

--- a/packages/cli/src/linter/linter/rules/prose-token-mismatch.test.ts
+++ b/packages/cli/src/linter/linter/rules/prose-token-mismatch.test.ts
@@ -1,0 +1,238 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import {
+  proseTokenMismatch,
+  proseTokenMismatchRule,
+  normalizeHex,
+} from './prose-token-mismatch.js';
+import { buildState } from './test-helpers.js';
+import type {
+  DocumentSection,
+  LineRange,
+  SuppressionDirective,
+} from '../../parser/spec.js';
+
+/**
+ * Build a single-section fixture with a body of prose lines starting at line 1.
+ * The first line is the heading; the remaining lines are body content.
+ */
+function section(
+  heading: string,
+  body: string[],
+  opts: {
+    suppressions?: SuppressionDirective[];
+    codeBlockRanges?: LineRange[];
+    startLine?: number;
+  } = {},
+): DocumentSection {
+  const startLine = opts.startLine ?? 1;
+  const lines = [`## ${heading}`, ...body];
+  return {
+    heading,
+    content: lines.join('\n'),
+    startLine,
+    endLine: startLine + lines.length - 1,
+    suppressions: opts.suppressions ?? [],
+    codeBlockRanges: opts.codeBlockRanges ?? [],
+  };
+}
+
+describe('proseTokenMismatch', () => {
+  it('returns no findings when prose hex matches a token value', () => {
+    const state = buildState({
+      colors: { primary: '#1a1c1e' },
+      documentSections: [
+        section('Colors', ['Primary (#1A1C1E) is the ink.']),
+      ],
+    });
+    expect(proseTokenMismatch(state)).toEqual([]);
+  });
+
+  it('flags an orphan hex that matches no token', () => {
+    const state = buildState({
+      colors: { primary: '#1a1c1e' },
+      documentSections: [
+        section('Colors', ['Accent (#B8422E) for highlights.']),
+      ],
+    });
+    const findings = proseTokenMismatch(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain('#B8422E');
+    expect(findings[0]!.message).toContain('does not match any defined token');
+  });
+
+  it('flags an anchored mismatch when the named token has a different value', () => {
+    const state = buildState({
+      colors: { tertiary: '#040000' },
+      documentSections: [
+        section('Colors', ['The `tertiary` token is #B8422E.']),
+      ],
+    });
+    const findings = proseTokenMismatch(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain('tertiary');
+    expect(findings[0]!.message).toContain('#B8422E');
+    expect(findings[0]!.message).toContain('#040000');
+  });
+
+  it('treats shorthand and full hex as equivalent', () => {
+    const state = buildState({
+      colors: { surface: '#fff' },
+      documentSections: [
+        section('Colors', ['Surface (#FFFFFF) is the canvas.']),
+      ],
+    });
+    expect(proseTokenMismatch(state)).toEqual([]);
+  });
+
+  it('matches alpha hex against alpha token values', () => {
+    const state = buildState({
+      colors: { veil: '#1a1c1e80' },
+      documentSections: [
+        section('Colors', ['Veil (#1A1C1E80) is a dim overlay.']),
+      ],
+    });
+    expect(proseTokenMismatch(state)).toEqual([]);
+  });
+
+  it('flags an alpha mismatch as orphan when no opaque-or-alpha token matches', () => {
+    const state = buildState({
+      colors: { veil: '#1a1c1e' },
+      documentSections: [
+        section('Colors', ['Veil (#1A1C1E80) is a dim overlay.']),
+      ],
+    });
+    const findings = proseTokenMismatch(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain('#1A1C1E80');
+  });
+
+  it('skips hex literals inside fenced code blocks', () => {
+    const state = buildState({
+      colors: { primary: '#1a1c1e' },
+      documentSections: [
+        section(
+          'Colors',
+          [
+            'Primary (#1A1C1E) is the ink.',
+            '```',
+            'background: #B8422E;',
+            '```',
+          ],
+          // The '```' opens at body line 2 (absolute line 3) and closes at
+          // body line 4 (absolute line 5). The literal sits on line 4.
+          { codeBlockRanges: [{ startLine: 3, endLine: 5 }] },
+        ),
+      ],
+    });
+    expect(proseTokenMismatch(state)).toEqual([]);
+  });
+
+  it('respects a disable-next-line suppression', () => {
+    // Heading on absolute line 1, comment on line 2, target prose on line 3.
+    const state = buildState({
+      colors: { primary: '#1a1c1e' },
+      documentSections: [
+        section(
+          'Colors',
+          [
+            '<!-- design.md disable-next-line prose-token-mismatch -->',
+            'Boston Clay (#B8422E) is from a historical brand.',
+          ],
+          { suppressions: [{ rule: 'prose-token-mismatch', fromLine: 3, toLine: 3 }] },
+        ),
+      ],
+    });
+    expect(proseTokenMismatch(state)).toEqual([]);
+  });
+
+  it('respects a region disable/enable suppression', () => {
+    const state = buildState({
+      colors: { primary: '#1a1c1e' },
+      documentSections: [
+        section(
+          'Colors',
+          [
+            '<!-- design.md disable prose-token-mismatch -->',
+            'External color (#B8422E).',
+            'Another (#C84E3A).',
+            '<!-- design.md enable prose-token-mismatch -->',
+          ],
+          { suppressions: [{ rule: 'prose-token-mismatch', fromLine: 2, toLine: 5 }] },
+        ),
+      ],
+    });
+    expect(proseTokenMismatch(state)).toEqual([]);
+  });
+
+  it('respects a wildcard (`*`) suppression', () => {
+    const state = buildState({
+      colors: { primary: '#1a1c1e' },
+      documentSections: [
+        section(
+          'Colors',
+          ['Vintage (#B8422E) is from the archive.'],
+          { suppressions: [{ rule: '*', fromLine: 1, toLine: 99 }] },
+        ),
+      ],
+    });
+    expect(proseTokenMismatch(state)).toEqual([]);
+  });
+
+  it('ignores hex anchors on markdown section links', () => {
+    // The negative lookbehind drops `#section`-style anchors.
+    const state = buildState({
+      colors: { primary: '#1a1c1e' },
+      documentSections: [
+        section('Colors', ['See the [colors](#colors) section.']),
+      ],
+    });
+    expect(proseTokenMismatch(state)).toEqual([]);
+  });
+
+  it('returns no findings when documentSections is missing', () => {
+    const state = buildState({
+      colors: { primary: '#1a1c1e' },
+    });
+    expect(proseTokenMismatch(state)).toEqual([]);
+  });
+
+  it('exposes a valid rule descriptor', () => {
+    expect(proseTokenMismatchRule.name).toBe('prose-token-mismatch');
+    expect(proseTokenMismatchRule.severity).toBe('warning');
+    expect(proseTokenMismatchRule.description).toBeTruthy();
+    expect(proseTokenMismatchRule.run).toBe(proseTokenMismatch);
+  });
+});
+
+describe('normalizeHex', () => {
+  it('lowercases 6-digit hex', () => {
+    expect(normalizeHex('#ABCDEF')).toBe('#abcdef');
+  });
+
+  it('expands 3-digit shorthand', () => {
+    expect(normalizeHex('#FFF')).toBe('#ffffff');
+    expect(normalizeHex('#abc')).toBe('#aabbcc');
+  });
+
+  it('expands 4-digit shorthand', () => {
+    expect(normalizeHex('#FFF0')).toBe('#ffffff00');
+  });
+
+  it('preserves 8-digit alpha hex', () => {
+    expect(normalizeHex('#1A1C1E80')).toBe('#1a1c1e80');
+  });
+});

--- a/packages/cli/src/linter/linter/rules/prose-token-mismatch.ts
+++ b/packages/cli/src/linter/linter/rules/prose-token-mismatch.ts
@@ -1,0 +1,204 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { ColorIndexEntry, DesignSystemState, ResolvedColor, ResolvedValue } from '../../model/spec.js';
+import type { LineRange, SuppressionDirective } from '../../parser/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+const RULE_NAME = 'prose-token-mismatch';
+
+/**
+ * Hex literals embedded in markdown prose.
+ * The negative lookbehind avoids matching the leading `#` of markdown anchors
+ * like `#section`. We accept 3, 4, 6, and 8 digit hex.
+ */
+const HEX_RE = /(?<![A-Za-z0-9])#([0-9A-Fa-f]{8}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{4}|[0-9A-Fa-f]{3})\b/g;
+
+/** Backticked token key like `tertiary`, `colors.tertiary`, `primary.500`. */
+const BACKTICK_KEY_RE = /`([A-Za-z][\w.-]*)`/g;
+
+/** Anchor search window (chars on each side of the hex literal). */
+const ANCHOR_WINDOW = 40;
+
+/**
+ * `prose-token-mismatch` — flags hex literals in markdown prose that drift
+ * from the declared token values.
+ *
+ * Sub-rule A (always on): every hex literal in prose must appear as the
+ *   resolved value of some color token.
+ * Sub-rule B (anchor-driven): when a hex appears next to a token's
+ *   `humanName` or a backticked token key, the hex must equal that
+ *   specific token's resolved value.
+ *
+ * Suppressible per-line, per-region, or per-file via
+ * `<!-- design.md disable-next-line prose-token-mismatch -->` and friends.
+ */
+export function proseTokenMismatch(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  const sections = state.documentSections;
+  if (!sections || sections.length === 0) return findings;
+
+  // Pre-build a humanName → token entry index for anchor matching.
+  const humanNameIndex = new Map<string, ColorIndexEntry>();
+  for (const entries of state.colorIndex.values()) {
+    for (const entry of entries) {
+      if (entry.humanName) {
+        humanNameIndex.set(entry.humanName.toLowerCase(), entry);
+      }
+    }
+  }
+
+  for (const section of sections) {
+    const lines = section.content.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i] ?? '';
+      const absLine = section.startLine + i;
+
+      if (isInCodeBlock(absLine, section.codeBlockRanges)) continue;
+      if (isSuppressed(absLine, RULE_NAME, section.suppressions)) continue;
+
+      HEX_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = HEX_RE.exec(line)) !== null) {
+        const literal = m[0];
+        const hex = normalizeHex(literal);
+        const matches = state.colorIndex.get(hex) ?? [];
+
+        const sectionLabel = section.heading || 'prose';
+        const path = `prose:${sectionLabel}:${absLine}`;
+
+        // Sub-rule B: anchored mismatch — anchor present, but hex disagrees
+        // with the anchored token's value.
+        const anchor = findInlineAnchor(line, m.index, state, humanNameIndex);
+        if (anchor) {
+          const anchored = state.symbolTable.get(`colors.${anchor.tokenKey}`);
+          const anchoredHex = resolvedHex(anchored);
+          if (anchoredHex && anchoredHex !== hex) {
+            findings.push({
+              path,
+              message: `Prose says ${anchor.label} (${literal}), but token '${anchor.tokenKey}' = ${anchoredHex}.`,
+            });
+            continue;
+          }
+        }
+
+        // Sub-rule A: orphan — hex doesn't appear as any token's value.
+        if (matches.length === 0) {
+          findings.push({
+            path,
+            message: `Hex ${literal} in prose does not match any defined token value.`,
+          });
+        }
+      }
+    }
+  }
+  return findings;
+}
+
+interface InlineAnchor {
+  /** The token key to look up in the symbol table (relative to `colors.`). */
+  tokenKey: string;
+  /** Display label used in the finding message. */
+  label: string;
+}
+
+/**
+ * Look within ~ANCHOR_WINDOW chars on either side of the hex for a token
+ * anchor — either a backticked token key (`tertiary`, `colors.tertiary`) or
+ * a humanName from a ramp anchor ("Boston Clay").
+ */
+function findInlineAnchor(
+  line: string,
+  hexStart: number,
+  state: DesignSystemState,
+  humanNameIndex: Map<string, ColorIndexEntry>,
+): InlineAnchor | null {
+  const winStart = Math.max(0, hexStart - ANCHOR_WINDOW);
+  const winEnd = Math.min(line.length, hexStart + ANCHOR_WINDOW);
+  const window = line.slice(winStart, winEnd);
+
+  // Backticked token keys win — they're explicit.
+  BACKTICK_KEY_RE.lastIndex = 0;
+  let bm: RegExpExecArray | null;
+  while ((bm = BACKTICK_KEY_RE.exec(window)) !== null) {
+    const raw = bm[1]!;
+    const tokenKey = raw.startsWith('colors.') ? raw.slice('colors.'.length) : raw;
+    if (state.symbolTable.has(`colors.${tokenKey}`)) {
+      return { tokenKey, label: `\`${raw}\`` };
+    }
+  }
+
+  // humanName match — case-insensitive whole-phrase scan.
+  const lower = window.toLowerCase();
+  for (const [name, entry] of humanNameIndex) {
+    const idx = lower.indexOf(name);
+    if (idx < 0) continue;
+    // Require word-boundary-ish surroundings so "red" doesn't match "redacted".
+    const before = idx > 0 ? lower[idx - 1] : ' ';
+    const afterIdx = idx + name.length;
+    const after = afterIdx < lower.length ? lower[afterIdx] : ' ';
+    if (isWordChar(before) || isWordChar(after)) continue;
+    return { tokenKey: entry.tokenKey, label: entry.humanName ?? entry.tokenKey };
+  }
+
+  return null;
+}
+
+function isWordChar(ch: string | undefined): boolean {
+  if (!ch) return false;
+  return /[\w]/.test(ch);
+}
+
+function resolvedHex(value: ResolvedValue | undefined): string | null {
+  if (!value || typeof value !== 'object' || !('type' in value)) return null;
+  if (value.type !== 'color') return null;
+  return (value as ResolvedColor).hex.toLowerCase();
+}
+
+/**
+ * Normalize a hex literal to lowercase #rrggbb (or #rrggbbaa). Expands
+ * 3- and 4-digit shorthand. Input is assumed to already be a valid hex
+ * literal (the caller matches against `HEX_RE`).
+ */
+export function normalizeHex(raw: string): string {
+  let hex = raw.toLowerCase();
+  if (hex.length === 4) {
+    hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  } else if (hex.length === 5) {
+    hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}${hex[4]}${hex[4]}`;
+  }
+  return hex;
+}
+
+function isInCodeBlock(line: number, ranges: LineRange[]): boolean {
+  for (const r of ranges) {
+    if (line >= r.startLine && line <= r.endLine) return true;
+  }
+  return false;
+}
+
+function isSuppressed(line: number, rule: string, suppressions: SuppressionDirective[]): boolean {
+  for (const s of suppressions) {
+    if (line < s.fromLine || line > s.toLine) continue;
+    if (s.rule === '*' || s.rule === rule) return true;
+  }
+  return false;
+}
+
+export const proseTokenMismatchRule: RuleDescriptor = {
+  name: RULE_NAME,
+  severity: 'warning',
+  description: 'Hex literals in prose drift from token values.',
+  run: proseTokenMismatch,
+};

--- a/packages/cli/src/linter/linter/rules/types.test.ts
+++ b/packages/cli/src/linter/linter/rules/types.test.ts
@@ -29,6 +29,7 @@ describe('LintRule type', () => {
       colorRamps: new Map(),
       colorPairs: new Map(),
       symbolTable: new Map(),
+      colorIndex: new Map(),
     })).toEqual([]);
   });
 
@@ -43,7 +44,7 @@ describe('LintRule type', () => {
   });
 
   it('has all rules in DEFAULT_RULE_DESCRIPTORS', () => {
-    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(15);
+    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(16);
     DEFAULT_RULE_DESCRIPTORS.forEach((rule: RuleDescriptor) => {
       expect(rule.name).toBeTruthy();
       expect(rule.severity).toBeTruthy();

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -25,6 +25,7 @@ import type {
   Finding,
   RampDef,
   PairDef,
+  ColorIndexEntry,
 } from './spec.js';
 
 import { isValidColor, isParseableDimension, isTokenReference, parseDimensionParts } from './spec.js';
@@ -271,6 +272,8 @@ export class ModelHandler implements ModelSpec {
         }
       }
 
+      const colorIndex = buildColorIndex(colors);
+
       return {
         designSystem: {
           name: input.name,
@@ -285,6 +288,8 @@ export class ModelHandler implements ModelSpec {
           colorPairs,
           symbolTable,
           sections: input.sections,
+          documentSections: input.documentSections,
+          colorIndex,
         },
         findings,
       };
@@ -300,6 +305,7 @@ export class ModelHandler implements ModelSpec {
           colorRamps: new Map(),
           colorPairs: new Map(),
           symbolTable: new Map(),
+          colorIndex: new Map(),
         },
         findings: [
           {
@@ -469,6 +475,32 @@ function expandPair(name: string, raw: RawPairDef, ctx: ExpansionContext): void 
 }
 
 const WCAG_AA_BODY = 4.5;
+
+/**
+ * Build the reverse hex → tokens index used by the `prose-token-mismatch` rule.
+ * Keys are normalized hex literals (lowercased, expanded to 6/8 digits).
+ * Each entry records every token whose value resolved to that hex; ramp
+ * anchors propagate their `humanName` so prose anchors can match by display
+ * name (e.g., "Boston Clay") in addition to the systematic key.
+ */
+function buildColorIndex(colors: Map<string, ResolvedColor>): Map<string, ColorIndexEntry[]> {
+  const index = new Map<string, ColorIndexEntry[]>();
+  for (const [tokenKey, color] of colors) {
+    const hex = color.hex.toLowerCase();
+    const entry: ColorIndexEntry = {
+      path: `colors.${tokenKey}`,
+      tokenKey,
+    };
+    if (color.humanName) entry.humanName = color.humanName;
+    const list = index.get(hex);
+    if (list) {
+      list.push(entry);
+    } else {
+      index.set(hex, [entry]);
+    }
+  }
+  return index;
+}
 
 // ── Pure utility functions ─────────────────────────────────────────
 

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { z } from 'zod';
-import type { ParsedDesignSystem } from '../parser/spec.js';
+import type { ParsedDesignSystem, DocumentSection } from '../parser/spec.js';
 import {
   STANDARD_UNITS as _STANDARD_UNITS,
   VALID_TYPOGRAPHY_PROPS as _VALID_TYPOGRAPHY_PROPS,
@@ -156,6 +156,24 @@ export interface DesignSystemState {
   symbolTable: Map<string, ResolvedValue>;
   /** Markdown heading names found in the document */
   sections?: string[] | undefined;
+  /** Partitioned markdown body, used by prose-aware rules. */
+  documentSections?: DocumentSection[] | undefined;
+  /**
+   * Reverse index from a normalized hex (lowercased, expanded to #rrggbb or
+   * #rrggbbaa) to every token whose value resolved to that hex. Used by the
+   * `prose-token-mismatch` rule to verify hex literals in prose against
+   * declared token values.
+   */
+  colorIndex: Map<string, ColorIndexEntry[]>;
+}
+
+export interface ColorIndexEntry {
+  /** The token's symbol-table path, e.g. "colors.primary" or "colors.brand.500". */
+  path: string;
+  /** The token key relative to `colors.`, e.g. "primary" or "brand.500". */
+  tokenKey: string;
+  /** Optional human-readable name (e.g., "Boston Clay") attached to ramp anchors. */
+  humanName?: string;
 }
 
 export interface ComponentDef {

--- a/packages/cli/src/linter/parser/handler.test.ts
+++ b/packages/cli/src/linter/parser/handler.test.ts
@@ -126,6 +126,103 @@ colors:
     });
   });
 
+  // ── Suppression directives + section line numbers ────────────────
+  describe('suppression directives and section ranges', () => {
+    it('captures startLine, endLine, and code-block ranges per section', () => {
+      const input = `---
+colors:
+  primary: "#000000"
+---
+
+## Colors
+
+Body before code.
+
+\`\`\`
+not yaml — should still be a code block range
+\`\`\`
+
+After.
+`;
+      const result = handler.execute({ content: input });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      const sections = result.data.documentSections!;
+      const colorsSection = sections.find(s => s.heading === 'Colors')!;
+      expect(colorsSection.startLine).toBeGreaterThan(0);
+      expect(colorsSection.endLine).toBeGreaterThan(colorsSection.startLine);
+      expect(colorsSection.codeBlockRanges.length).toBe(1);
+      const range = colorsSection.codeBlockRanges[0]!;
+      expect(range.endLine).toBeGreaterThan(range.startLine);
+    });
+
+    it('parses disable-next-line directives', () => {
+      const input = `---
+colors:
+  primary: "#000000"
+---
+
+## Colors
+
+<!-- design.md disable-next-line prose-token-mismatch -->
+Boston Clay (#B8422E) for legacy.
+`;
+      const result = handler.execute({ content: input });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      const colorsSection = result.data.documentSections!.find(s => s.heading === 'Colors')!;
+      expect(colorsSection.suppressions.length).toBe(1);
+      const s = colorsSection.suppressions[0]!;
+      expect(s.rule).toBe('prose-token-mismatch');
+      expect(s.fromLine).toBe(s.toLine);
+    });
+
+    it('parses region disable/enable directives', () => {
+      const input = `---
+colors:
+  primary: "#000000"
+---
+
+## Colors
+
+<!-- design.md disable prose-token-mismatch -->
+External (#B8422E).
+External (#C84E3A).
+<!-- design.md enable prose-token-mismatch -->
+`;
+      const result = handler.execute({ content: input });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      const colorsSection = result.data.documentSections!.find(s => s.heading === 'Colors')!;
+      expect(colorsSection.suppressions.length).toBe(1);
+      const s = colorsSection.suppressions[0]!;
+      expect(s.rule).toBe('prose-token-mismatch');
+      expect(s.toLine).toBeGreaterThan(s.fromLine);
+    });
+
+    it('parses disable-file directives applying to every section', () => {
+      const input = `---
+colors:
+  primary: "#000000"
+---
+<!-- design.md disable-file prose-token-mismatch -->
+
+## Colors
+
+Anything (#deadbe) goes.
+`;
+      const result = handler.execute({ content: input });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      const sections = result.data.documentSections!;
+      // Both the prelude (between frontmatter and ## Colors) and the
+      // Colors section should carry the suppression.
+      for (const section of sections) {
+        expect(section.suppressions.some(s => s.rule === 'prose-token-mismatch')).toBe(true);
+      }
+    });
+  });
+
   // ── Cycle 6: Malformed YAML ───────────────────────────────────────
   describe('malformed YAML', () => {
     it('returns YAML_PARSE_ERROR on invalid YAML syntax', () => {

--- a/packages/cli/src/linter/parser/handler.ts
+++ b/packages/cli/src/linter/parser/handler.ts
@@ -13,7 +13,16 @@
 // limitations under the License.
 
 import YAML from 'yaml';
-import type { ParserSpec, ParserInput, ParserResult, ParsedDesignSystem, SourceLocation } from './spec.js';
+import type {
+  ParserSpec,
+  ParserInput,
+  ParserResult,
+  ParsedDesignSystem,
+  SourceLocation,
+  DocumentSection,
+  SuppressionDirective,
+  LineRange,
+} from './spec.js';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkFrontmatter from 'remark-frontmatter';
@@ -37,6 +46,7 @@ export class ParserHandler implements ParserSpec {
       const blocks: Array<{ yaml: string; block: 'frontmatter' | number; startLine: number }> = [];
       const sections: string[] = [];
       const headingsWithLines: Array<{ text: string; line: number }> = [];
+      const allCodeBlockRanges: LineRange[] = [];
       let blockIndex = 0;
 
       visit(ast, (node) => {
@@ -51,11 +61,14 @@ export class ParserHandler implements ParserSpec {
 
         if (node.type === 'code') {
           const codeNode = node as Code;
+          const startLine = node.position?.start.line ?? 1;
+          const endLine = node.position?.end.line ?? startLine;
+          allCodeBlockRanges.push({ startLine, endLine });
           if (codeNode.lang === 'yaml' || codeNode.lang === 'yml') {
             blocks.push({
               yaml: codeNode.value,
               block: blockIndex,
-              startLine: node.position?.start.line ?? 1
+              startLine
             });
             blockIndex++;
           }
@@ -75,38 +88,51 @@ export class ParserHandler implements ParserSpec {
 
       // Slice content into sections
       const contentLines = content.split('\n');
-      const documentSections: Array<{ heading: string; content: string }> = [];
-      
+      const allSuppressions = parseSuppressionDirectives(contentLines);
+      const documentSections: DocumentSection[] = [];
+
       const firstHeading = headingsWithLines[0];
       if (firstHeading) {
         // Prelude (content before first H2)
         const firstHeadingLine = firstHeading.line;
         if (firstHeadingLine > 1) {
-          documentSections.push({
-            heading: '',
-            content: contentLines.slice(0, firstHeadingLine - 1).join('\n')
-          });
+          documentSections.push(buildSection(
+            '',
+            contentLines,
+            1,
+            firstHeadingLine - 1,
+            allSuppressions,
+            allCodeBlockRanges,
+          ));
         }
 
         for (let i = 0; i < headingsWithLines.length; i++) {
           const current = headingsWithLines[i];
           if (!current) continue;
-          
+
           const next = headingsWithLines[i + 1];
-          const startIdx = current.line - 1;
-          const endIdx = next ? next.line - 1 : contentLines.length;
-          
-          documentSections.push({
-            heading: current.text,
-            content: contentLines.slice(startIdx, endIdx).join('\n')
-          });
+          const startLine = current.line;
+          const endLine = next ? next.line - 1 : contentLines.length;
+
+          documentSections.push(buildSection(
+            current.text,
+            contentLines,
+            startLine,
+            endLine,
+            allSuppressions,
+            allCodeBlockRanges,
+          ));
         }
       } else {
         // No H2 headings found, entire file is one section
-        documentSections.push({
-          heading: '',
-          content: content
-        });
+        documentSections.push(buildSection(
+          '',
+          contentLines,
+          1,
+          contentLines.length,
+          allSuppressions,
+          allCodeBlockRanges,
+        ));
       }
 
       if (blocks.length === 0) {
@@ -137,7 +163,7 @@ export class ParserHandler implements ParserSpec {
    * Merge multiple code blocks into a single ParsedDesignSystem.
    * Detects duplicate top-level sections across blocks.
    */
-  private mergeCodeBlocks(blocks: Array<{ yaml: string; block: 'frontmatter' | number; startLine: number }>, sections: string[], documentSections: Array<{ heading: string; content: string }>): ParserResult {
+  private mergeCodeBlocks(blocks: Array<{ yaml: string; block: 'frontmatter' | number; startLine: number }>, sections: string[], documentSections: DocumentSection[]): ParserResult {
     const merged: Record<string, unknown> = {};
     const sourceMap = new Map<string, SourceLocation>();
     const seenSections = new Map<string, 'frontmatter' | number>();
@@ -189,7 +215,7 @@ export class ParserHandler implements ParserSpec {
   /**
    * Map a raw parsed object to the ParsedDesignSystem interface.
    */
-  private toDesignSystem(raw: Record<string, unknown>, sourceMap: Map<string, SourceLocation>, sections: string[], documentSections: Array<{ heading: string; content: string }>): ParsedDesignSystem {
+  private toDesignSystem(raw: Record<string, unknown>, sourceMap: Map<string, SourceLocation>, sections: string[], documentSections: DocumentSection[]): ParsedDesignSystem {
     return {
       name: typeof raw['name'] === 'string' ? raw['name'] : undefined,
       description: typeof raw['description'] === 'string' ? raw['description'] : undefined,
@@ -211,4 +237,92 @@ export class ParserHandler implements ParserSpec {
       .join('')
       .trim();
   }
+}
+
+/**
+ * Build a section, scoping suppressions and code-block ranges to the
+ * section's [startLine, endLine] window.
+ */
+function buildSection(
+  heading: string,
+  contentLines: string[],
+  startLine: number,
+  endLine: number,
+  allSuppressions: SuppressionDirective[],
+  allCodeBlockRanges: LineRange[],
+): DocumentSection {
+  const suppressions = allSuppressions.filter(s =>
+    !(s.toLine < startLine || s.fromLine > endLine)
+  );
+  const codeBlockRanges = allCodeBlockRanges.filter(r =>
+    !(r.endLine < startLine || r.startLine > endLine)
+  );
+  return {
+    heading,
+    content: contentLines.slice(startLine - 1, endLine).join('\n'),
+    startLine,
+    endLine,
+    suppressions,
+    codeBlockRanges,
+  };
+}
+
+/**
+ * Scan markdown for `<!-- design.md ... -->` HTML comment directives.
+ * Recognized forms:
+ *   <!-- design.md disable-next-line <rule>[,<rule>...] -->
+ *   <!-- design.md disable-file      <rule>[,<rule>...] -->
+ *   <!-- design.md disable           <rule>[,<rule>...] -->
+ *   <!-- design.md enable            <rule>[,<rule>...] -->
+ * Use `*` as the rule name to apply to all rules.
+ */
+const DIRECTIVE_RE = /<!--\s*design\.md\s+(disable-next-line|disable-file|disable|enable)\s+([\w*][\w*,\s-]*?)\s*-->/g;
+
+function parseSuppressionDirectives(contentLines: string[]): SuppressionDirective[] {
+  const directives: SuppressionDirective[] = [];
+  // Per-rule open ranges keyed by rule name (or `*`).
+  const open = new Map<string, number>();
+  const totalLines = contentLines.length;
+
+  for (let i = 0; i < contentLines.length; i++) {
+    const line = contentLines[i];
+    if (!line) continue;
+    DIRECTIVE_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = DIRECTIVE_RE.exec(line)) !== null) {
+      const kind = m[1]!;
+      const rules = m[2]!.split(',').map(r => r.trim()).filter(Boolean);
+      if (rules.length === 0) continue;
+      const lineNum = i + 1; // 1-based
+
+      if (kind === 'disable-next-line') {
+        for (const rule of rules) {
+          directives.push({ rule, fromLine: lineNum + 1, toLine: lineNum + 1 });
+        }
+      } else if (kind === 'disable-file') {
+        for (const rule of rules) {
+          directives.push({ rule, fromLine: 1, toLine: totalLines });
+        }
+      } else if (kind === 'disable') {
+        for (const rule of rules) {
+          if (!open.has(rule)) open.set(rule, lineNum);
+        }
+      } else if (kind === 'enable') {
+        for (const rule of rules) {
+          const from = open.get(rule);
+          if (from !== undefined) {
+            directives.push({ rule, fromLine: from, toLine: lineNum });
+            open.delete(rule);
+          }
+        }
+      }
+    }
+  }
+
+  // Close any still-open ranges at EOF.
+  for (const [rule, from] of open) {
+    directives.push({ rule, fromLine: from, toLine: totalLines });
+  }
+
+  return directives;
 }

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -89,7 +89,47 @@ export interface ParsedDesignSystem {
   /** Markdown heading names found in the document (e.g., 'Colors', 'Typography') */
   sections?: string[] | undefined;
   /** Full content of each section, including heading and body. */
-  documentSections?: Array<{ heading: string; content: string }> | undefined;
+  documentSections?: DocumentSection[] | undefined;
+}
+
+/**
+ * A suppression directive parsed from `<!-- design.md ... -->` HTML comments.
+ * `rule` is the rule name, or `*` for all rules. Line numbers are document-wide
+ * and 1-based; both `fromLine` and `toLine` are inclusive.
+ */
+export interface SuppressionDirective {
+  rule: string;
+  fromLine: number;
+  toLine: number;
+}
+
+/** A line range, 1-based, inclusive on both ends. */
+export interface LineRange {
+  startLine: number;
+  endLine: number;
+}
+
+/** A document section partitioned by H2 heading. */
+export interface DocumentSection {
+  /** The heading text, or '' for the prelude before the first H2. */
+  heading: string;
+  /** The full content of the section, including its heading line. */
+  content: string;
+  /** 1-based line number of the section's first line in the original document. */
+  startLine: number;
+  /** 1-based line number of the section's last line in the original document. */
+  endLine: number;
+  /**
+   * Suppression directives parsed from HTML comments inside the section.
+   * Line numbers are absolute (document-wide), 1-based, inclusive.
+   */
+  suppressions: SuppressionDirective[];
+  /**
+   * Fenced code block ranges within the section. Used by prose-aware rules
+   * to skip content that is intentionally illustrative rather than authored
+   * narrative. Line numbers are absolute (document-wide), 1-based, inclusive.
+   */
+  codeBlockRanges: LineRange[];
 }
 
 // ── RESULT ─────────────────────────────────────────────────────────

--- a/packages/cli/src/linter/spec-gen/spec.mdx
+++ b/packages/cli/src/linter/spec-gen/spec.mdx
@@ -328,3 +328,43 @@ When a DESIGN.md consumer encounters content not defined by this spec:
 | Unknown component property | Accept with warning | `myCustomProp` |
 | Typed component property with malformed value | Reject with error | `opacity: 2` |
 | Duplicate section heading | Error; reject the file | Two `## Colors` headings |
+
+# Linting
+
+The active linting rules are listed in the rules table emitted by `design.md spec --rules`.
+
+### Why `prose-token-mismatch`
+
+A DESIGN.md typically describes its palette in two places: the YAML tokens
+under `colors:`, and the prose under `## Colors` (e.g.
+*"Boston Clay (#B8422E) is the sole driver for interaction"*). When a
+designer recolors a token, the prose can silently fall out of sync. The
+existing `broken-ref` rule validates `{colors.tertiary}`-style references
+but cannot see hex literals embedded in sentences.
+
+`prose-token-mismatch` scans markdown prose for hex literals and verifies
+that each one resolves to a defined token's value. When an inline anchor
+is present — a backticked token key (`` `tertiary` ``, `` `colors.tertiary` ``)
+or a ramp anchor's `humanName` — the rule additionally checks that the hex
+matches *that specific token's* current value, catching renames and
+recolors as well as deletions.
+
+### Suppression Directives
+
+Linter findings can be suppressed inline with HTML comment directives.
+This is useful when prose intentionally cites a historical, external, or
+OS-default color that should not match a token.
+
+```markdown
+<!-- design.md disable-next-line prose-token-mismatch -->
+The legacy logo used Boston Red (#C8102E).
+
+<!-- design.md disable prose-token-mismatch -->
+External examples (#FF6700) appear throughout this section.
+<!-- design.md enable prose-token-mismatch -->
+
+<!-- design.md disable-file prose-token-mismatch -->
+```
+
+Use `*` as the rule name to suppress every rule. Multiple rules may be
+listed, separated by commas (e.g. `disable-next-line rule-a, rule-b`).


### PR DESCRIPTION
Implements the design from #4 (comment [#4320666240](https://github.com/joesteinkamp/design.md/issues/4#issuecomment-4320666240)).

## Summary

- New lint rule `prose-token-mismatch` (warning) that flags hex literals in markdown prose which drift from declared token values.
  - **Sub-rule A — orphan**: every hex in prose must appear as some token's value.
  - **Sub-rule B — anchored**: when a hex sits next to a backticked token key (`` `tertiary` ``, `` `colors.tertiary` ``) or a ramp anchor's `humanName` ("Boston Clay"), the hex must equal *that specific token's* current value.
- New comment-directive suppression mechanism, parsed once and consulted per-finding by every prose-aware rule:
  - `<!-- design.md disable-next-line <rule>[,<rule>...] -->`
  - `<!-- design.md disable <rule> -->` … `<!-- design.md enable <rule> -->`
  - `<!-- design.md disable-file <rule> -->`
  - `*` matches every rule.
- `documentSections` now carry `startLine`, `endLine`, `suppressions`, and `codeBlockRanges` so prose-aware rules can target source line ranges and skip fenced code blocks.
- `DesignSystemState.colorIndex: Map<hex, ColorIndexEntry[]>` gives the rule O(1) hex → token lookup.

## Behavior on existing fixtures

Running the linter against `fixtures/HERITAGE.md` now surfaces 9 prose-token mismatches (e.g. prose says `#1A1C1E` for "Primary" but the token resolves to `#000101`) — exactly the kind of drift the rule was designed to catch.

## Test plan

- [x] `bun test` — 323 pass / 0 fail (added 17 unit tests for the rule + 4 parser tests for directive parsing).
- [x] `bun run spec:gen --check` — generated spec is in sync.
- [x] `tsc --noEmit` — clean (only pre-existing bun-types issues unrelated to this change).
- [x] Manual run against `HERITAGE.md` and `RAMPS_AND_PAIRS.md` to confirm true positives without false positives.

Closes #4

---
_Generated by [Claude Code](https://claude.ai/code/session_015uPVYtULabPvrTVtxw3Nsv)_