### PR TITLE
feat(linter): component registry + closed-world rules (#6)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -377,6 +377,67 @@ shape; the prose carries the rationale. Cover at least:
   Borders should not be the primary visual identity of a surface —
   reach for color or elevation first.
 
+### Component Registry (Closed-World)
+
+By default, the components map is **open-world**: any component name is
+accepted and the linter will not complain. To opt into a closed set —
+the equivalent of TypeScript's `noImplicitAny` for components — split
+the components block into a `registry` (the catalog) and `definitions`
+(the values):
+
+```yaml
+components:
+  registry:
+    - name: button-primary
+      kind: button
+      requiredProperties: [backgroundColor, padding]
+    - name: card
+      kind: container
+    - name: card-elevated
+      kind: container
+      composes: card           # pre-merge card's props before overrides
+  definitions:
+    button-primary:
+      backgroundColor: "{colors.primary}"
+      padding: 12px
+    card:
+      backgroundColor: "{colors.surface}"
+    card-elevated:
+      shadow: "{elevation.raised}"
+```
+
+Once a registry is declared, the closed-world rules engage:
+
+* **`unbound-component`** (error) — flags definitions and prose
+  `{components.X}` references whose name isn't in the registry.
+* **`missing-required-property`** (error) — a registry entry's
+  `requiredProperties` must each be set by the matching definition
+  (composed properties count).
+* **`registry-without-definition`** (warning) — a registry entry has no
+  matching definition.
+* **`composes-cycle`** (error) — cycles in the `composes:` graph.
+* **`naming-convention`** (warning) — registry names follow
+  `noun-modifier` ordering with a closed modifier vocabulary
+  (primary/secondary/tertiary/danger/ghost/outline/subtle/bare/elevated/
+  hover/focus/active/disabled).
+
+**Authoring discipline.** Adding a registry entry is a deliberate,
+reviewable act. Definitions can be added or edited freely; only the
+registry edit signals "this system now supports a new component". When
+in doubt, prefer composing existing components (Card with an Image
+inside) over inventing a new one — the registry should grow slowly.
+
+**Variant vs new component.** If two components differ only in color or
+size, they're variants — express the difference via a hover/focus/etc.
+state on a single registry entry, not a separate name. If they differ in
+structure (slots, behavior, role), they're new components and warrant
+their own entry.
+
+**Anti-patterns.** `card-with-image`, `button-but-rounded`, `header-v2`
+— all signals that variants or composition are missing. The naming and
+composition rules above will flag the symptom; the prose explains the
+cure.
+
 ## Do's and Don'ts
 
 This section provides practical guidelines and common pitfalls. These act as guardrails when creating designs.

--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -89,6 +89,6 @@ describe('spec command', () => {
     const output = JSON.parse(outputStr);
     expect(output.spec).toBeDefined();
     expect(output.rules).toBeDefined();
-    expect(output.rules.length).toBe(16);
+    expect(output.rules.length).toBe(21);
   });
 });

--- a/packages/cli/src/linter/fixture.test.ts
+++ b/packages/cli/src/linter/fixture.test.ts
@@ -59,6 +59,33 @@ describe('Fixture Test', () => {
     expect(result.summary.infos).toBeGreaterThan(0);
   });
 
+  it('processes REGISTRY.md with closed-world rules engaged', () => {
+    const path = join(import.meta.dir, 'fixtures', 'REGISTRY.md');
+    const content = readFileSync(path, 'utf-8');
+
+    const result = lint(content);
+
+    // Registry shape parses end-to-end and the resolved state carries it.
+    const registry = result.designSystem.componentRegistry;
+    expect(registry).toBeDefined();
+    expect(registry!.size).toBe(5);
+
+    // Kind-derived interactivity.
+    expect(registry!.get('button-primary')!.interactive).toBe(true);
+    expect(registry!.get('card')!.interactive).toBe(false);
+
+    // composes pre-merge — card-elevated inherits backgroundColor from card.
+    const cardElevated = result.designSystem.components.get('card-elevated')!;
+    const bg = cardElevated.properties.get('backgroundColor');
+    expect(typeof bg === 'object' && bg !== null && 'type' in bg && bg.type === 'color').toBe(true);
+
+    // No unbound-component or missing-required-property errors.
+    const unboundErrors = result.findings.filter(d => d.message.includes('not in the component registry'));
+    expect(unboundErrors).toEqual([]);
+    const missingRequired = result.findings.filter(d => d.message.includes('requires '));
+    expect(missingRequired).toEqual([]);
+  });
+
   it('processes RAMPS_AND_PAIRS.md end-to-end with no errors', () => {
     const path = join(import.meta.dir, 'fixtures', 'RAMPS_AND_PAIRS.md');
     const content = readFileSync(path, 'utf-8');

--- a/packages/cli/src/linter/fixtures/REGISTRY.md
+++ b/packages/cli/src/linter/fixtures/REGISTRY.md
@@ -1,0 +1,99 @@
+---
+name: Registry Demo
+colors:
+  primary: "#1a1c1e"
+  on-primary: "#ffffff"
+  secondary: "#6c7278"
+  on-secondary: "#ffffff"
+  surface: "#ffffff"
+  on-surface: "#1a1c1e"
+typography:
+  body-md:
+    fontFamily: Inter
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.5
+  label-md:
+    fontFamily: Inter
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.4
+rounded:
+  sm: 4px
+  md: 8px
+  lg: 12px
+components:
+  registry:
+    - name: button-primary
+      kind: button
+      requiredProperties: [backgroundColor, textColor, padding, rounded]
+    - name: button-secondary
+      kind: button
+    - name: card
+      kind: container
+    - name: card-elevated
+      kind: container
+      composes: card
+    - name: input-text
+      kind: input
+      interactive: true
+      requiredProperties: [backgroundColor, textColor, padding]
+  definitions:
+    button-primary:
+      backgroundColor: "{colors.primary}"
+      textColor: "{colors.on-primary}"
+      typography: "{typography.label-md}"
+      rounded: "{rounded.md}"
+      padding: 12px
+    button-secondary:
+      backgroundColor: "{colors.secondary}"
+      textColor: "{colors.on-secondary}"
+      typography: "{typography.label-md}"
+      rounded: "{rounded.md}"
+      padding: 12px
+    card:
+      backgroundColor: "{colors.surface}"
+      textColor: "{colors.on-surface}"
+      rounded: "{rounded.lg}"
+      padding: 16px
+    card-elevated:
+      shadow: "0 4px 8px rgba(0,0,0,0.08)"
+    input-text:
+      backgroundColor: "{colors.surface}"
+      textColor: "{colors.on-surface}"
+      typography: "{typography.body-md}"
+      padding: 8px
+---
+
+## Brand & Style
+
+A registry-demo design system. Closed-world component model.
+
+## Colors
+
+Primary `{colors.primary}` and a single accompanying `secondary`.
+
+## Typography
+
+A two-step type scale: `body-md` and `label-md`.
+
+## Layout
+
+Compact 8px rhythm.
+
+## Elevation & Depth
+
+The elevated card variant uses a 0/4/8 raised shadow.
+
+## Shapes
+
+Rounded scale: `sm`, `md`, `lg`.
+
+## Components
+
+Use `{components.button-primary}` for the primary CTA, `{components.button-secondary}` for secondary actions, and compose `{components.card-elevated}` over `{components.card}` rather than inventing new variants.
+
+## Do's and Don'ts
+
+- Do prefer composition over new registry entries
+- Don't invent component names that aren't in the registry

--- a/packages/cli/src/linter/linter/rules/composes-cycle.test.ts
+++ b/packages/cli/src/linter/linter/rules/composes-cycle.test.ts
@@ -1,0 +1,75 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { composesCycle, composesCycleRule } from './composes-cycle.js';
+import { buildState } from './test-helpers.js';
+
+describe('composesCycle', () => {
+  it('is a no-op when no registry is declared', () => {
+    const state = buildState({
+      components: { card: { backgroundColor: '#000' } },
+    });
+    expect(composesCycle(state)).toEqual([]);
+  });
+
+  it('passes for a non-cyclic chain', () => {
+    const state = buildState({
+      componentRegistry: [
+        { name: 'card', kind: 'container' },
+        { name: 'card-elevated', kind: 'container', composes: 'card' },
+      ],
+      components: {
+        card: { backgroundColor: '#000' },
+        'card-elevated': { shadow: '0 4px 8px rgba(0,0,0,0.1)' },
+      },
+    });
+    expect(composesCycle(state)).toEqual([]);
+  });
+
+  it('detects a 2-node cycle', () => {
+    const state = buildState({
+      componentRegistry: [
+        { name: 'a', kind: 'container', composes: 'b' },
+        { name: 'b', kind: 'container', composes: 'a' },
+      ],
+      components: { a: { backgroundColor: '#000' }, b: { backgroundColor: '#fff' } },
+    });
+    const findings = composesCycle(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain('cycle');
+  });
+
+  it('detects a 3-node cycle and reports it once', () => {
+    const state = buildState({
+      componentRegistry: [
+        { name: 'a', kind: 'container', composes: 'b' },
+        { name: 'b', kind: 'container', composes: 'c' },
+        { name: 'c', kind: 'container', composes: 'a' },
+      ],
+      components: {
+        a: { backgroundColor: '#000' },
+        b: { backgroundColor: '#fff' },
+        c: { backgroundColor: '#aaa' },
+      },
+    });
+    const findings = composesCycle(state);
+    // Same cycle, reported once even though every entry can find it.
+    expect(findings.length).toBe(1);
+  });
+
+  it('descriptor is an error', () => {
+    expect(composesCycleRule.severity).toBe('error');
+  });
+});

--- a/packages/cli/src/linter/linter/rules/composes-cycle.ts
+++ b/packages/cli/src/linter/linter/rules/composes-cycle.ts
@@ -1,0 +1,85 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState, RegistryEntry } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Composes-cycle — detects cycles in the registry's `composes:` graph
+ * (e.g., `card-elevated → card-fancy → card-elevated`). The model handler
+ * short-circuits cycles when merging properties; this rule surfaces them so
+ * authors can fix the registry rather than silently ignore the broken chain.
+ *
+ * Each cycle is reported once, anchored on the registry entry whose `composes`
+ * link closes the loop.
+ */
+export function composesCycle(state: DesignSystemState): RuleFinding[] {
+  const registry = state.componentRegistry;
+  if (!registry) return [];
+
+  const findings: RuleFinding[] = [];
+  const reported = new Set<string>();
+
+  for (const [name] of registry) {
+    const cycle = findCycle(name, registry);
+    if (!cycle) continue;
+    const key = canonicalCycleKey(cycle);
+    if (reported.has(key)) continue;
+    reported.add(key);
+    findings.push({
+      path: `components.registry.${cycle[0]}.composes`,
+      message: `Composition cycle detected: ${cycle.join(' → ')} → ${cycle[0]}.`,
+    });
+  }
+  return findings;
+}
+
+/** Walk the composes chain from `start`. Returns the cycle path if one closes back on a visited node. */
+function findCycle(
+  start: string,
+  registry: Map<string, RegistryEntry>,
+): string[] | null {
+  const path: string[] = [];
+  const inPath = new Set<string>();
+  let current: string | undefined = start;
+  while (current !== undefined) {
+    if (inPath.has(current)) {
+      // Slice from the cycle entry point onward.
+      const idx = path.indexOf(current);
+      return path.slice(idx);
+    }
+    path.push(current);
+    inPath.add(current);
+    const entry: RegistryEntry | undefined = registry.get(current);
+    current = entry?.composes;
+  }
+  return null;
+}
+
+/** Rotation-invariant key so the same cycle reported from different starts collapses to one. */
+function canonicalCycleKey(cycle: string[]): string {
+  if (cycle.length === 0) return '';
+  let minIdx = 0;
+  for (let i = 1; i < cycle.length; i++) {
+    if (cycle[i]! < cycle[minIdx]!) minIdx = i;
+  }
+  return [...cycle.slice(minIdx), ...cycle.slice(0, minIdx)].join('→');
+}
+
+export const composesCycleRule: RuleDescriptor = {
+  name: 'composes-cycle',
+  severity: 'error',
+  description: 'Cycles in the component composition graph.',
+  run: composesCycle,
+};

--- a/packages/cli/src/linter/linter/rules/index.ts
+++ b/packages/cli/src/linter/linter/rules/index.ts
@@ -31,6 +31,11 @@ import { pairContrastRule } from './pair-contrast.js';
 import { mixedPairForegroundRule } from './mixed-pair-foreground.js';
 import { rampAnchorNamingRule } from './ramp-anchor-naming.js';
 import { proseTokenMismatchRule } from './prose-token-mismatch.js';
+import { unboundComponentRule } from './unbound-component.js';
+import { missingRequiredPropertyRule } from './missing-required-property.js';
+import { registryWithoutDefinitionRule } from './registry-without-definition.js';
+import { composesCycleRule } from './composes-cycle.js';
+import { namingConventionRule } from './naming-convention.js';
 
 /** The default set of lint rule descriptors, in order. */
 export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
@@ -50,6 +55,11 @@ export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
   elevationWithoutSemanticsRule,
   tripleSeparationRule,
   proseTokenMismatchRule,
+  unboundComponentRule,
+  missingRequiredPropertyRule,
+  registryWithoutDefinitionRule,
+  composesCycleRule,
+  namingConventionRule,
 ];
 
 /** Converts a RuleDescriptor into a LintRule by injecting severity into findings. */
@@ -82,4 +92,9 @@ export { pairContrast } from './pair-contrast.js';
 export { mixedPairForeground } from './mixed-pair-foreground.js';
 export { rampAnchorNaming } from './ramp-anchor-naming.js';
 export { proseTokenMismatch } from './prose-token-mismatch.js';
+export { unboundComponent } from './unbound-component.js';
+export { missingRequiredProperty } from './missing-required-property.js';
+export { registryWithoutDefinition } from './registry-without-definition.js';
+export { composesCycle } from './composes-cycle.js';
+export { namingConvention } from './naming-convention.js';
 export type { LintRule } from './types.js';

--- a/packages/cli/src/linter/linter/rules/missing-required-property.test.ts
+++ b/packages/cli/src/linter/linter/rules/missing-required-property.test.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { missingRequiredProperty, missingRequiredPropertyRule } from './missing-required-property.js';
+import { buildState } from './test-helpers.js';
+
+describe('missingRequiredProperty', () => {
+  it('is a no-op when no registry is declared', () => {
+    const state = buildState({
+      components: { 'button-primary': { backgroundColor: '#000' } },
+    });
+    expect(missingRequiredProperty(state)).toEqual([]);
+  });
+
+  it('flags definitions missing a required property', () => {
+    const state = buildState({
+      componentRegistry: [
+        {
+          name: 'button-primary',
+          kind: 'button',
+          requiredProperties: ['backgroundColor', 'padding'],
+        },
+      ],
+      components: {
+        'button-primary': { backgroundColor: '#000' },
+      },
+    });
+    const findings = missingRequiredProperty(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('components.button-primary.padding');
+    expect(findings[0]!.message).toContain('requires');
+  });
+
+  it('passes when all required properties are set', () => {
+    const state = buildState({
+      componentRegistry: [
+        {
+          name: 'button-primary',
+          kind: 'button',
+          requiredProperties: ['backgroundColor', 'padding'],
+        },
+      ],
+      components: {
+        'button-primary': { backgroundColor: '#000', padding: '12px' },
+      },
+    });
+    expect(missingRequiredProperty(state)).toEqual([]);
+  });
+
+  it('counts inherited properties via composes', () => {
+    const state = buildState({
+      componentRegistry: [
+        { name: 'card', kind: 'container', requiredProperties: ['backgroundColor'] },
+        {
+          name: 'card-elevated',
+          kind: 'container',
+          requiredProperties: ['backgroundColor'],
+          composes: 'card',
+        },
+      ],
+      components: {
+        card: { backgroundColor: '#000' },
+        // intentionally omits backgroundColor; inherits from card.
+        'card-elevated': { shadow: '0 4px 8px rgba(0,0,0,0.1)' },
+      },
+    });
+    expect(missingRequiredProperty(state)).toEqual([]);
+  });
+
+  it('does not flag entries without a definition (registry-without-definition handles those)', () => {
+    const state = buildState({
+      componentRegistry: [{ name: 'card', kind: 'container', requiredProperties: ['backgroundColor'] }],
+      components: {},
+    });
+    expect(missingRequiredProperty(state)).toEqual([]);
+  });
+
+  it('has a valid rule descriptor', () => {
+    expect(missingRequiredPropertyRule.name).toBe('missing-required-property');
+    expect(missingRequiredPropertyRule.severity).toBe('error');
+    expect(missingRequiredPropertyRule.run).toBe(missingRequiredProperty);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/missing-required-property.ts
+++ b/packages/cli/src/linter/linter/rules/missing-required-property.ts
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Missing required property — when a registry entry declares
+ * `requiredProperties: [...]`, the matching definition must set each of them.
+ *
+ * The check runs against the post-`composes`-merge property set: if a parent
+ * (composed) component supplies the required property, the child does not
+ * need to repeat it.
+ *
+ * No-op when the registry is absent.
+ */
+export function missingRequiredProperty(state: DesignSystemState): RuleFinding[] {
+  const registry = state.componentRegistry;
+  if (!registry) return [];
+
+  const findings: RuleFinding[] = [];
+  for (const [name, entry] of registry) {
+    if (entry.requiredProperties.length === 0) continue;
+    const def = state.components.get(name);
+    if (!def) continue; // surfaced by registry-without-definition
+    for (const required of entry.requiredProperties) {
+      if (!def.properties.has(required)) {
+        findings.push({
+          path: `components.${name}.${required}`,
+          message: `'${name}' requires '${required}' but the definition does not set it.`,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+export const missingRequiredPropertyRule: RuleDescriptor = {
+  name: 'missing-required-property',
+  severity: 'error',
+  description: 'Required properties on a registry entry — the matching definition must set each one.',
+  run: missingRequiredProperty,
+};

--- a/packages/cli/src/linter/linter/rules/naming-convention.test.ts
+++ b/packages/cli/src/linter/linter/rules/naming-convention.test.ts
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { namingConvention, namingConventionRule } from './naming-convention.js';
+import { buildState } from './test-helpers.js';
+
+describe('namingConvention', () => {
+  it('is a no-op when no registry is declared', () => {
+    const state = buildState({});
+    expect(namingConvention(state)).toEqual([]);
+  });
+
+  it('accepts bare nouns', () => {
+    const state = buildState({
+      componentRegistry: [{ name: 'card', kind: 'container' }],
+    });
+    expect(namingConvention(state)).toEqual([]);
+  });
+
+  it('accepts noun-modifier with permitted modifiers', () => {
+    const state = buildState({
+      componentRegistry: [
+        { name: 'button-primary', kind: 'button' },
+        { name: 'card-elevated', kind: 'container' },
+        { name: 'button-ghost', kind: 'button' },
+      ],
+    });
+    expect(namingConvention(state)).toEqual([]);
+  });
+
+  it('flags non-vocabulary modifiers', () => {
+    const state = buildState({
+      componentRegistry: [{ name: 'button-fancy', kind: 'button' }],
+    });
+    const findings = namingConvention(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain('fancy');
+  });
+
+  it('flags modifier-noun ordering with a fix suggestion', () => {
+    const state = buildState({
+      componentRegistry: [{ name: 'primary-button', kind: 'button' }],
+    });
+    const findings = namingConvention(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain('button-primary');
+  });
+
+  it('descriptor is a warning', () => {
+    expect(namingConventionRule.severity).toBe('warning');
+  });
+});

--- a/packages/cli/src/linter/linter/rules/naming-convention.ts
+++ b/packages/cli/src/linter/linter/rules/naming-convention.ts
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import { COMPONENT_MODIFIERS } from '../../spec-config.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Naming convention — registry entries should follow `noun-modifier`. The
+ * rule fires when an entry's modifier (the segment after the first hyphen)
+ * is not in the closed modifier vocabulary.
+ *
+ * Examples:
+ *   `button-primary`   ✓
+ *   `card-elevated`    ✓
+ *   `button-fancy`     ⚠  ('fancy' is not a permitted modifier)
+ *   `fancy-button`     ⚠  (modifier-noun, not noun-modifier — heuristic catch)
+ *
+ * Bare nouns (`card`, `input`) pass.
+ */
+const MODIFIERS = new Set(COMPONENT_MODIFIERS);
+
+export function namingConvention(state: DesignSystemState): RuleFinding[] {
+  const registry = state.componentRegistry;
+  if (!registry) return [];
+
+  const findings: RuleFinding[] = [];
+  for (const [name] of registry) {
+    const segments = name.split('-');
+    if (segments.length < 2) continue; // bare noun is fine
+
+    // Heuristic: if the FIRST segment is a known modifier, this is likely
+    // modifier-noun ordering. e.g., `primary-button`.
+    if (MODIFIERS.has(segments[0]!) && !MODIFIERS.has(segments[segments.length - 1]!)) {
+      findings.push({
+        path: `components.registry.${name}`,
+        message: `'${name}' looks like 'modifier-noun'. Use 'noun-modifier' (e.g., '${segments.slice(1).join('-')}-${segments[0]}').`,
+      });
+      continue;
+    }
+
+    // Otherwise the trailing segment must be a permitted modifier.
+    const tail = segments[segments.length - 1]!;
+    if (!MODIFIERS.has(tail)) {
+      findings.push({
+        path: `components.registry.${name}`,
+        message: `'${tail}' is not in the permitted modifier vocabulary. Permitted: ${[...MODIFIERS].join(', ')}.`,
+      });
+    }
+  }
+  return findings;
+}
+
+export const namingConventionRule: RuleDescriptor = {
+  name: 'naming-convention',
+  severity: 'warning',
+  description: 'Registry names follow `noun-modifier` with a closed modifier vocabulary.',
+  run: namingConvention,
+};

--- a/packages/cli/src/linter/linter/rules/registry-without-definition.test.ts
+++ b/packages/cli/src/linter/linter/rules/registry-without-definition.test.ts
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import {
+  registryWithoutDefinition,
+  registryWithoutDefinitionRule,
+} from './registry-without-definition.js';
+import { buildState } from './test-helpers.js';
+
+describe('registryWithoutDefinition', () => {
+  it('is a no-op when no registry is declared', () => {
+    const state = buildState({
+      components: { 'button-primary': { backgroundColor: '#000' } },
+    });
+    expect(registryWithoutDefinition(state)).toEqual([]);
+  });
+
+  it('flags registry entries without a matching definition', () => {
+    const state = buildState({
+      componentRegistry: [
+        { name: 'button-primary', kind: 'button' },
+        { name: 'button-tertiary', kind: 'button' },
+      ],
+      components: { 'button-primary': { backgroundColor: '#000' } },
+    });
+    const findings = registryWithoutDefinition(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('components.registry.button-tertiary');
+  });
+
+  it('passes when every registry entry has a definition', () => {
+    const state = buildState({
+      componentRegistry: [{ name: 'card', kind: 'container' }],
+      components: { card: { backgroundColor: '#000' } },
+    });
+    expect(registryWithoutDefinition(state)).toEqual([]);
+  });
+
+  it('descriptor is a warning', () => {
+    expect(registryWithoutDefinitionRule.severity).toBe('warning');
+  });
+});

--- a/packages/cli/src/linter/linter/rules/registry-without-definition.ts
+++ b/packages/cli/src/linter/linter/rules/registry-without-definition.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Registry-without-definition — flags registry entries that have no matching
+ * `components.definitions.<name>` block. Either the entry is aspirational
+ * (reserve a name for later) or it's a typo. Warns rather than errors so
+ * authors can stage in registry-first work.
+ */
+export function registryWithoutDefinition(state: DesignSystemState): RuleFinding[] {
+  const registry = state.componentRegistry;
+  if (!registry) return [];
+
+  const findings: RuleFinding[] = [];
+  for (const [name] of registry) {
+    if (!state.components.has(name)) {
+      findings.push({
+        path: `components.registry.${name}`,
+        message: `'${name}' is in the registry but has no definition. Add a 'components.definitions.${name}' block or remove the registry entry.`,
+      });
+    }
+  }
+  return findings;
+}
+
+export const registryWithoutDefinitionRule: RuleDescriptor = {
+  name: 'registry-without-definition',
+  severity: 'warning',
+  description: 'Registry entries lacking a matching definition block.',
+  run: registryWithoutDefinition,
+};

--- a/packages/cli/src/linter/linter/rules/types.test.ts
+++ b/packages/cli/src/linter/linter/rules/types.test.ts
@@ -44,7 +44,7 @@ describe('LintRule type', () => {
   });
 
   it('has all rules in DEFAULT_RULE_DESCRIPTORS', () => {
-    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(16);
+    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(21);
     DEFAULT_RULE_DESCRIPTORS.forEach((rule: RuleDescriptor) => {
       expect(rule.name).toBeTruthy();
       expect(rule.severity).toBeTruthy();

--- a/packages/cli/src/linter/linter/rules/unbound-component.test.ts
+++ b/packages/cli/src/linter/linter/rules/unbound-component.test.ts
@@ -1,0 +1,86 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { unboundComponent, unboundComponentRule } from './unbound-component.js';
+import { buildState } from './test-helpers.js';
+
+describe('unboundComponent', () => {
+  it('is a no-op when no registry is declared (open-world back-compat)', () => {
+    const state = buildState({
+      components: { 'button-mystery': { backgroundColor: '#000' } },
+    });
+    expect(unboundComponent(state)).toEqual([]);
+  });
+
+  it('flags definitions outside the registry', () => {
+    const state = buildState({
+      componentRegistry: [{ name: 'button-primary', kind: 'button' }],
+      components: {
+        'button-primary': { backgroundColor: '#000' },
+        'button-quaternary': { backgroundColor: '#fff' },
+      },
+    });
+    const findings = unboundComponent(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('components.button-quaternary');
+    expect(findings[0]!.message).toContain('not in the component registry');
+  });
+
+  it('flags prose references outside the registry', () => {
+    const state = buildState({
+      componentRegistry: [{ name: 'button-primary', kind: 'button' }],
+      components: { 'button-primary': { backgroundColor: '#000' } },
+      documentSections: [
+        {
+          heading: 'Components',
+          content: 'Use {components.button-primary} for CTAs and {components.widget-floof} for X.',
+          startLine: 1,
+          endLine: 1,
+          suppressions: [],
+          codeBlockRanges: [],
+        },
+      ],
+    });
+    const findings = unboundComponent(state);
+    expect(findings.some(f => f.message.includes('widget-floof'))).toBe(true);
+    // button-primary should not be flagged
+    expect(findings.some(f => f.message.includes('button-primary'))).toBe(false);
+  });
+
+  it('does not flag prose references that are in the registry', () => {
+    const state = buildState({
+      componentRegistry: [{ name: 'card', kind: 'container' }],
+      components: { card: { backgroundColor: '#000' } },
+      documentSections: [
+        {
+          heading: 'Components',
+          content: 'Compose {components.card} freely.',
+          startLine: 1,
+          endLine: 1,
+          suppressions: [],
+          codeBlockRanges: [],
+        },
+      ],
+    });
+    expect(unboundComponent(state)).toEqual([]);
+  });
+
+  it('has a valid rule descriptor', () => {
+    expect(unboundComponentRule.name).toBe('unbound-component');
+    expect(unboundComponentRule.severity).toBe('error');
+    expect(unboundComponentRule.description).toBeTruthy();
+    expect(unboundComponentRule.run).toBe(unboundComponent);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/unbound-component.ts
+++ b/packages/cli/src/linter/linter/rules/unbound-component.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Unbound component — flags any component whose name is not declared in the
+ * `componentRegistry`. The registry, when present, is the closed set of valid
+ * component names; anything outside it is an open-world drift.
+ *
+ * Two flag sources are covered here:
+ *   1. Definitions side — every key in `state.components` not in the registry.
+ *   2. Prose side — `{components.X}` references in document sections where X
+ *      is not in the registry.
+ *
+ * Source-file scanning (TSX/HTML) is a separate, opt-in flag (`--src`); not
+ * implemented in this rule.
+ *
+ * No-op when the registry is absent (back-compat / open-world).
+ */
+const PROSE_REF_RE = /\{components\.([a-zA-Z0-9_-]+)\}/g;
+
+export function unboundComponent(state: DesignSystemState): RuleFinding[] {
+  const registry = state.componentRegistry;
+  if (!registry) return [];
+
+  const findings: RuleFinding[] = [];
+
+  // 1. Definitions not in the registry.
+  for (const compName of state.components.keys()) {
+    if (!registry.has(compName)) {
+      findings.push({
+        path: `components.${compName}`,
+        message: `'${compName}' is not in the component registry. Add it to 'components.registry' or remove the definition.`,
+      });
+    }
+  }
+
+  // 2. Prose references (`{components.X}`) inside document sections.
+  const seenProseRefs = new Set<string>();
+  for (const section of state.documentSections ?? []) {
+    PROSE_REF_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = PROSE_REF_RE.exec(section.content)) !== null) {
+      const name = m[1]!;
+      if (registry.has(name)) continue;
+      const key = `${section.heading}::${name}`;
+      if (seenProseRefs.has(key)) continue;
+      seenProseRefs.add(key);
+      findings.push({
+        path: section.heading
+          ? `prose.${section.heading}.${name}`
+          : `prose.${name}`,
+        message: `Prose references '{components.${name}}' but '${name}' is not in the component registry.`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+export const unboundComponentRule: RuleDescriptor = {
+  name: 'unbound-component',
+  severity: 'error',
+  description: 'Components referenced or defined outside the registry — the closed-world contract over component names.',
+  run: unboundComponent,
+};

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -448,4 +448,73 @@ describe('ModelHandler', () => {
       expect(typeof elevation === 'object' && elevation !== null && 'type' in elevation && elevation.type === 'shadow').toBe(true);
     });
   });
+
+  describe('component registry', () => {
+    it('omits componentRegistry when not declared (open-world back-compat)', () => {
+      const result = handler.execute(makeParsed({
+        components: { card: { backgroundColor: '#000' } },
+      }));
+      expect(result.designSystem.componentRegistry).toBeUndefined();
+    });
+
+    it('builds the registry map with kind-derived interactivity', () => {
+      const result = handler.execute(makeParsed({
+        componentRegistry: [
+          { name: 'button-primary', kind: 'button' },
+          { name: 'card', kind: 'container' },
+        ],
+        components: {
+          'button-primary': { backgroundColor: '#000' },
+          card: { backgroundColor: '#fff' },
+        },
+      }));
+      const registry = result.designSystem.componentRegistry!;
+      expect(registry.get('button-primary')!.interactive).toBe(true);
+      expect(registry.get('card')!.interactive).toBe(false);
+    });
+
+    it('lets explicit interactive override the kind default', () => {
+      const result = handler.execute(makeParsed({
+        componentRegistry: [
+          { name: 'card', kind: 'container', interactive: true },
+        ],
+        components: { card: { backgroundColor: '#000' } },
+      }));
+      expect(result.designSystem.componentRegistry!.get('card')!.interactive).toBe(true);
+    });
+
+    it('pre-merges composed properties before child overrides', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#ff0000' },
+        componentRegistry: [
+          { name: 'card', kind: 'container' },
+          { name: 'card-elevated', kind: 'container', composes: 'card' },
+        ],
+        components: {
+          card: { backgroundColor: '{colors.primary}', padding: '12px' },
+          'card-elevated': { padding: '24px' },
+        },
+      }));
+      const elevated = result.designSystem.components.get('card-elevated')!;
+      const bg = elevated.properties.get('backgroundColor');
+      // Inherited from card.
+      expect(typeof bg === 'object' && bg !== null && 'type' in bg && bg.type === 'color').toBe(true);
+      // Own override wins.
+      const padding = elevated.properties.get('padding');
+      expect(typeof padding === 'object' && padding !== null && 'value' in padding ? padding.value : null).toBe(24);
+    });
+
+    it('short-circuits composes cycles without crashing', () => {
+      const result = handler.execute(makeParsed({
+        componentRegistry: [
+          { name: 'a', kind: 'container', composes: 'b' },
+          { name: 'b', kind: 'container', composes: 'a' },
+        ],
+        components: { a: { padding: '12px' }, b: { padding: '8px' } },
+      }));
+      // Build succeeded; the linter rule reports the cycle.
+      expect(result.designSystem.components.has('a')).toBe(true);
+      expect(result.designSystem.components.has('b')).toBe(true);
+    });
+  });
 });

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { ParsedDesignSystem, RawColorValue, RawRampDef, RawPairDef } from '../parser/spec.js';
+import type { ParsedDesignSystem, RawColorValue, RawRampDef, RawPairDef, RawRegistryEntry } from '../parser/spec.js';
 import type {
   ModelSpec,
   ModelResult,
@@ -26,11 +26,13 @@ import type {
   RampDef,
   PairDef,
   ColorIndexEntry,
+  RegistryEntry,
 } from './spec.js';
 
 import { isValidColor, isParseableDimension, isTokenReference, parseDimensionParts } from './spec.js';
 import { COMPONENT_SUB_TOKEN_VALIDATORS } from '../component-validators.js';
 import { generateRampSteps, DEFAULT_RAMP_STEPS } from './color-ramp.js';
+import { KIND_DEFAULTS } from '../spec-config.js';
 
 const MAX_REFERENCE_DEPTH = 10;
 
@@ -215,10 +217,20 @@ export class ModelHandler implements ModelSpec {
         }
       }
 
-      // ── Phase 3: Build components ──────────────────────────────────
+      // ── Phase 3a: Resolve registry ─────────────────────────────────
+      const componentRegistry = input.componentRegistry
+        ? buildRegistry(input.componentRegistry)
+        : undefined;
+
+      // ── Phase 3b: Build components ─────────────────────────────────
       const components = new Map<string, ComponentDef>();
-      if (input.components) {
-        for (const [compName, props] of Object.entries(input.components)) {
+      // Pre-merge composed properties: for each definition, walk its registry
+      // entry's `composes` chain and merge those definitions' raw properties
+      // before resolving overrides. Cycles are short-circuited; the
+      // `composes-cycle` rule reports them.
+      const mergedRaw = mergeComposedDefinitions(input.components ?? {}, componentRegistry);
+      if (mergedRaw) {
+        for (const [compName, props] of Object.entries(mergedRaw)) {
           const properties = new Map<string, ResolvedValue>();
           const unresolvedRefs: string[] = [];
 
@@ -284,6 +296,7 @@ export class ModelHandler implements ModelSpec {
           spacing,
           elevation,
           components,
+          componentRegistry,
           colorRamps,
           colorPairs,
           symbolTable,
@@ -317,6 +330,69 @@ export class ModelHandler implements ModelSpec {
       };
     }
   }
+}
+
+// ── Component registry & composition ───────────────────────────────
+
+/**
+ * Build the resolved registry map from raw entries. Defaults `interactive`
+ * from the kind when not explicitly set; missing kinds leave `interactive`
+ * `false`. Duplicate names take the last definition (linter rules can flag
+ * this as a separate concern).
+ */
+function buildRegistry(rawEntries: RawRegistryEntry[]): Map<string, RegistryEntry> {
+  const out = new Map<string, RegistryEntry>();
+  for (const raw of rawEntries) {
+    const interactive = raw.interactive
+      ?? (raw.kind ? KIND_DEFAULTS[raw.kind]?.interactive ?? false : false);
+    const entry: RegistryEntry = {
+      name: raw.name,
+      interactive,
+      requiredProperties: raw.requiredProperties ?? [],
+    };
+    if (raw.kind !== undefined) entry.kind = raw.kind;
+    if (raw.composes !== undefined) entry.composes = raw.composes;
+    out.set(raw.name, entry);
+  }
+  return out;
+}
+
+/**
+ * Pre-merge `composes` chains into a flat raw definitions map, in declaration
+ * order: composed properties are written first, then the definition's own
+ * properties override. Cycles are detected via a visited set and short-
+ * circuited (the chain stops at the cycle point); the linter's
+ * `composes-cycle` rule reports the cycle separately.
+ */
+function mergeComposedDefinitions(
+  rawDefs: Record<string, Record<string, string>>,
+  registry: Map<string, RegistryEntry> | undefined,
+): Record<string, Record<string, string>> {
+  if (!registry) return rawDefs;
+  const out: Record<string, Record<string, string>> = {};
+  for (const [name, props] of Object.entries(rawDefs)) {
+    out[name] = resolveComposedProps(name, rawDefs, registry, new Set());
+    // Ensure props are preserved even if registry has no entry
+    if (!registry.has(name)) {
+      out[name] = props;
+    }
+  }
+  return out;
+}
+
+function resolveComposedProps(
+  name: string,
+  rawDefs: Record<string, Record<string, string>>,
+  registry: Map<string, RegistryEntry>,
+  visited: Set<string>,
+): Record<string, string> {
+  if (visited.has(name)) return {};
+  visited.add(name);
+  const entry = registry.get(name);
+  const ownProps = rawDefs[name] ?? {};
+  if (!entry?.composes) return { ...ownProps };
+  const composed = resolveComposedProps(entry.composes, rawDefs, registry, visited);
+  return { ...composed, ...ownProps };
 }
 
 // ── Object-shaped color expansion (ramps and pairs) ────────────────

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -128,6 +128,24 @@ export type ResolvedValue =
 export const VALID_TYPOGRAPHY_PROPS = _VALID_TYPOGRAPHY_PROPS;
 export const VALID_COMPONENT_SUB_TOKENS = _VALID_COMPONENT_SUB_TOKENS;
 
+/**
+ * A resolved registry entry. When `componentRegistry` is present in the
+ * `DesignSystemState`, it constitutes the closed set of valid component names
+ * for the design system; any name outside the registry is a `unbound-component`
+ * violation.
+ */
+export interface RegistryEntry {
+  name: string;
+  /** Kind drives default behaviors (e.g., interactivity). */
+  kind?: string;
+  /** Final interactivity flag — explicit setting wins over kind default. */
+  interactive: boolean;
+  /** Property names the matching definition must set. */
+  requiredProperties: string[];
+  /** Composition target — pre-merge that entry's definition before overrides. */
+  composes?: string;
+}
+
 // ── STATE ──────────────────────────────────────────────────────────
 export interface DesignSystemState {
   name?: string | undefined;
@@ -148,6 +166,11 @@ export interface DesignSystemState {
    */
   elevation: Map<string, ResolvedShadow>;
   components: Map<string, ComponentDef>;
+  /**
+   * Closed-world registry of component names. Absent = open-world (back-compat);
+   * present = the closed set of valid names.
+   */
+  componentRegistry?: Map<string, RegistryEntry> | undefined;
   /** Ramp definitions, keyed by ramp name. */
   colorRamps: Map<string, RampDef>;
   /** Pair definitions, keyed by pair name. */

--- a/packages/cli/src/linter/parser/handler.test.ts
+++ b/packages/cli/src/linter/parser/handler.test.ts
@@ -250,4 +250,55 @@ Some markdown text with no YAML blocks.
       }
     });
   });
+
+  describe('component registry shape', () => {
+    it('parses flat components (back-compat) and leaves componentRegistry undefined', () => {
+      const input = `---
+components:
+  button-primary:
+    backgroundColor: "#000000"
+---`;
+      const result = handler.execute({ content: input });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.components?.['button-primary']?.['backgroundColor']).toBe('#000000');
+        expect(result.data.componentRegistry).toBeUndefined();
+      }
+    });
+
+    it('parses registry + definitions split shape', () => {
+      const input = `---
+components:
+  registry:
+    - name: button-primary
+      kind: button
+      requiredProperties: [backgroundColor, padding]
+    - name: card-elevated
+      kind: container
+      composes: card
+    - name: card
+      kind: container
+  definitions:
+    button-primary:
+      backgroundColor: "#000000"
+      padding: "12px"
+    card:
+      backgroundColor: "#ffffff"
+    card-elevated:
+      backgroundColor: "#eeeeee"
+---`;
+      const result = handler.execute({ content: input });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.componentRegistry?.length).toBe(3);
+        const btn = result.data.componentRegistry?.find(e => e.name === 'button-primary');
+        expect(btn?.kind).toBe('button');
+        expect(btn?.requiredProperties).toEqual(['backgroundColor', 'padding']);
+        const elevated = result.data.componentRegistry?.find(e => e.name === 'card-elevated');
+        expect(elevated?.composes).toBe('card');
+        // Definitions are still surfaced via `components`.
+        expect(result.data.components?.['button-primary']?.['backgroundColor']).toBe('#000000');
+      }
+    });
+  });
 });

--- a/packages/cli/src/linter/parser/handler.ts
+++ b/packages/cli/src/linter/parser/handler.ts
@@ -18,6 +18,7 @@ import type {
   ParserInput,
   ParserResult,
   ParsedDesignSystem,
+  RawRegistryEntry,
   SourceLocation,
   DocumentSection,
   SuppressionDirective,
@@ -216,6 +217,7 @@ export class ParserHandler implements ParserSpec {
    * Map a raw parsed object to the ParsedDesignSystem interface.
    */
   private toDesignSystem(raw: Record<string, unknown>, sourceMap: Map<string, SourceLocation>, sections: string[], documentSections: DocumentSection[]): ParsedDesignSystem {
+    const { components, componentRegistry } = normalizeComponents(raw['components']);
     return {
       name: typeof raw['name'] === 'string' ? raw['name'] : undefined,
       description: typeof raw['description'] === 'string' ? raw['description'] : undefined,
@@ -224,7 +226,8 @@ export class ParserHandler implements ParserSpec {
       rounded: raw['rounded'] as Record<string, string> | undefined,
       spacing: raw['spacing'] as Record<string, string> | undefined,
       elevation: raw['elevation'] as Record<string, string> | undefined,
-      components: raw['components'] as Record<string, Record<string, string>> | undefined,
+      components,
+      componentRegistry,
       sourceMap,
       sections,
       documentSections,
@@ -325,4 +328,62 @@ function parseSuppressionDirectives(contentLines: string[]): SuppressionDirectiv
   }
 
   return directives;
+}
+
+/**
+ * Normalize the `components:` block into definitions + optional registry.
+ *
+ * Two accepted shapes:
+ *   1. Flat (back-compat, open-world):
+ *        components:
+ *          button-primary: { backgroundColor: ... }
+ *   2. Registry + definitions (closed-world):
+ *        components:
+ *          registry:
+ *            - name: button-primary
+ *              kind: button
+ *          definitions:
+ *            button-primary: { backgroundColor: ... }
+ *
+ * Shape detection: presence of a top-level `registry` key (whose value is an
+ * array) selects the closed-world form. Anything else falls through to the
+ * flat form.
+ */
+function normalizeComponents(raw: unknown): {
+  components: Record<string, Record<string, string>> | undefined;
+  componentRegistry: RawRegistryEntry[] | undefined;
+} {
+  if (!raw || typeof raw !== 'object') {
+    return { components: undefined, componentRegistry: undefined };
+  }
+  const obj = raw as Record<string, unknown>;
+  const hasRegistry = Array.isArray(obj['registry']);
+  if (!hasRegistry) {
+    return {
+      components: obj as Record<string, Record<string, string>>,
+      componentRegistry: undefined,
+    };
+  }
+  const registry = (obj['registry'] as unknown[]).filter(
+    (e): e is Record<string, unknown> => !!e && typeof e === 'object'
+  ).map((e): RawRegistryEntry => {
+    const entry: RawRegistryEntry = {
+      name: typeof e['name'] === 'string' ? e['name'] : '',
+    };
+    if (typeof e['kind'] === 'string') entry.kind = e['kind'];
+    if (typeof e['interactive'] === 'boolean') entry.interactive = e['interactive'];
+    if (Array.isArray(e['requiredProperties'])) {
+      entry.requiredProperties = (e['requiredProperties'] as unknown[]).filter(
+        (x): x is string => typeof x === 'string'
+      );
+    }
+    if (typeof e['composes'] === 'string') entry.composes = e['composes'];
+    return entry;
+  }).filter(e => e.name.length > 0);
+
+  const definitions = obj['definitions'] && typeof obj['definitions'] === 'object'
+    ? (obj['definitions'] as Record<string, Record<string, string>>)
+    : {};
+
+  return { components: definitions, componentRegistry: registry };
 }

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -70,6 +70,22 @@ export interface RawPairDef {
 
 export type RawColorValue = string | RawRampDef | RawPairDef;
 
+/**
+ * A registry entry — the closed-world declaration that a component name is part
+ * of the design system. Adding an entry is a deliberate, reviewable act.
+ */
+export interface RawRegistryEntry {
+  name: string;
+  /** Component kind (button, input, container, etc.). Drives default behaviors. */
+  kind?: string;
+  /** Override the kind's default interactivity. */
+  interactive?: boolean;
+  /** Properties the matching definition must set. */
+  requiredProperties?: string[];
+  /** Pre-merge another entry's definition before resolving overrides. */
+  composes?: string;
+}
+
 /** Raw, unresolved parsed output — mirrors the YAML schema */
 export interface ParsedDesignSystem {
   name?: string | undefined;
@@ -85,6 +101,12 @@ export interface ParsedDesignSystem {
    */
   elevation?: Record<string, string> | undefined;
   components?: Record<string, Record<string, string>> | undefined;
+  /**
+   * Closed-world registry of component names. When present, every entry in
+   * `components` (the definitions) must correspond to a registry entry.
+   * Absent = open-world (back-compat) behavior.
+   */
+  componentRegistry?: RawRegistryEntry[] | undefined;
   sourceMap: Map<string, SourceLocation>;
   /** Markdown heading names found in the document (e.g., 'Colors', 'Typography') */
   sections?: string[] | undefined;

--- a/packages/cli/src/linter/spec-config.ts
+++ b/packages/cli/src/linter/spec-config.ts
@@ -38,6 +38,11 @@ const PropertyDefSchema = z.object({
   description: z.string().optional(),
 });
 
+const ComponentKindSchema = z.object({
+  name: z.string(),
+  interactive: z.boolean(),
+});
+
 const ConfigSchema = z.object({
   version: z.string(),
   units: z.array(z.string()).min(1),
@@ -48,6 +53,8 @@ const ConfigSchema = z.object({
   typography_properties: z.array(PropertyDefSchema).min(1),
   component_sub_tokens: z.array(PropertyDefSchema).min(1),
   color_roles: z.array(z.string()).min(1),
+  component_kinds: z.array(ComponentKindSchema).min(1),
+  component_modifiers: z.array(z.string()).min(1),
   recommended_tokens: z.record(z.string(), z.array(z.string())),
   examples: z.object({
     colors: z.record(z.string(), z.string()),
@@ -109,6 +116,13 @@ export interface ComponentSubTokenDef {
   description?: string | undefined;
 }
 
+export interface ComponentKindDef {
+  /** Kind name (e.g., 'button', 'container'). */
+  name: string;
+  /** Whether components of this kind are interactive by default. */
+  interactive: boolean;
+}
+
 // ── Constant exports ─────────────────────────────────────────────────
 // These are eagerly initialized from the lazy singleton on first import.
 // The singleton cache ensures the YAML file is read exactly once.
@@ -130,6 +144,20 @@ export const COMPONENT_SUB_TOKENS: readonly ComponentSubTokenDef[] = config.comp
 
 /** Core color roles that every design system should define. */
 export const CORE_COLOR_ROLES = config.color_roles;
+
+/** Component kinds (button, container, etc.) and their default interactivity. */
+export const COMPONENT_KINDS: readonly ComponentKindDef[] = config.component_kinds;
+
+/** Set of valid kind names. */
+export const VALID_COMPONENT_KINDS: readonly string[] = COMPONENT_KINDS.map(k => k.name);
+
+/** Per-kind defaults, indexed by name. */
+export const KIND_DEFAULTS: Record<string, { interactive: boolean }> = Object.fromEntries(
+  COMPONENT_KINDS.map(k => [k.name, { interactive: k.interactive }])
+);
+
+/** Closed set of permitted name modifiers (the `-modifier` suffix in `noun-modifier`). */
+export const COMPONENT_MODIFIERS: readonly string[] = config.component_modifiers;
 
 /** Non-normative recommended token names, organized by category. */
 export const RECOMMENDED_TOKENS = config.recommended_tokens;
@@ -170,6 +198,8 @@ export interface SpecConfig {
   TYPOGRAPHY_PROPERTIES: typeof TYPOGRAPHY_PROPERTIES;
   COMPONENT_SUB_TOKENS: typeof COMPONENT_SUB_TOKENS;
   CORE_COLOR_ROLES: typeof CORE_COLOR_ROLES;
+  COMPONENT_KINDS: typeof COMPONENT_KINDS;
+  COMPONENT_MODIFIERS: typeof COMPONENT_MODIFIERS;
   RECOMMENDED_TOKENS: typeof RECOMMENDED_TOKENS;
   EXAMPLES: typeof EXAMPLES;
 }
@@ -182,6 +212,8 @@ export const SPEC_CONFIG: SpecConfig = {
   TYPOGRAPHY_PROPERTIES,
   COMPONENT_SUB_TOKENS,
   CORE_COLOR_ROLES,
+  COMPONENT_KINDS,
+  COMPONENT_MODIFIERS,
   RECOMMENDED_TOKENS,
   EXAMPLES,
 };

--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -108,6 +108,48 @@ color_roles:
   - tertiary
   - neutral
 
+# Component kinds drive default behaviors (e.g., interactivity, required states).
+# Adding a new kind = add it here; rules and exporters read this list.
+component_kinds:
+  - name: button
+    interactive: true
+  - name: input
+    interactive: true
+  - name: navigation
+    interactive: true
+  - name: container
+    interactive: false
+  - name: display
+    interactive: false
+  - name: overlay
+    interactive: false
+
+# Modifiers permitted in `noun-modifier` component names. The `naming-convention`
+# rule treats anything else after the first hyphen as a candidate violation.
+component_modifiers:
+  # Style modifiers
+  - primary
+  - secondary
+  - tertiary
+  - danger
+  - ghost
+  - outline
+  - subtle
+  - bare
+  - elevated
+  # Interaction states
+  - hover
+  - focus
+  - active
+  - disabled
+  # Input types — `input-text`, `input-number`, etc. form a closed set
+  # mirroring HTML input types.
+  - text
+  - number
+  - email
+  - password
+  - search
+
 # Color value shapes
 # ──────────────────
 # In addition to a flat hex (`primary: "#1A1C1E"`), `colors` accepts two

--- a/packages/cli/src/linter/spec-gen/spec.mdx
+++ b/packages/cli/src/linter/spec-gen/spec.mdx
@@ -296,6 +296,67 @@ shape; the prose carries the rationale. Cover at least:
   Borders should not be the primary visual identity of a surface —
   reach for color or elevation first.
 
+### Component Registry (Closed-World)
+
+By default, the components map is **open-world**: any component name is
+accepted and the linter will not complain. To opt into a closed set —
+the equivalent of TypeScript's `noImplicitAny` for components — split
+the components block into a `registry` (the catalog) and `definitions`
+(the values):
+
+```yaml
+components:
+  registry:
+    - name: button-primary
+      kind: button
+      requiredProperties: [backgroundColor, padding]
+    - name: card
+      kind: container
+    - name: card-elevated
+      kind: container
+      composes: card           # pre-merge card's props before overrides
+  definitions:
+    button-primary:
+      backgroundColor: "{colors.primary}"
+      padding: 12px
+    card:
+      backgroundColor: "{colors.surface}"
+    card-elevated:
+      shadow: "{elevation.raised}"
+```
+
+Once a registry is declared, the closed-world rules engage:
+
+- **`unbound-component`** (error) — flags definitions and prose
+  `{components.X}` references whose name isn't in the registry.
+- **`missing-required-property`** (error) — a registry entry's
+  `requiredProperties` must each be set by the matching definition
+  (composed properties count).
+- **`registry-without-definition`** (warning) — a registry entry has no
+  matching definition.
+- **`composes-cycle`** (error) — cycles in the `composes:` graph.
+- **`naming-convention`** (warning) — registry names follow
+  `noun-modifier` ordering with a closed modifier vocabulary
+  (primary/secondary/tertiary/danger/ghost/outline/subtle/bare/elevated/
+  hover/focus/active/disabled).
+
+**Authoring discipline.** Adding a registry entry is a deliberate,
+reviewable act. Definitions can be added or edited freely; only the
+registry edit signals "this system now supports a new component". When
+in doubt, prefer composing existing components (Card with an Image
+inside) over inventing a new one — the registry should grow slowly.
+
+**Variant vs new component.** If two components differ only in color or
+size, they're variants — express the difference via a hover/focus/etc.
+state on a single registry entry, not a separate name. If they differ in
+structure (slots, behavior, role), they're new components and warrant
+their own entry.
+
+**Anti-patterns.** `card-with-image`, `button-but-rounded`, `header-v2`
+— all signals that variants or composition are missing. The naming and
+composition rules above will flag the symptom; the prose explains the
+cure.
+
 ## Do's and Don'ts
 
 This section provides practical guidelines and common pitfalls. These act as guardrails when creating designs.


### PR DESCRIPTION
Closes the open-world component schema with an opt-in registry per the design doc in #6.

## Summary

When the `components:` block uses the new `registry: + definitions:` shape, five new rules engage:

- **`unbound-component`** (error) — flags definitions and `{components.X}` prose references whose name isn't in the registry.
- **`missing-required-property`** (error) — `requiredProperties` on a registry entry must be set by the matching definition; composed properties count.
- **`registry-without-definition`** (warning) — registry entries without a matching definition.
- **`composes-cycle`** (error) — cycles in the `composes:` graph.
- **`naming-convention`** (warning) — registry names follow `noun-modifier` with a closed modifier vocabulary.

The flat `components:` shape continues to work unchanged — the registry is fully opt-in. Adds:

- `kind` (button/input/container/display/navigation/overlay) which drives default interactivity.
- `composes:` for property pre-merge before child overrides.
- `requiredProperties:` per registry entry.
- A documented modifier vocabulary surfaced from `spec-config.yaml`.

## What's not in this PR

The design doc lists six rollout phases. This PR delivers phases 1–3 (schema, model, the five rules). Deferred for follow-ups:

- Phase 4 — bulk migration of `examples/atmospheric-glass`, `paws-and-paths`, `totality-festival` to the registry shape (mechanical, scriptable per the doc).
- Phase 5 — `--src <glob>` source-file scanner (TSX/JSX/HTML/Vue).
- Phase 6 — Tailwind plugin emission and DTCG `$extensions['design.md'].registry` additions.

A `REGISTRY.md` fixture and end-to-end fixture test demonstrate the closed-world shape.

## Test plan

- [x] `bun test` — 357 pass (was 323 + 34 new tests across 6 files)
- [x] `bun run src/index.ts lint REGISTRY.md` — zero errors/warnings
- [x] `bun run src/index.ts lint examples/atmospheric-glass/DESIGN.md` — back-compat: zero new errors (open-world rules dormant when no registry is declared)
- [x] `bun run spec:gen` — `docs/spec.md` regenerates with the new Components subsection

https://claude.ai/code/session_01JHvRnaKUAmj3qJFTfNm8fJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHvRnaKUAmj3qJFTfNm8fJ)_