### PR TITLE
feat(themes): first-class theme primitive (dark / high-contrast / density)

### DIFF
--- a/examples/paws-and-paths/DESIGN.md
+++ b/examples/paws-and-paths/DESIGN.md
@@ -235,6 +235,69 @@ components:
     rounded: "{rounded.full}"
     padding: "{spacing.xs}"
     iconSize: "{iconography.sizes.sm}"
+themes:
+  dark:
+    description: "Evening walk: orange recedes, deep night-blue carries the surface, and golden retriever orange shifts to a desaturated container step so it sits well against the dark canvas."
+    colors:
+      surface: "#0f1420"
+      surface-dim: "#0a0e18"
+      surface-bright: "#1c2230"
+      surface-container-lowest: "#070a12"
+      surface-container-low: "#141a26"
+      surface-container: "#1a2030"
+      surface-container-high: "#212838"
+      surface-container-highest: "#2a3142"
+      on-surface: "#e7ecf8"
+      on-surface-variant: "#bfbab2"
+      inverse-surface: "#e7ecf8"
+      inverse-on-surface: "#151c27"
+      outline: "#9c8a76"
+      outline-variant: "#574a3c"
+      surface-tint: "#ffb95f"
+      primary: "#ffb95f"
+      on-primary: "#3d2400"
+      primary-container: "#5b3500"
+      on-primary-container: "#ffddb8"
+      inverse-primary: "#855300"
+      secondary: "#adc6ff"
+      on-secondary: "#001a42"
+      secondary-container: "#003a89"
+      on-secondary-container: "#d8e2ff"
+      tertiary: "#7fd0ff"
+      on-tertiary: "#001e2d"
+      tertiary-container: "#004966"
+      on-tertiary-container: "#c5e7ff"
+      error: "#ffb4ab"
+      on-error: "#690005"
+      error-container: "#93000a"
+      on-error-container: "#ffdad6"
+      primary-fixed: "#ffddb8"
+      primary-fixed-dim: "#ffb95f"
+      on-primary-fixed: "#2a1700"
+      on-primary-fixed-variant: "#653e00"
+      secondary-fixed: "#d8e2ff"
+      secondary-fixed-dim: "#adc6ff"
+      on-secondary-fixed: "#001a42"
+      on-secondary-fixed-variant: "#004395"
+      tertiary-fixed: "#c5e7ff"
+      tertiary-fixed-dim: "#7fd0ff"
+      on-tertiary-fixed: "#001e2d"
+      on-tertiary-fixed-variant: "#004c6a"
+      background: "#0f1420"
+      on-background: "#e7ecf8"
+      surface-variant: "#2a3142"
+    elevation:
+      # Dark surfaces lift via lighter color, not darker shadows. Shadows still
+      # ground the element against scroll edges, but the surface tint does
+      # most of the elevation work.
+      resting: "0 1px 2px rgba(0,0,0,0.45)"
+      raised: "0 4px 12px rgba(0,0,0,0.55)"
+      overlay: "0 12px 24px rgba(0,0,0,0.65)"
+      modal: "0 24px 48px rgba(0,0,0,0.75)"
+    contrastTarget:
+      body: 4.5
+      large: 3
+      ui: 3
 ---
 
 ## Brand & Style
@@ -259,6 +322,17 @@ This design system utilizes **Plus Jakarta Sans** for its friendly, rounded term
 - **Headlines:** Bold weights are used to create a clear hierarchy and guide the eye quickly to key information.
 - **Body:** Generous line heights are applied to the body text to maintain the "premium and clean" feel.
 - **Labels:** Used for buttons and small metadata, utilizing a medium or semi-bold weight to remain distinct even at small scales.
+
+## Themes
+
+Paws & Paths ships with a single base palette (the `light` mode) and a `dark` mode counterpart for evening walks and OS-level dark preferences. Themes here are alternate values, not alternate brands — the personality, type family, and shape language stay constant.
+
+- **Don't invert, reconsider.** The dark mode is not "light with inverted colors." Surfaces *lift* via lighter color steps (e.g., `surface-container-high` is paler than `surface`) instead of stacking deeper shadows. The Golden Retriever orange recedes to a desaturated container step (`#5b3500`) — fully-saturated `#855300` would vibrate against the deep navy backgrounds.
+- **Contrast targets that hold across themes.** Both themes target WCAG AA (`body: 4.5`, `large: 3`, `ui: 3`). The `contrast-ratio` rule runs per theme; a dark-only state that drops below the body floor surfaces explicitly with the theme name in the diagnostic.
+<!-- design.md disable-next-line prose-token-mismatch -->
+- **Saturation discipline in dark mode.** Use `primary-container` / `on-primary-container` for dark backgrounds and accents; reserve the bare `primary` (now `#ffb95f`) for elements that want to read as "lit from above," not as a saturated brand mark.
+- **High-contrast (future).** A high-contrast theme would inherit from `light`, set `contrastTarget.body` to 7, strip decorative shadows from `elevation.resting`, and replace tonal hover affordances with explicit borders. Adding it is a follow-up — themes are expensive (every component is reviewed in every theme) and we add them only when the use case is durable.
+- **When to add a theme.** Themes are durable identity surfaces (light vs. dark, normal vs. high-contrast, comfortable vs. compact density). Never per-customer or per-campaign — those belong elsewhere.
 
 ## Layout & Spacing
 

--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -89,6 +89,6 @@ describe('spec command', () => {
     const output = JSON.parse(outputStr);
     expect(output.spec).toBeDefined();
     expect(output.rules).toBeDefined();
-    expect(output.rules.length).toBe(30);
+    expect(output.rules.length).toBe(32);
   });
 });

--- a/packages/cli/src/linter/dtcg/handler.test.ts
+++ b/packages/cli/src/linter/dtcg/handler.test.ts
@@ -29,6 +29,8 @@ function emptyState(overrides?: Partial<DesignSystemState>): DesignSystemState {
     components: new Map(),
     colorRamps: new Map(),
     colorPairs: new Map(),
+    themes: new Map(),
+    activeTheme: 'light',
     symbolTable: new Map(),
     colorIndex: new Map(),
     ...overrides,
@@ -233,6 +235,8 @@ describe('DtcgEmitterHandler', () => {
       resolvedStates,
       unresolvedRefs: [],
       referencedTokens: [],
+      propertyRefs: new Map(),
+      stateRefs: new Map(),
     };
 
     const state = emptyState({

--- a/packages/cli/src/linter/fixture.test.ts
+++ b/packages/cli/src/linter/fixture.test.ts
@@ -145,6 +145,49 @@ describe('Fixture Test', () => {
     expect(colors['primary-container']).toBeDefined();
   });
 
+  it('processes THEMES.md with light/dark/high-contrast theme views', () => {
+    const path = join(import.meta.dir, 'fixtures', 'THEMES.md');
+    const content = readFileSync(path, 'utf-8');
+    const result = lint(content);
+
+    const ds = result.designSystem;
+
+    // Three theme views: implicit light + declared dark + high-contrast.
+    expect(ds.themes.size).toBe(3);
+    expect(ds.themes.has('light')).toBe(true);
+    expect(ds.themes.has('dark')).toBe(true);
+    expect(ds.themes.has('high-contrast')).toBe(true);
+    expect(ds.activeTheme).toBe('light');
+
+    // Light view mirrors the root token tree.
+    const light = ds.themes.get('light')!;
+    expect(light.colors.get('primary')?.hex).toBe('#3b82f6');
+    expect(light.contrastTarget).toEqual({ body: 4.5, large: 3, ui: 3 });
+
+    // Dark view replaces the primary ramp cleanly — anchor + steps update.
+    const dark = ds.themes.get('dark')!;
+    expect(dark.colors.get('primary')?.hex).toBe('#a3c9ff');
+    expect(dark.colors.get('primary.500')?.hex).toBe('#a3c9ff');
+    expect(dark.colors.get('surface')?.hex).toBe('#0b1220');
+    // Re-declared inline pair on the ramp also lives in the theme view.
+    expect(dark.colors.get('primary-container')).toBeDefined();
+
+    // High-contrast view raises the body contrast floor to AAA.
+    const hc = ds.themes.get('high-contrast')!;
+    expect(hc.contrastTarget.body).toBe(7);
+    expect(hc.contrastTarget.ui).toBe(4.5);
+
+    // Tailwind exporter surfaces dark + high-contrast as additional themes.
+    if (!result.tailwindConfig.success) throw new Error('Tailwind emit failed');
+    const themes = result.tailwindConfig.data.themes!;
+    expect(themes['dark']?.colors['surface']).toBe('#0b1220');
+    expect(themes['high-contrast']?.contrastTarget?.body).toBe(7);
+
+    // Lint runs end-to-end without errors.
+    const errors = result.findings.filter(d => d.severity === 'error');
+    expect(errors).toEqual([]);
+  });
+
   it('processes MOTION_AND_ICONS.md end-to-end', () => {
     const path = join(import.meta.dir, 'fixtures', 'MOTION_AND_ICONS.md');
     const content = readFileSync(path, 'utf-8');

--- a/packages/cli/src/linter/fixtures/THEMES.md
+++ b/packages/cli/src/linter/fixtures/THEMES.md
@@ -1,0 +1,96 @@
+---
+name: Themes Demo
+colors:
+  primary:
+    type: ramp
+    anchor: "#3b82f6"
+    humanName: "Ocean"
+    description: "Driver for interaction."
+    pairs:
+      container: { bg: 100, fg: 800 }
+  surface: "#FFFFFF"
+  on-surface: "#0F172A"
+  surface-info:
+    type: pair
+    container: "#E0F2FE"
+    onContainer: "#0C4A6E"
+typography:
+  body-md:
+    fontFamily: Public Sans
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.6
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.surface}"
+    rounded: 4px
+    padding: 12px
+  callout-info:
+    backgroundColor: "{colors.surface-info}"
+    textColor: "{colors.on-surface-info}"
+    padding: 16px
+themes:
+  dark:
+    description: "Dark counterpart with surface tinted up via lighter color steps."
+    colors:
+      primary:
+        type: ramp
+        anchor: "#A3C9FF"
+        humanName: "Sky"
+        pairs:
+          container: { bg: 700, fg: 100 }
+      surface: "#0B1220"
+      on-surface: "#E2E8F0"
+      surface-info:
+        type: pair
+        container: "#1B3A5F"
+        onContainer: "#A3C9FF"
+  high-contrast:
+    inheritsFrom: light
+    description: "Authored on top of light; raises the contrast floor to AAA."
+    colors:
+      primary:
+        type: ramp
+        anchor: "#000000"
+        humanName: "True Black"
+        pairs:
+          container: { bg: 900, fg: 50 }
+      surface: "#FFFFFF"
+      on-surface: "#000000"
+      surface-info:
+        type: pair
+        container: "#FFFFFF"
+        onContainer: "#000000"
+        minContrast: 7
+    contrastTarget:
+      body: 7
+      large: 4.5
+      ui: 4.5
+---
+
+## Overview
+Demonstrates `themes:` with dark and high-contrast variants on top of an
+implicit `light` base.
+
+## Colors
+A single base palette. Themes layer overrides on top.
+
+## Typography
+Body text only.
+
+## Themes
+- **Don't invert, reconsider** — the dark theme lifts surfaces via lighter
+  color steps rather than inverting brightness.
+- **Contrast targets that hold across themes** — light/dark target WCAG AA;
+  high-contrast targets AAA.
+- **Saturation discipline in dark mode** — the dark `primary` ramp anchors
+  at a desaturated step (`#A3C9FF`), not at the original brand 500.
+- **Density mode use cases** — not declared here; the example focuses on
+  color modes only.
+- **High-contrast is not a visual style** — it raises the contrast floor and
+  swaps decorative surfaces for explicit boundaries.
+- **When to add a theme** — durable identity surfaces only.
+
+## Components
+A primary button and an info callout.

--- a/packages/cli/src/linter/linter/rules/contrast-ratio.test.ts
+++ b/packages/cli/src/linter/linter/rules/contrast-ratio.test.ts
@@ -39,4 +39,53 @@ describe('contrastCheck', () => {
     const contrastWarnings = contrastCheck(state).filter(d => d.message.includes('contrast'));
     expect(contrastWarnings.length).toBe(0);
   });
+
+  it('warns when a theme override breaks contrast for an inherited component', () => {
+    const state = buildState({
+      // Light: black-on-white passes.
+      colors: { primary: '#000000', 'on-primary': '#ffffff' },
+      components: {
+        'button-primary': {
+          backgroundColor: '{colors.primary}',
+          textColor: '{colors.on-primary}',
+        },
+      },
+      themes: {
+        // Dark theme overrides primary to a low-contrast pairing.
+        dark: { colors: { primary: '#dddddd', 'on-primary': '#cccccc' } },
+      },
+    });
+
+    const findings = contrastCheck(state);
+    // Light theme is clean; dark theme fires.
+    const lightFindings = findings.filter(f => !f.message.includes("theme 'dark'"));
+    const darkFindings = findings.filter(f => f.message.includes("theme 'dark'"));
+    expect(lightFindings.length).toBe(0);
+    expect(darkFindings.length).toBe(1);
+    expect(darkFindings[0]!.path).toBe('components.button-primary');
+  });
+
+  it('respects per-theme contrastTarget — high-contrast theme requires AAA-style ratios', () => {
+    // 4.5:1 passes WCAG AA but fails AAA (7:1).
+    const state = buildState({
+      colors: { primary: '#767676', 'on-primary': '#ffffff' },
+      components: {
+        'button-primary': {
+          backgroundColor: '{colors.primary}',
+          textColor: '{colors.on-primary}',
+        },
+      },
+      themes: {
+        'high-contrast': {
+          colors: { primary: '#767676', 'on-primary': '#ffffff' },
+          contrastTarget: { body: 7, large: 4.5, ui: 4.5 },
+        },
+      },
+    });
+
+    const findings = contrastCheck(state);
+    // Light theme passes AA. High-contrast fails AAA target.
+    expect(findings.some(f => f.message.includes("theme 'high-contrast'"))).toBe(true);
+    expect(findings.some(f => !f.message.includes("theme '") && f.path === 'components.button-primary')).toBe(false);
+  });
 });

--- a/packages/cli/src/linter/linter/rules/contrast-ratio.ts
+++ b/packages/cli/src/linter/linter/rules/contrast-ratio.ts
@@ -12,54 +12,97 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { DesignSystemState, ResolvedColor, ResolvedValue } from '../../model/spec.js';
+import type { ComponentDef, DesignSystemState, ResolvedColor, ResolvedValue, ThemeView } from '../../model/spec.js';
 import { contrastRatio } from '../../model/handler.js';
+import { BASE_THEME_NAME } from '../../spec-config.js';
 import type { RuleDescriptor, RuleFinding } from './types.js';
 
 const WCAG_AA_MINIMUM = 4.5;
 
 /**
- * WCAG contrast ratio — warns when component backgroundColor/textColor pairs
- * fall below the AA minimum of 4.5:1, including for each per-state override.
- * A button whose `disabled` state drops to 2.5:1 will warn.
+ * WCAG contrast ratio — for every component's backgroundColor/textColor
+ * pair, verify the ratio meets the active theme's contrast target. When
+ * additional themes are declared, the same check runs per theme so a
+ * dark or high-contrast theme that breaks contrast surfaces explicitly.
+ *
+ * Per-theme target defaults to WCAG AA (4.5:1) but is configurable via
+ * `themes.<name>.contrastTarget.body`.
  */
 export function contrastCheck(state: DesignSystemState): RuleFinding[] {
   const findings: RuleFinding[] = [];
-  for (const [compName, comp] of state.components) {
-    checkPair(compName, null, comp.properties, findings);
-    for (const [stateName, props] of comp.resolvedStates) {
-      checkPair(compName, stateName, props, findings);
+  for (const [themeName, theme] of state.themes) {
+    for (const [compName, comp] of state.components) {
+      // Base properties.
+      checkPair(themeName, theme, compName, null, comp, comp.properties, findings);
+      // Per-state overrides — re-resolve through the theme view so a
+      // hover state that references `{colors.primary}` picks up the
+      // theme-scoped value.
+      for (const [stateName, props] of comp.resolvedStates) {
+        checkPair(themeName, theme, compName, stateName, comp, props, findings);
+      }
     }
   }
   return findings;
 }
 
 function checkPair(
+  themeName: string,
+  theme: ThemeView,
   compName: string,
   stateName: string | null,
+  comp: ComponentDef,
   props: Map<string, ResolvedValue>,
   findings: RuleFinding[],
 ): void {
-  const bgValue = props.get('backgroundColor');
-  const textValue = props.get('textColor');
-  if (!bgValue || !textValue) return;
-
-  const bgColor = resolveToColor(bgValue);
-  const textColor = resolveToColor(textValue);
+  const bgColor = pickColor(theme, comp, props, 'backgroundColor', stateName);
+  const textColor = pickColor(theme, comp, props, 'textColor', stateName);
   if (!bgColor || !textColor) return;
 
+  const target = theme.contrastTarget.body;
   const ratio = contrastRatio(bgColor, textColor);
-  if (ratio >= WCAG_AA_MINIMUM) return;
+  if (ratio >= target) return;
 
-  const path = stateName ? `components.${compName}.states.${stateName}` : `components.${compName}`;
+  const path = stateName
+    ? `components.${compName}.states.${stateName}`
+    : `components.${compName}`;
   const where = stateName ? ` (${stateName} state)` : '';
+  const inTheme = themeName === BASE_THEME_NAME ? '' : ` in theme '${themeName}'`;
+  const targetSuffix = target === WCAG_AA_MINIMUM
+    ? `WCAG AA minimum of ${WCAG_AA_MINIMUM}:1`
+    : `theme '${themeName}' target of ${target}:1`;
   findings.push({
     path,
-    message: `textColor (${textColor.hex}) on backgroundColor (${bgColor.hex})${where} has contrast ratio ${ratio.toFixed(2)}:1, below WCAG AA minimum of ${WCAG_AA_MINIMUM}:1.`,
+    message:
+      `textColor (${textColor.hex}) on backgroundColor (${bgColor.hex})${where}${inTheme} ` +
+      `has contrast ratio ${ratio.toFixed(2)}:1, below ${targetSuffix}.`,
   });
 }
 
-function resolveToColor(value: ResolvedValue): ResolvedColor | null {
+/**
+ * Resolve a component property to a `ResolvedColor` through a theme view.
+ * Falls back to the base-resolved property when the theme doesn't carry a
+ * matching token reference (e.g., the component uses a literal hex).
+ */
+function pickColor(
+  theme: ThemeView,
+  comp: ComponentDef,
+  props: Map<string, ResolvedValue>,
+  propName: 'backgroundColor' | 'textColor',
+  stateName: string | null,
+): ResolvedColor | null {
+  // Per-theme refs: re-resolve through the theme's color map.
+  const ref = stateName
+    ? comp.stateRefs.get(stateName)?.get(propName) ?? comp.propertyRefs.get(propName)
+    : comp.propertyRefs.get(propName);
+  if (ref && ref.startsWith('colors.')) {
+    const themeColor = theme.colors.get(ref.slice('colors.'.length));
+    if (themeColor) return themeColor;
+  }
+  // Fall back to the base-resolved value.
+  return resolveToColor(props.get(propName));
+}
+
+function resolveToColor(value: ResolvedValue | undefined): ResolvedColor | null {
   if (typeof value === 'object' && value !== null && 'type' in value && value.type === 'color') {
     return value as ResolvedColor;
   }
@@ -69,6 +112,7 @@ function resolveToColor(value: ResolvedValue): ResolvedColor | null {
 export const contrastCheckRule: RuleDescriptor = {
   name: 'contrast-ratio',
   severity: 'warning',
-  description: 'WCAG contrast ratio — warns when component backgroundColor/textColor pairs fall below the AA minimum of 4.5:1.',
+  description:
+    'WCAG contrast ratio — warns when component backgroundColor/textColor pairs fall below each theme\'s contrast target.',
   run: contrastCheck,
 };

--- a/packages/cli/src/linter/linter/rules/index.ts
+++ b/packages/cli/src/linter/linter/rules/index.ts
@@ -34,6 +34,8 @@ import { animatingLayoutPropertyRule } from './animating-layout-property.js';
 import { elevationWithoutSemanticsRule } from './elevation-without-semantics.js';
 import { tripleSeparationRule } from './triple-separation.js';
 import { pairContrastRule } from './pair-contrast.js';
+import { themeParityRule } from './theme-parity.js';
+import { pairParityRule } from './pair-parity.js';
 import { mixedPairForegroundRule } from './mixed-pair-foreground.js';
 import { rampAnchorNamingRule } from './ramp-anchor-naming.js';
 import { proseTokenMismatchRule } from './prose-token-mismatch.js';
@@ -52,6 +54,8 @@ export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
   missingPrimaryRule,
   contrastCheckRule,
   pairContrastRule,
+  themeParityRule,
+  pairParityRule,
   mixedPairForegroundRule,
   rampAnchorNamingRule,
   orphanedTokensRule,
@@ -113,6 +117,8 @@ export { animatingLayoutProperty } from './animating-layout-property.js';
 export { elevationWithoutSemantics } from './elevation-without-semantics.js';
 export { tripleSeparation } from './triple-separation.js';
 export { pairContrast } from './pair-contrast.js';
+export { themeParity } from './theme-parity.js';
+export { pairParity } from './pair-parity.js';
 export { mixedPairForeground } from './mixed-pair-foreground.js';
 export { rampAnchorNaming } from './ramp-anchor-naming.js';
 export { proseTokenMismatch } from './prose-token-mismatch.js';

--- a/packages/cli/src/linter/linter/rules/pair-parity.test.ts
+++ b/packages/cli/src/linter/linter/rules/pair-parity.test.ts
@@ -1,0 +1,93 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { pairParity } from './pair-parity.js';
+import { buildState } from './test-helpers.js';
+
+describe('pairParity', () => {
+  it('returns no findings when no themes declare pair overrides', () => {
+    const state = buildState({
+      colors: {
+        'surface-info': { type: 'pair', container: '#E0F2FE', onContainer: '#0C4A6E' },
+      },
+    });
+    expect(pairParity(state)).toEqual([]);
+  });
+
+  it('does not warn when both halves of the pair are overridden in the theme', () => {
+    const state = buildState({
+      colors: {
+        'surface-info': { type: 'pair', container: '#E0F2FE', onContainer: '#0C4A6E' },
+      },
+      themes: {
+        dark: {
+          colors: {
+            'surface-info': { type: 'pair', container: '#1B3A5F', onContainer: '#A3C9FF' },
+          },
+        },
+      },
+    });
+    expect(pairParity(state)).toEqual([]);
+  });
+
+  it('warns when only the container is overridden', () => {
+    // Override only the bare flat alias — the on-* alias inherits.
+    const state = buildState({
+      colors: {
+        'surface-info': { type: 'pair', container: '#E0F2FE', onContainer: '#0C4A6E' },
+      },
+      themes: {
+        dark: {
+          colors: {
+            'surface-info': '#1B3A5F',
+          },
+        },
+      },
+    });
+    const findings = pairParity(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('themes.dark.colors.surface-info');
+    expect(findings[0]!.message).toContain('container');
+  });
+
+  it('warns when only the on-container is overridden', () => {
+    const state = buildState({
+      colors: {
+        'surface-info': { type: 'pair', container: '#E0F2FE', onContainer: '#0C4A6E' },
+      },
+      themes: {
+        dark: {
+          colors: { 'on-surface-info': '#FFFFFF' },
+        },
+      },
+    });
+    const findings = pairParity(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain('on-container');
+  });
+
+  it('does not warn when the theme leaves the pair entirely inherited', () => {
+    const state = buildState({
+      colors: {
+        primary: '#1A1C1E',
+        'surface-info': { type: 'pair', container: '#E0F2FE', onContainer: '#0C4A6E' },
+      },
+      themes: {
+        dark: { colors: { primary: '#A3C9FF' } },
+      },
+    });
+    expect(pairParity(state)).toEqual([]);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/pair-parity.ts
+++ b/packages/cli/src/linter/linter/rules/pair-parity.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import { BASE_THEME_NAME } from '../../spec-config.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Pair parity — when a theme overrides one half of a color pair but leaves
+ * the other half inherited, the pair's contrast contract is silently broken.
+ * Catches `dark.surface-info.container` being overridden while
+ * `dark.surface-info.onContainer` keeps the light value.
+ */
+export function pairParity(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  const base = state.themes.get(BASE_THEME_NAME);
+  if (!base) return findings;
+
+  for (const [themeName, theme] of state.themes) {
+    if (themeName === BASE_THEME_NAME) continue;
+
+    for (const [pairName, basePair] of base.colorPairs) {
+      const themePair = theme.colorPairs.get(pairName);
+      if (!themePair) continue;
+      const containerChanged = themePair.container.hex !== basePair.container.hex;
+      const onContainerChanged = themePair.onContainer.hex !== basePair.onContainer.hex;
+      if (containerChanged === onContainerChanged) continue;
+
+      const which = containerChanged ? 'container' : 'on-container';
+      const other = containerChanged ? 'on-container' : 'container';
+      findings.push({
+        path: `themes.${themeName}.colors.${pairName}`,
+        message:
+          `Pair '${pairName}' in theme '${themeName}' overrides the ${which} ` +
+          `but inherits the ${other} from the base. Override both halves of a pair together — ` +
+          `the contrast contract relies on it.`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+export const pairParityRule: RuleDescriptor = {
+  name: 'pair-parity',
+  severity: 'warning',
+  description:
+    'Pair parity — overriding half of a color pair across themes silently breaks the contrast contract.',
+  run: pairParity,
+};

--- a/packages/cli/src/linter/linter/rules/theme-parity.test.ts
+++ b/packages/cli/src/linter/linter/rules/theme-parity.test.ts
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { themeParity } from './theme-parity.js';
+import { buildState } from './test-helpers.js';
+
+describe('themeParity', () => {
+  it('returns no findings when no themes are declared', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', surface: '#FFFFFF' },
+    });
+    expect(themeParity(state)).toEqual([]);
+  });
+
+  it('warns when a theme inherits a base color silently', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', surface: '#FFFFFF', tertiary: '#B8422E' },
+      themes: {
+        dark: { colors: { primary: '#A3C9FF', surface: '#1A1C1E' } },
+      },
+    });
+
+    const findings = themeParity(state);
+    // `tertiary` is the only un-overridden base color.
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('themes.dark.colors.tertiary');
+  });
+
+  it('does not warn when every base color is explicitly overridden', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', surface: '#FFFFFF' },
+      themes: {
+        dark: { colors: { primary: '#A3C9FF', surface: '#1A1C1E' } },
+      },
+    });
+    expect(themeParity(state)).toEqual([]);
+  });
+
+  it('skips ramp step entries (parity is checked at the anchor)', () => {
+    const state = buildState({
+      colors: {
+        primary: { type: 'ramp', anchor: '#1A1C1E', humanName: 'Charcoal' },
+      },
+      themes: {
+        dark: {
+          colors: {
+            primary: { type: 'ramp', anchor: '#A3C9FF', humanName: 'Sky' },
+          },
+        },
+      },
+    });
+    expect(themeParity(state)).toEqual([]);
+  });
+
+  it('treats overriding a ramp-derived pair as covering the ramp anchor', () => {
+    const state = buildState({
+      colors: {
+        primary: {
+          type: 'ramp',
+          anchor: '#1A1C1E',
+          humanName: 'Charcoal',
+          pairs: { container: { bg: 100, fg: 800 } },
+        },
+      },
+      themes: {
+        // The author overrode `primary-container` (the derived pair) but not
+        // the bare `primary` anchor — that's intentional and should not warn.
+        dark: {
+          colors: {
+            'primary-container': {
+              type: 'pair',
+              container: '#0F2A52',
+              onContainer: '#A3C9FF',
+            },
+          },
+        },
+      },
+    });
+    expect(themeParity(state)).toEqual([]);
+  });
+
+  it('warns once per un-overridden base color across multiple themes', () => {
+    const state = buildState({
+      colors: { primary: '#1A1C1E', secondary: '#6C7278' },
+      themes: {
+        dark: { colors: { primary: '#A3C9FF' } },        // missing secondary
+        'high-contrast': { colors: { secondary: '#000000' } }, // missing primary
+      },
+    });
+
+    const findings = themeParity(state);
+    expect(findings.length).toBe(2);
+    expect(findings.some(f => f.path === 'themes.dark.colors.secondary')).toBe(true);
+    expect(findings.some(f => f.path === 'themes.high-contrast.colors.primary')).toBe(true);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/theme-parity.ts
+++ b/packages/cli/src/linter/linter/rules/theme-parity.ts
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import { BASE_THEME_NAME } from '../../spec-config.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Theme parity — for every declared theme, every semantic color in the base
+ * must be explicitly overridden (or explicitly re-stated with the same value).
+ * Catches the "added a new color, forgot to override it for dark mode"
+ * failure mode. Ramp steps and pair members are exempt — they expand from
+ * a single declaration, so the parity check applies to the anchor / pair
+ * name, not each derived entry.
+ */
+export function themeParity(state: DesignSystemState): RuleFinding[] {
+  const findings: RuleFinding[] = [];
+  const base = state.themes.get(BASE_THEME_NAME);
+  if (!base) return findings;
+
+  // Build the set of base "anchor" color names — exclude ramp steps and
+  // pair-derived members (they're parity-checked through their group).
+  const baseAnchorNames: string[] = [];
+  for (const [name, color] of base.colors) {
+    // Skip ramp steps (dotted form); the anchor lives at the bare name.
+    if (color.rampMember && color.rampMember.ramp !== name) continue;
+    // Skip dotted pair members (`pair.container`, `pair.onContainer`).
+    if (color.pairRole && name.includes('.')) continue;
+    // Skip the `on-<pair>` flat alias for standalone pairs — checking the
+    // bare pair name covers both members.
+    if (color.pairRole && color.pairRole.role === 'on-container' && name.startsWith('on-')) continue;
+    baseAnchorNames.push(name);
+  }
+
+  for (const [themeName, theme] of state.themes) {
+    if (themeName === BASE_THEME_NAME) continue;
+
+    for (const name of baseAnchorNames) {
+      if (theme.explicitColorOverrides.has(name)) continue;
+      // For ramp anchors, an override of any of the ramp's derived pair
+      // entries (e.g., `primary-container`) is sufficient — the author
+      // clearly thought about this group.
+      if (theme.explicitColorOverrides.has(`${name}-container`)) continue;
+
+      findings.push({
+        path: `themes.${themeName}.colors.${name}`,
+        message:
+          `Theme '${themeName}' inherits color '${name}' unchanged from the base. ` +
+          `Either override it for this theme or re-declare it with the same value to acknowledge the inheritance.`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+export const themeParityRule: RuleDescriptor = {
+  name: 'theme-parity',
+  severity: 'warning',
+  description:
+    'Theme parity — every base color must be explicitly overridden in each declared theme.',
+  run: themeParity,
+};

--- a/packages/cli/src/linter/linter/rules/types.test.ts
+++ b/packages/cli/src/linter/linter/rules/types.test.ts
@@ -29,6 +29,8 @@ describe('LintRule type', () => {
       components: new Map(),
       colorRamps: new Map(),
       colorPairs: new Map(),
+      themes: new Map(),
+      activeTheme: 'light',
       symbolTable: new Map(),
       colorIndex: new Map(),
     })).toEqual([]);
@@ -45,7 +47,7 @@ describe('LintRule type', () => {
   });
 
   it('has all rules in DEFAULT_RULE_DESCRIPTORS', () => {
-    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(30);
+    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(32);
     DEFAULT_RULE_DESCRIPTORS.forEach((rule: RuleDescriptor) => {
       expect(rule.name).toBeTruthy();
       expect(rule.severity).toBeTruthy();

--- a/packages/cli/src/linter/model/handler.themes.test.ts
+++ b/packages/cli/src/linter/model/handler.themes.test.ts
@@ -1,0 +1,245 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { ModelHandler } from './handler.js';
+import type { ParsedDesignSystem } from '../parser/spec.js';
+
+const handler = new ModelHandler();
+
+function makeParsed(overrides: Partial<ParsedDesignSystem> = {}): ParsedDesignSystem {
+  return { sourceMap: new Map(), ...overrides };
+}
+
+describe('ModelHandler — themes', () => {
+  it('always emits an implicit `light` base view that mirrors the root tokens', () => {
+    const result = handler.execute(makeParsed({
+      colors: { primary: '#1A1C1E', surface: '#FFFFFF' },
+    }));
+
+    expect(result.designSystem.activeTheme).toBe('light');
+    const light = result.designSystem.themes.get('light')!;
+    expect(light).toBeDefined();
+    expect(light.colors.get('primary')?.hex).toBe('#1a1c1e');
+    expect(light.colors.get('surface')?.hex).toBe('#ffffff');
+    // Default contrast target is WCAG AA.
+    expect(light.contrastTarget).toEqual({ body: 4.5, large: 3, ui: 3 });
+  });
+
+  it('builds a dark theme whose color overrides replace the base values', () => {
+    const result = handler.execute(makeParsed({
+      colors: { primary: '#1A1C1E', surface: '#FFFFFF' },
+      themes: {
+        dark: {
+          colors: { primary: '#A3C9FF', surface: '#1A1C1E' },
+        },
+      },
+    }));
+
+    const dark = result.designSystem.themes.get('dark')!;
+    expect(dark).toBeDefined();
+    expect(dark.colors.get('primary')?.hex).toBe('#a3c9ff');
+    expect(dark.colors.get('surface')?.hex).toBe('#1a1c1e');
+    // Top-level state still reflects the active (light) theme.
+    expect(result.designSystem.colors.get('primary')?.hex).toBe('#1a1c1e');
+  });
+
+  it('inherits non-overridden colors from the parent', () => {
+    const result = handler.execute(makeParsed({
+      colors: { primary: '#1A1C1E', secondary: '#6C7278', neutral: '#F7F5F2' },
+      themes: {
+        dark: { colors: { primary: '#A3C9FF' } },
+      },
+    }));
+
+    const dark = result.designSystem.themes.get('dark')!;
+    expect(dark.colors.get('primary')?.hex).toBe('#a3c9ff');
+    // Inherited from base.
+    expect(dark.colors.get('secondary')?.hex).toBe('#6c7278');
+    expect(dark.colors.get('neutral')?.hex).toBe('#f7f5f2');
+  });
+
+  it('supports per-theme contrast targets', () => {
+    const result = handler.execute(makeParsed({
+      colors: { primary: '#1A1C1E' },
+      themes: {
+        'high-contrast': {
+          colors: { primary: '#000000' },
+          contrastTarget: { body: 7, large: 4.5, ui: 4.5 },
+        },
+      },
+    }));
+
+    const hc = result.designSystem.themes.get('high-contrast')!;
+    expect(hc.contrastTarget).toEqual({ body: 7, large: 4.5, ui: 4.5 });
+  });
+
+  it('falls back to parent contrastTarget for unspecified fields', () => {
+    const result = handler.execute(makeParsed({
+      colors: { primary: '#1A1C1E' },
+      themes: {
+        dark: { colors: { primary: '#A3C9FF' }, contrastTarget: { body: 7 } },
+      },
+    }));
+
+    const dark = result.designSystem.themes.get('dark')!;
+    expect(dark.contrastTarget.body).toBe(7);
+    expect(dark.contrastTarget.large).toBe(3);
+    expect(dark.contrastTarget.ui).toBe(3);
+  });
+
+  it('resolves inheritsFrom chains (compact-dark inherits from dark)', () => {
+    const result = handler.execute(makeParsed({
+      colors: { primary: '#1A1C1E' },
+      spacing: { sm: '8px', md: '16px' },
+      themes: {
+        dark: { colors: { primary: '#A3C9FF' } },
+        'compact-dark': {
+          inheritsFrom: 'dark',
+          spacing: { sm: '4px', md: '12px' },
+        },
+      },
+    }));
+
+    const compactDark = result.designSystem.themes.get('compact-dark')!;
+    // Inherits primary from dark.
+    expect(compactDark.colors.get('primary')?.hex).toBe('#a3c9ff');
+    // Overrides spacing.
+    expect(compactDark.spacing.get('sm')?.value).toBe(4);
+    expect(compactDark.spacing.get('md')?.value).toBe(12);
+  });
+
+  it('warns and falls back to light when inheritsFrom names an undeclared theme', () => {
+    const result = handler.execute(makeParsed({
+      colors: { primary: '#1A1C1E' },
+      themes: {
+        weird: { inheritsFrom: 'nonexistent', colors: { primary: '#FF00FF' } },
+      },
+    }));
+
+    expect(result.findings.some(f =>
+      f.severity === 'warning' && f.path === 'themes.weird.inheritsFrom'
+    )).toBe(true);
+    const weird = result.designSystem.themes.get('weird')!;
+    expect(weird.colors.get('primary')?.hex).toBe('#ff00ff');
+  });
+
+  it('breaks cyclic inheritsFrom chains gracefully', () => {
+    const result = handler.execute(makeParsed({
+      colors: { primary: '#1A1C1E' },
+      themes: {
+        a: { inheritsFrom: 'b', colors: { primary: '#FF0000' } },
+        b: { inheritsFrom: 'a', colors: { primary: '#00FF00' } },
+      },
+    }));
+
+    expect(result.findings.some(f => f.message.includes('cyclic'))).toBe(true);
+    expect(result.designSystem.themes.has('a')).toBe(true);
+    expect(result.designSystem.themes.has('b')).toBe(true);
+  });
+
+  it('expands ramps declared per theme and replaces the parent ramp cleanly', () => {
+    const result = handler.execute(makeParsed({
+      colors: {
+        primary: { type: 'ramp', anchor: '#1A1C1E', humanName: 'Charcoal' },
+      },
+      themes: {
+        dark: {
+          colors: {
+            primary: { type: 'ramp', anchor: '#A3C9FF', humanName: 'Sky' },
+          },
+        },
+      },
+    }));
+
+    const light = result.designSystem.themes.get('light')!;
+    const dark = result.designSystem.themes.get('dark')!;
+    // Both views have a primary ramp at step 500 (= the anchor) but with
+    // different hex values.
+    expect(light.colors.get('primary')?.hex).toBe('#1a1c1e');
+    expect(dark.colors.get('primary')?.hex).toBe('#a3c9ff');
+    expect(light.colors.get('primary.500')?.hex).toBe('#1a1c1e');
+    expect(dark.colors.get('primary.500')?.hex).toBe('#a3c9ff');
+    // The dark ramp definition replaces the light one in the dark view.
+    expect(dark.colorRamps.get('primary')?.anchor.hex).toBe('#a3c9ff');
+  });
+
+  it('expands inline-pair derivations declared per theme', () => {
+    const result = handler.execute(makeParsed({
+      colors: { surface: '#FFFFFF' },
+      themes: {
+        dark: {
+          colors: {
+            'surface-info': {
+              type: 'pair',
+              container: '#1B3A5F',
+              onContainer: '#A3C9FF',
+            },
+          },
+        },
+      },
+    }));
+
+    const dark = result.designSystem.themes.get('dark')!;
+    expect(dark.colors.get('surface-info')?.hex).toBe('#1b3a5f');
+    expect(dark.colors.get('on-surface-info')?.hex).toBe('#a3c9ff');
+    expect(dark.colorPairs.get('surface-info')).toBeDefined();
+  });
+
+  it('overrides typography properties as a property merge, not a replacement', () => {
+    const result = handler.execute(makeParsed({
+      typography: {
+        'body-md': { fontFamily: 'Inter', fontSize: '16px', fontWeight: 400 },
+      },
+      themes: {
+        comfortable: {
+          typography: { 'body-md': { fontSize: '17px' } },
+        },
+      },
+    }));
+
+    const comfortable = result.designSystem.themes.get('comfortable')!;
+    const bodyMd = comfortable.typography.get('body-md')!;
+    expect(bodyMd.fontSize?.value).toBe(17);
+    // Inherited from base.
+    expect(bodyMd.fontFamily).toBe('Inter');
+    expect(bodyMd.fontWeight).toBe(400);
+  });
+
+  it('emits an error finding for invalid hex values in a theme override', () => {
+    const result = handler.execute(makeParsed({
+      colors: { primary: '#1A1C1E' },
+      themes: {
+        dark: { colors: { primary: 'not-a-color' } },
+      },
+    }));
+
+    const errors = result.findings.filter(f =>
+      f.severity === 'error' && f.path === 'themes.dark.colors.primary'
+    );
+    expect(errors.length).toBe(1);
+  });
+
+  it('lets a `themes.light` block layer overrides on the implicit base', () => {
+    const result = handler.execute(makeParsed({
+      colors: { primary: '#1A1C1E' },
+      themes: {
+        light: { colors: { primary: '#647D66' } },
+      },
+    }));
+
+    const light = result.designSystem.themes.get('light')!;
+    expect(light.colors.get('primary')?.hex).toBe('#647d66');
+  });
+});

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { ParsedDesignSystem, RawColorValue, RawRampDef, RawPairDef, RawMotionDef, RawIconographyDef, RawRegistryEntry, RawComponentValue } from '../parser/spec.js';
+import type { ParsedDesignSystem, RawColorValue, RawRampDef, RawPairDef, RawMotionDef, RawIconographyDef, RawRegistryEntry, RawComponentValue, RawThemeDef } from '../parser/spec.js';
 import type {
   ModelSpec,
   ModelResult,
@@ -31,7 +31,11 @@ import type {
   MotionState,
   IconographyState,
   RegistryEntry,
+  ThemeView,
+  ThemeContrastTarget,
 } from './spec.js';
+import { DEFAULT_CONTRAST_TARGET } from './spec.js';
+import { BASE_THEME_NAME } from '../spec-config.js';
 
 import {
   isValidColor,
@@ -267,6 +271,8 @@ export class ModelHandler implements ModelSpec {
           const resolvedStates = new Map<string, Map<string, ResolvedValue>>();
           const unresolvedRefs: string[] = [];
           const referencedTokens: string[] = [];
+          const propertyRefs = new Map<string, string>();
+          const stateRefs = new Map<string, Map<string, string>>();
           let interactive: boolean | undefined;
 
           const collectRefs = (value: unknown) => {
@@ -290,8 +296,11 @@ export class ModelHandler implements ModelSpec {
                 for (const [stateName, stateProps] of Object.entries(rawValue as Record<string, unknown>)) {
                   if (!stateProps || typeof stateProps !== 'object' || Array.isArray(stateProps)) continue;
                   const overrides = new Map<string, ResolvedValue>();
+                  const stateRefMap = new Map<string, string>();
                   for (const [sPropName, sRawValue] of Object.entries(stateProps as Record<string, unknown>)) {
                     collectRefs(sRawValue);
+                    const wholeRef = wholeValueTokenRef(sRawValue);
+                    if (wholeRef !== null) stateRefMap.set(sPropName, wholeRef);
                     const validator = COMPONENT_SUB_TOKEN_VALIDATORS.get(sPropName);
                     if (validator && typeof sRawValue === 'string') {
                       const result = validator(sRawValue);
@@ -307,12 +316,15 @@ export class ModelHandler implements ModelSpec {
                     overrides.set(sPropName, resolved);
                   }
                   states.set(stateName, overrides);
+                  if (stateRefMap.size > 0) stateRefs.set(stateName, stateRefMap);
                 }
               }
               continue;
             }
 
             collectRefs(rawValue);
+            const wholeRef = wholeValueTokenRef(rawValue);
+            if (wholeRef !== null) propertyRefs.set(propName, wholeRef);
 
             // Validate the raw author input against the typed schema.
             // Token references and resolution failures are not validated
@@ -353,13 +365,39 @@ export class ModelHandler implements ModelSpec {
             resolvedStates.set(stateName, merged);
           }
 
-          const def: ComponentDef = { properties, states, resolvedStates, unresolvedRefs, referencedTokens };
+          const def: ComponentDef = {
+            properties,
+            states,
+            resolvedStates,
+            unresolvedRefs,
+            referencedTokens,
+            propertyRefs,
+            stateRefs,
+          };
           if (interactive !== undefined) def.interactive = interactive;
           components.set(compName, def);
         }
       }
 
       const colorIndex = buildColorIndex(colors);
+
+      // ── Phase 4: Theme views ───────────────────────────────────────
+      // Build the implicit `light` base view from the resolved top-level
+      // state, then deep-merge each declared theme's overrides on top of
+      // its `inheritsFrom` parent (default: `light`). Theme views carry
+      // their own re-resolved colors / pairs / ramps so the same token
+      // name can hold different values across themes.
+      const themes = buildThemeViews({
+        baseColors: colors,
+        baseTypography: typography,
+        baseRounded: rounded,
+        baseSpacing: spacing,
+        baseElevation: elevation,
+        baseColorRamps: colorRamps,
+        baseColorPairs: colorPairs,
+        rawThemes: input.themes,
+        findings,
+      });
 
       return {
         designSystem: {
@@ -376,6 +414,8 @@ export class ModelHandler implements ModelSpec {
           componentRegistry,
           colorRamps,
           colorPairs,
+          themes,
+          activeTheme: BASE_THEME_NAME,
           symbolTable,
           sections: input.sections,
           documentSections: input.documentSections,
@@ -395,6 +435,8 @@ export class ModelHandler implements ModelSpec {
           components: new Map(),
           colorRamps: new Map(),
           colorPairs: new Map(),
+          themes: new Map(),
+          activeTheme: BASE_THEME_NAME,
           symbolTable: new Map(),
           colorIndex: new Map(),
         },
@@ -481,6 +523,16 @@ interface ExpansionContext {
   colorPairs: Map<string, PairDef>;
   symbolTable: Map<string, ResolvedValue>;
   findings: Finding[];
+  /**
+   * Optional prefix prepended to all error `path:` values. Defaults to
+   * `'colors'`. Theme-scoped expansions pass `'themes.<name>.colors'` so
+   * findings are clearly attributable to the theme.
+   */
+  pathPrefix?: string;
+}
+
+function colorPath(ctx: ExpansionContext): string {
+  return ctx.pathPrefix ?? 'colors';
 }
 
 /**
@@ -496,7 +548,7 @@ function expandObjectColor(name: string, raw: RawRampDef | RawPairDef, ctx: Expa
   } else {
     ctx.findings.push({
       severity: 'error',
-      path: `colors.${name}`,
+      path: `${colorPath(ctx)}.${name}`,
       message: `Unknown color shape '${(raw as { type?: string }).type ?? 'object'}'. Expected 'ramp' or 'pair'.`,
     });
   }
@@ -506,7 +558,7 @@ function expandRamp(name: string, raw: RawRampDef, ctx: ExpansionContext): void 
   if (typeof raw.anchor !== 'string' || !isValidColor(raw.anchor)) {
     ctx.findings.push({
       severity: 'error',
-      path: `colors.${name}.anchor`,
+      path: `${colorPath(ctx)}.${name}.anchor`,
       message: `'${raw.anchor}' is not a valid hex anchor. Expected a hex color code (e.g., #ffffff).`,
     });
     return;
@@ -548,7 +600,7 @@ function expandRamp(name: string, raw: RawRampDef, ctx: ExpansionContext): void 
       if (!bgColor || !fgColor) {
         ctx.findings.push({
           severity: 'error',
-          path: `colors.${name}.pairs.${pairKey}`,
+          path: `${colorPath(ctx)}.${name}.pairs.${pairKey}`,
           message: `Pair '${pairKey}' references step ${!bgColor ? bg : fg}, but the ramp does not declare that step.`,
         });
         continue;
@@ -586,7 +638,7 @@ function expandPair(name: string, raw: RawPairDef, ctx: ExpansionContext): void 
   if (typeof raw.container !== 'string' || !isValidColor(raw.container)) {
     ctx.findings.push({
       severity: 'error',
-      path: `colors.${name}.container`,
+      path: `${colorPath(ctx)}.${name}.container`,
       message: `'${raw.container}' is not a valid hex color.`,
     });
     return;
@@ -594,7 +646,7 @@ function expandPair(name: string, raw: RawPairDef, ctx: ExpansionContext): void 
   if (typeof raw.onContainer !== 'string' || !isValidColor(raw.onContainer)) {
     ctx.findings.push({
       severity: 'error',
-      path: `colors.${name}.onContainer`,
+      path: `${colorPath(ctx)}.${name}.onContainer`,
       message: `'${raw.onContainer}' is not a valid hex color.`,
     });
     return;
@@ -657,6 +709,17 @@ function buildColorIndex(colors: Map<string, ResolvedColor>): Map<string, ColorI
 }
 
 // ── Pure utility functions ─────────────────────────────────────────
+
+/**
+ * If the raw value is a single whole-value token reference (`{colors.primary}`),
+ * return its bare path (`colors.primary`). Otherwise return `null` (the value
+ * is a literal, an embedded-ref shorthand, or a non-string).
+ */
+function wholeValueTokenRef(rawValue: unknown): string | null {
+  if (typeof rawValue !== 'string') return null;
+  if (!isTokenReference(rawValue)) return null;
+  return rawValue.slice(1, -1);
+}
 
 /**
  * Resolve a single component property value (string/number/boolean) into
@@ -1078,4 +1141,388 @@ export function resolveEmbeddedRefs(
     return match;
   });
   return { value: replaced, unresolved };
+}
+
+// ── Theme views ────────────────────────────────────────────────────
+
+interface ThemeBuildInputs {
+  baseColors: Map<string, ResolvedColor>;
+  baseTypography: Map<string, ResolvedTypography>;
+  baseRounded: Map<string, ResolvedDimension>;
+  baseSpacing: Map<string, ResolvedDimension>;
+  baseElevation: Map<string, ResolvedShadow>;
+  baseColorRamps: Map<string, RampDef>;
+  baseColorPairs: Map<string, PairDef>;
+  rawThemes: Record<string, RawThemeDef> | undefined;
+  findings: Finding[];
+}
+
+/**
+ * Build the per-theme resolved views. The implicit `light` base is always
+ * present. Other themes inherit from `light` (or the named `inheritsFrom`
+ * theme), then deep-merge their overrides on top.
+ *
+ * Cycles or unknown `inheritsFrom` parents fall back to the `light` base
+ * with a warning.
+ */
+function buildThemeViews(input: ThemeBuildInputs): Map<string, ThemeView> {
+  const out = new Map<string, ThemeView>();
+
+  const lightView: ThemeView = {
+    name: BASE_THEME_NAME,
+    colors: new Map(input.baseColors),
+    typography: new Map(input.baseTypography),
+    rounded: new Map(input.baseRounded),
+    spacing: new Map(input.baseSpacing),
+    elevation: new Map(input.baseElevation),
+    colorRamps: new Map(input.baseColorRamps),
+    colorPairs: new Map(input.baseColorPairs),
+    // The base view "overrides" every color by definition — it owns them.
+    explicitColorOverrides: new Set(input.baseColors.keys()),
+    contrastTarget: { ...DEFAULT_CONTRAST_TARGET },
+  };
+  out.set(BASE_THEME_NAME, lightView);
+
+  if (!input.rawThemes) return out;
+
+  // Resolve themes in declaration order so a theme can extend another that
+  // appears earlier. Cycles short-circuit to the `light` base.
+  const visiting = new Set<string>();
+  const resolve = (name: string, raw: RawThemeDef): ThemeView => {
+    if (out.has(name)) return out.get(name)!;
+    if (visiting.has(name)) {
+      input.findings.push({
+        severity: 'warning',
+        path: `themes.${name}.inheritsFrom`,
+        message: `Theme '${name}' has a cyclic inheritsFrom chain. Falling back to the '${BASE_THEME_NAME}' base.`,
+      });
+      return lightView;
+    }
+    visiting.add(name);
+
+    let parent: ThemeView = lightView;
+    if (raw.inheritsFrom && raw.inheritsFrom !== BASE_THEME_NAME) {
+      const parentRaw = input.rawThemes?.[raw.inheritsFrom];
+      if (!parentRaw) {
+        input.findings.push({
+          severity: 'warning',
+          path: `themes.${name}.inheritsFrom`,
+          message: `Theme '${name}' inherits from '${raw.inheritsFrom}', which is not declared. Falling back to the '${BASE_THEME_NAME}' base.`,
+        });
+      } else {
+        parent = resolve(raw.inheritsFrom, parentRaw);
+      }
+    }
+
+    const view = mergeThemeOnto(name, raw, parent, input.findings);
+    out.set(name, view);
+    visiting.delete(name);
+    return view;
+  };
+
+  for (const [name, raw] of Object.entries(input.rawThemes)) {
+    if (name === BASE_THEME_NAME) {
+      // A `themes.light` block layers on top of the root token tree. Treat
+      // it as overrides on the implicit base — useful when an author wants
+      // a separate Light section while keeping a darker base.
+      const merged = mergeThemeOnto(name, raw, lightView, input.findings);
+      // Replace the lightView entry; subsequent themes still inherit
+      // from this merged version.
+      out.set(BASE_THEME_NAME, merged);
+      continue;
+    }
+    resolve(name, raw);
+  }
+
+  return out;
+}
+
+/**
+ * Deep-merge a single theme's overrides onto a parent view. Returns a new
+ * `ThemeView`; does not mutate the parent.
+ */
+function mergeThemeOnto(
+  name: string,
+  raw: RawThemeDef,
+  parent: ThemeView,
+  findings: Finding[],
+): ThemeView {
+  // Start from a clone of the parent.
+  const colors = new Map(parent.colors);
+  const typography = new Map(parent.typography);
+  const rounded = new Map(parent.rounded);
+  const spacing = new Map(parent.spacing);
+  const elevation = new Map(parent.elevation);
+  const colorRamps = new Map(parent.colorRamps);
+  const colorPairs = new Map(parent.colorPairs);
+
+  // Theme-local symbol table: starts as a flat snapshot of the parent's
+  // tokens. References inside this theme resolve here, not against the
+  // global root symbol table — so `{colors.primary}` in a dark override
+  // resolves to dark-primary, not light-primary.
+  const symbolTable = new Map<string, ResolvedValue>();
+  for (const [k, v] of colors) symbolTable.set(`colors.${k}`, v);
+  for (const [k, v] of typography) symbolTable.set(`typography.${k}`, v);
+  for (const [k, v] of rounded) symbolTable.set(`rounded.${k}`, v);
+  for (const [k, v] of spacing) symbolTable.set(`spacing.${k}`, v);
+  for (const [k, v] of elevation) symbolTable.set(`elevation.${k}`, v);
+
+  const explicitColorOverrides = new Set<string>();
+
+  // Apply color overrides.
+  if (raw.colors) {
+    for (const [colorName, val] of Object.entries(raw.colors)) {
+      explicitColorOverrides.add(colorName);
+      // Re-declaring a ramp or pair under the same name in a theme should
+      // cleanly replace the parent's expansion, not leave dotted/derived
+      // members behind from the parent.
+      if (val && typeof val === 'object') {
+        clearGroupedColors(colorName, colors, symbolTable, colorRamps, colorPairs);
+      }
+
+      if (typeof val === 'string') {
+        if (isTokenReference(val)) {
+          const resolved = resolveReferenceForTheme(symbolTable, val.slice(1, -1));
+          if (resolved !== null && typeof resolved === 'object' && 'type' in resolved && resolved.type === 'color') {
+            colors.set(colorName, resolved as ResolvedColor);
+            symbolTable.set(`colors.${colorName}`, resolved);
+            updatePairFromFlatOverride(colorName, resolved as ResolvedColor, colorPairs);
+          } else {
+            findings.push({
+              severity: 'error',
+              path: `themes.${name}.colors.${colorName}`,
+              message: `'${val}' does not resolve to a color in theme '${name}'.`,
+            });
+          }
+        } else if (isValidColor(val)) {
+          const resolved = parseColor(val);
+          colors.set(colorName, resolved);
+          symbolTable.set(`colors.${colorName}`, resolved);
+          updatePairFromFlatOverride(colorName, resolved, colorPairs);
+        } else {
+          findings.push({
+            severity: 'error',
+            path: `themes.${name}.colors.${colorName}`,
+            message: `'${val}' is not a valid color. Expected a hex color code (e.g., #ffffff).`,
+          });
+        }
+      } else if (val && typeof val === 'object') {
+        expandObjectColor(colorName, val, {
+          colors,
+          colorRamps,
+          colorPairs,
+          symbolTable,
+          findings,
+          pathPrefix: `themes.${name}.colors`,
+        });
+      }
+    }
+  }
+
+  // Typography overrides — merge property maps on top of the parent's
+  // typography scale entry. A theme may override only `fontSize` without
+  // restating `fontFamily`.
+  if (raw.typography) {
+    for (const [tName, props] of Object.entries(raw.typography)) {
+      const base = typography.get(tName);
+      const merged = parseTypographyProps(
+        props,
+        `themes.${name}.typography.${tName}`,
+        findings,
+        base,
+      );
+      typography.set(tName, merged);
+      symbolTable.set(`typography.${tName}`, merged);
+    }
+  }
+
+  if (raw.rounded) {
+    for (const [rName, value] of Object.entries(raw.rounded)) {
+      if (typeof value !== 'string') continue;
+      if (!isParseableDimension(value)) {
+        findings.push({
+          severity: 'error',
+          path: `themes.${name}.rounded.${rName}`,
+          message: `'${value}' is not a valid dimension.`,
+        });
+        continue;
+      }
+      const dim = parseDimensionAsDim(value);
+      rounded.set(rName, dim);
+      symbolTable.set(`rounded.${rName}`, dim);
+    }
+  }
+
+  if (raw.spacing) {
+    for (const [sName, value] of Object.entries(raw.spacing)) {
+      if (typeof value !== 'string') continue;
+      if (!isParseableDimension(value)) {
+        findings.push({
+          severity: 'error',
+          path: `themes.${name}.spacing.${sName}`,
+          message: `'${value}' is not a valid dimension.`,
+        });
+        continue;
+      }
+      const dim = parseDimensionAsDim(value);
+      spacing.set(sName, dim);
+      symbolTable.set(`spacing.${sName}`, dim);
+    }
+  }
+
+  if (raw.elevation) {
+    for (const [eName, value] of Object.entries(raw.elevation)) {
+      if (typeof value !== 'string') continue;
+      const shadow: ResolvedShadow = { type: 'shadow', raw: value };
+      elevation.set(eName, shadow);
+      symbolTable.set(`elevation.${eName}`, shadow);
+    }
+  }
+
+  const contrastTarget: ThemeContrastTarget = {
+    body: raw.contrastTarget?.body ?? parent.contrastTarget.body,
+    large: raw.contrastTarget?.large ?? parent.contrastTarget.large,
+    ui: raw.contrastTarget?.ui ?? parent.contrastTarget.ui,
+  };
+
+  const view: ThemeView = {
+    name,
+    colors,
+    typography,
+    rounded,
+    spacing,
+    elevation,
+    colorRamps,
+    colorPairs,
+    explicitColorOverrides,
+    contrastTarget,
+  };
+  if (raw.inheritsFrom !== undefined) view.inheritsFrom = raw.inheritsFrom;
+  if (raw.description !== undefined) view.description = raw.description;
+  return view;
+}
+
+/**
+ * When a theme re-declares a ramp or pair under an existing name, drop the
+ * parent's grouped entries (steps, dotted members, on-* aliases) so the new
+ * expansion fully replaces the prior one. Bare flat overrides do not trigger
+ * this — they only override the single anchor entry.
+ */
+function clearGroupedColors(
+  name: string,
+  colors: Map<string, ResolvedColor>,
+  symbolTable: Map<string, ResolvedValue>,
+  colorRamps: Map<string, RampDef>,
+  colorPairs: Map<string, PairDef>,
+): void {
+  const dottedPrefix = `${name}.`;
+  const hyphenPrefix = `${name}-`;
+  const onHyphenPrefix = `on-${name}-`;
+  const onFlat = `on-${name}`;
+  for (const key of [...colors.keys()]) {
+    if (key.startsWith(dottedPrefix) || key.startsWith(hyphenPrefix) || key.startsWith(onHyphenPrefix) || key === onFlat) {
+      colors.delete(key);
+      symbolTable.delete(`colors.${key}`);
+    }
+  }
+  colorRamps.delete(name);
+  colorPairs.delete(name);
+  // Standalone-pair ramps register additional entries; sweep any pair
+  // whose name is rooted at this name.
+  for (const pairName of [...colorPairs.keys()]) {
+    if (pairName === name || pairName.startsWith(`${name}-`)) {
+      colorPairs.delete(pairName);
+    }
+  }
+}
+
+function resolveReferenceForTheme(
+  symbolTable: Map<string, ResolvedValue>,
+  path: string,
+): ResolvedValue | null {
+  return resolveReference(symbolTable, path, new Set());
+}
+
+/**
+ * When a theme's flat color override touches a pair-member alias, mirror
+ * the new value into the pair definition so `pair-parity` and exporters
+ * see the half-update. The bare pair name and the `on-<pair>` alias map
+ * to `container` / `onContainer`. We keep parity by cloning the prior
+ * pair definition before mutating.
+ */
+function updatePairFromFlatOverride(
+  name: string,
+  newColor: ResolvedColor,
+  colorPairs: Map<string, PairDef>,
+): void {
+  // Bare alias: matches a pair name directly → update container.
+  const direct = colorPairs.get(name);
+  if (direct) {
+    colorPairs.set(name, { ...direct, container: newColor });
+    return;
+  }
+  // `on-<pair>` alias → update the underlying pair's onContainer.
+  if (name.startsWith('on-')) {
+    const pairName = name.slice(3);
+    const pair = colorPairs.get(pairName);
+    if (pair) {
+      colorPairs.set(pairName, { ...pair, onContainer: newColor });
+    }
+  }
+}
+
+function parseDimensionAsDim(raw: string): ResolvedDimension {
+  const parts = parseDimensionParts(raw)!;
+  return { type: 'dimension', value: parts.value, unit: parts.unit };
+}
+
+/**
+ * Parse typography properties for a theme override. Differs from the
+ * top-level `parseTypography` only in that it merges on top of an
+ * optional `base` ResolvedTypography so unspecified properties inherit
+ * from the parent theme.
+ */
+function parseTypographyProps(
+  props: Record<string, string | number>,
+  path: string,
+  findings: Finding[],
+  base: ResolvedTypography | undefined,
+): ResolvedTypography {
+  const result: ResolvedTypography = base ? { ...base } : { type: 'typography' };
+
+  if (typeof props['fontFamily'] === 'string') result.fontFamily = props['fontFamily'];
+  if (typeof props['fontFeature'] === 'string') result.fontFeature = props['fontFeature'];
+  if (typeof props['fontVariation'] === 'string') result.fontVariation = props['fontVariation'];
+
+  if (props['fontWeight'] !== undefined) {
+    const fw = props['fontWeight'];
+    const fwValue = typeof fw === 'number' ? fw : Number(fw);
+    if (Number.isNaN(fwValue)) {
+      findings.push({
+        severity: 'error',
+        path: `${path}.fontWeight`,
+        message: `'${fw}' is not a valid font weight.`,
+      });
+    } else {
+      result.fontWeight = fwValue;
+    }
+  }
+
+  for (const prop of ['fontSize', 'lineHeight', 'letterSpacing'] as const) {
+    const raw = props[prop];
+    if (typeof raw !== 'string') continue;
+    if (isParseableDimension(raw)) {
+      result[prop] = parseDimensionAsDim(raw);
+    } else if (prop === 'lineHeight' && /^\d*\.?\d+$/.test(raw)) {
+      result[prop] = { type: 'dimension', value: parseFloat(raw), unit: '' };
+    } else if (!isTokenReference(raw)) {
+      findings.push({
+        severity: 'error',
+        path: `${path}.${prop}`,
+        message: `'${raw}' is not a valid dimension.`,
+      });
+    }
+  }
+
+  return result;
 }

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -171,6 +171,57 @@ export interface RegistryEntry {
   composes?: string;
 }
 
+/**
+ * Per-theme contrast targets. Defaults to WCAG AA when a theme does not
+ * declare its own targets. AAA-style themes (e.g., `high-contrast`) typically
+ * raise `body` to 7 and `ui` to 4.5.
+ */
+export interface ThemeContrastTarget {
+  body: number;
+  large: number;
+  ui: number;
+}
+
+/** Default contrast target — WCAG AA. */
+export const DEFAULT_CONTRAST_TARGET: ThemeContrastTarget = {
+  body: 4.5,
+  large: 3,
+  ui: 3,
+};
+
+/**
+ * A theme's resolved view of the token tree. Ramps and pairs are re-resolved
+ * per theme so the same name can carry different values across themes
+ * (`{colors.primary}` is one hex in `light`, another in `dark`).
+ *
+ * `light` is always present as the implicit base; named themes deep-merge
+ * their overrides on top.
+ */
+export interface ThemeView {
+  name: string;
+  /** Optional parent theme. `undefined` = the implicit `light` base. */
+  inheritsFrom?: string | undefined;
+  description?: string | undefined;
+  colors: Map<string, ResolvedColor>;
+  typography: Map<string, ResolvedTypography>;
+  rounded: Map<string, ResolvedDimension>;
+  spacing: Map<string, ResolvedDimension>;
+  elevation: Map<string, ResolvedShadow>;
+  /** Re-resolved per theme so ramp anchors and steps reflect theme overrides. */
+  colorRamps: Map<string, RampDef>;
+  /** Re-resolved per theme so pair members reflect theme overrides. */
+  colorPairs: Map<string, PairDef>;
+  /**
+   * Color names this theme *explicitly* declared in its overrides, distinct
+   * from values that inherit unchanged from the parent. The `theme-parity`
+   * rule uses this to catch colors that were silently inherited (the
+   * "added a new color, forgot to override it for dark mode" failure).
+   */
+  explicitColorOverrides: Set<string>;
+  /** Per-theme contrast target. Defaults to WCAG AA. */
+  contrastTarget: ThemeContrastTarget;
+}
+
 // ── STATE ──────────────────────────────────────────────────────────
 export interface DesignSystemState {
   name?: string | undefined;
@@ -211,7 +262,21 @@ export interface DesignSystemState {
   colorRamps: Map<string, RampDef>;
   /** Pair definitions, keyed by pair name. */
   colorPairs: Map<string, PairDef>;
-  /** Flat lookup: "colors.primary" → ResolvedColor */
+  /**
+   * Resolved per-theme views, keyed by theme name. Always contains the
+   * implicit `light` base view that mirrors the top-level fields. Other
+   * theme views are deep-merge results of their declared overrides on top
+   * of their `inheritsFrom` parent (default: `light`).
+   */
+  themes: Map<string, ThemeView>;
+  /**
+   * Currently-active theme name. Top-level `colors`/`typography`/etc. are
+   * mirrors of this theme's view. Defaults to `light`. Rules that operate
+   * on the active theme (the existing single-theme rules) keep working
+   * unchanged; rules that need cross-theme reasoning iterate `themes`.
+   */
+  activeTheme: string;
+  /** Flat lookup: "colors.primary" → ResolvedValue (active theme). */
   symbolTable: Map<string, ResolvedValue>;
   /** Markdown heading names found in the document */
   sections?: string[] | undefined;
@@ -259,6 +324,20 @@ export interface ComponentDef {
    * references that get substituted out of the resolved property value.
    */
   referencedTokens: string[];
+  /**
+   * Per-property whole-value token references, recorded pre-resolution.
+   * Keyed by property name (`backgroundColor`); value is the bare path
+   * (e.g., `colors.primary`). Per-theme rules use this to re-resolve a
+   * property's color through the relevant theme's color map without
+   * keeping the raw markdown around.
+   */
+  propertyRefs: Map<string, string>;
+  /**
+   * Per-state whole-value token references, recorded pre-resolution.
+   * Outer key: state name (`hover`, `focus-visible`, ...). Inner key:
+   * property name. Inner value: the bare path (e.g., `colors.primary`).
+   */
+  stateRefs: Map<string, Map<string, string>>;
 }
 
 /**

--- a/packages/cli/src/linter/parser/handler.ts
+++ b/packages/cli/src/linter/parser/handler.ts
@@ -231,6 +231,7 @@ export class ParserHandler implements ParserSpec {
       iconography: raw['iconography'] as ParsedDesignSystem['iconography'],
       components,
       componentRegistry,
+      themes: raw['themes'] as ParsedDesignSystem['themes'],
       sourceMap,
       sections,
       documentSections,

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -95,6 +95,27 @@ export interface RawIconographyDef {
 }
 
 /**
+ * A theme block — overrides only. Anything not overridden is inherited from
+ * `inheritsFrom` (default: the implicit `light` base = the root token tree).
+ * Resolution is a deep-merge of theme-over-base, scoped per token category.
+ */
+export interface RawThemeDef {
+  /** Optional parent theme name. Default is the implicit `light` base. */
+  inheritsFrom?: string;
+  description?: string;
+  colors?: Record<string, RawColorValue>;
+  typography?: Record<string, Record<string, string | number>>;
+  rounded?: Record<string, string>;
+  spacing?: Record<string, string>;
+  elevation?: Record<string, string>;
+  /**
+   * Per-theme contrast targets used by `theme-contrast-ratio`. Defaults to
+   * WCAG AA when absent (body 4.5:1, large text 3:1, non-text UI 3:1).
+   */
+  contrastTarget?: { body?: number; large?: number; ui?: number };
+}
+
+/**
  * A registry entry — the closed-world declaration that a component name is part
  * of the design system. Adding an entry is a deliberate, reviewable act.
  */
@@ -155,6 +176,12 @@ export interface ParsedDesignSystem {
    * Absent = open-world (back-compat) behavior.
    */
   componentRegistry?: RawRegistryEntry[] | undefined;
+  /**
+   * Theme overrides. Keys are theme names; the implicit `light` base lives
+   * in the root token tree (so a `themes.light` entry is unnecessary, though
+   * tolerated). Values are deep-merged onto the base during model build.
+   */
+  themes?: Record<string, RawThemeDef> | undefined;
   sourceMap: Map<string, SourceLocation>;
   /** Markdown heading names found in the document (e.g., 'Colors', 'Typography') */
   sections?: string[] | undefined;

--- a/packages/cli/src/linter/spec-config.ts
+++ b/packages/cli/src/linter/spec-config.ts
@@ -99,6 +99,7 @@ const ConfigSchema = z.object({
   easing_keywords: z.array(z.string()).min(1),
   component_kinds: z.array(ComponentKindSchema).min(1),
   component_modifiers: z.array(z.string()).min(1),
+  well_known_themes: z.array(z.string()).min(1),
   recommended_tokens: z.record(z.string(), z.array(z.string())),
   examples: z.object({
     colors: z.record(z.string(), z.string()),
@@ -230,6 +231,16 @@ export const KIND_DEFAULTS: Record<string, { interactive: boolean }> = Object.fr
 
 /** Closed set of permitted name modifiers (the `-modifier` suffix in `noun-modifier`). */
 export const COMPONENT_MODIFIERS: readonly string[] = config.component_modifiers;
+
+/**
+ * Well-known theme names. Informational, not closed — authors may declare
+ * themes outside this set. The implicit `light` base is always present at
+ * the root token tree.
+ */
+export const WELL_KNOWN_THEMES: readonly string[] = config.well_known_themes;
+
+/** The implicit base theme name. The root token tree IS this theme. */
+export const BASE_THEME_NAME = 'light';
 
 /** Non-normative recommended token names, organized by category. */
 export const RECOMMENDED_TOKENS = config.recommended_tokens;

--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -29,6 +29,10 @@ sections:
       - Brand & Style
   - canonical: Colors
   - canonical: Typography
+  - canonical: Themes
+    aliases:
+      - Modes
+      - Themes & Modes
   - canonical: Layout
     aliases:
       - Layout & Spacing
@@ -44,6 +48,16 @@ sections:
       - Icons
   - canonical: Components
   - canonical: "Do's and Don'ts"
+
+# Well-known theme names. The list is informational, not closed: authors may
+# declare theme names outside this set. The implicit `light` base is always
+# present at the root token tree; named themes layer overrides on top.
+well_known_themes:
+  - light
+  - dark
+  - high-contrast
+  - comfortable
+  - compact
 
 # Closed enum of supported icon libraries. `custom-svg` is the escape hatch.
 icon_libraries:

--- a/packages/cli/src/linter/tailwind/handler.test.ts
+++ b/packages/cli/src/linter/tailwind/handler.test.ts
@@ -251,4 +251,57 @@ describe('TailwindEmitterHandler', () => {
       expect(disabled?.['cursor']).toBe('not-allowed');
     });
   });
+
+  describe('themes mapping', () => {
+    it('omits the themes field when no extra themes are declared', () => {
+      const state = buildState({ colors: { primary: '#1A1C1E' } });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      expect(result.data.themes).toBeUndefined();
+    });
+
+    it('emits per-theme color overrides for dark and high-contrast', () => {
+      const state = buildState({
+        colors: { primary: '#1A1C1E', surface: '#FFFFFF' },
+        themes: {
+          dark: { colors: { primary: '#A3C9FF', surface: '#1A1C1E' } },
+          'high-contrast': {
+            colors: { primary: '#000000', surface: '#FFFFFF' },
+            contrastTarget: { body: 7, large: 4.5, ui: 4.5 },
+          },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+
+      // Base colors live in theme.extend.colors as the light defaults.
+      expect(result.data.theme.extend.colors?.['primary']).toBe('#1a1c1e');
+
+      // Themes carries the dark and high-contrast overrides.
+      const themes = result.data.themes!;
+      expect(themes['dark']?.colors['primary']).toBe('#a3c9ff');
+      expect(themes['dark']?.colors['surface']).toBe('#1a1c1e');
+      expect(themes['high-contrast']?.colors['primary']).toBe('#000000');
+      expect(themes['high-contrast']?.contrastTarget).toEqual({ body: 7, large: 4.5, ui: 4.5 });
+    });
+
+    it('emits per-theme ramp groups, mirroring the base shape', () => {
+      const state = buildState({
+        colors: { primary: { type: 'ramp', anchor: '#1A1C1E', humanName: 'Charcoal' } },
+        themes: {
+          dark: { colors: { primary: { type: 'ramp', anchor: '#A3C9FF', humanName: 'Sky' } } },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+
+      const lightPrimary = result.data.theme.extend.colors?.['primary'] as Record<string, string>;
+      expect(lightPrimary?.['DEFAULT']).toBe('#1a1c1e');
+      expect(lightPrimary?.['500']).toBe('#1a1c1e');
+
+      const darkPrimary = result.data.themes!['dark']?.colors['primary'] as Record<string, string>;
+      expect(darkPrimary?.['DEFAULT']).toBe('#a3c9ff');
+      expect(darkPrimary?.['500']).toBe('#a3c9ff');
+    });
+  });
 });

--- a/packages/cli/src/linter/tailwind/handler.ts
+++ b/packages/cli/src/linter/tailwind/handler.ts
@@ -17,8 +17,10 @@ import type {
   TailwindEmitterResult,
   TailwindEmitterOptions,
   TailwindComponentRule,
+  TailwindThemes,
 } from './spec.js';
-import type { ComponentDef, DesignSystemState, ResolvedDimension, ResolvedValue } from '../model/spec.js';
+import type { ComponentDef, DesignSystemState, RampDef, ResolvedColor, ResolvedDimension, ResolvedValue, ThemeView } from '../model/spec.js';
+import { BASE_THEME_NAME } from '../spec-config.js';
 
 const STATE_TO_VARIANT: Record<string, string> = {
   hover: '&:hover',
@@ -60,7 +62,7 @@ export class TailwindEmitterHandler implements TailwindEmitterSpec {
       data: {
         theme: {
           extend: {
-            colors: this.mapColors(state),
+            colors: this.mapColors(state.colors, state.colorRamps),
             fontFamily: this.mapFontFamilies(state),
             fontSize: this.mapFontSizes(state),
             borderRadius: this.mapDimensions(state.rounded),
@@ -77,7 +79,32 @@ export class TailwindEmitterHandler implements TailwindEmitterSpec {
       result.data.plugin = this.mapComponents(state);
     }
 
+    const themes = this.mapThemes(state);
+    if (themes !== undefined) {
+      result.data.themes = themes;
+    }
+
     return result;
+  }
+
+  /**
+   * Emit per-theme color overrides for every declared theme except the
+   * implicit `light` base (whose values already live in `theme.extend.colors`).
+   * Returns `undefined` when no additional themes are declared so the field
+   * stays omitted in the simple single-theme case.
+   */
+  private mapThemes(state: DesignSystemState): TailwindThemes | undefined {
+    const out: TailwindThemes = {};
+    let any = false;
+    for (const [themeName, view] of state.themes) {
+      if (themeName === BASE_THEME_NAME) continue;
+      out[themeName] = {
+        colors: this.mapColors(view.colors, view.colorRamps),
+        contrastTarget: { ...view.contrastTarget },
+      };
+      any = true;
+    }
+    return any ? out : undefined;
   }
 
   private mapComponents(state: DesignSystemState): Record<string, TailwindComponentRule> {
@@ -151,12 +178,15 @@ export class TailwindEmitterHandler implements TailwindEmitterSpec {
     return result;
   }
 
-  private mapColors(state: DesignSystemState): Record<string, string | Record<string, string>> {
+  private mapColors(
+    colors: Map<string, ResolvedColor>,
+    colorRamps: Map<string, RampDef>,
+  ): Record<string, string | Record<string, string>> {
     const result: Record<string, string | Record<string, string>> = {};
 
     // Ramps emit as nested objects: { DEFAULT: '...', '50': '...', '500': '...', ... }
     // The flat colors map carries every step plus the anchor; group them by ramp.
-    for (const [rampName, ramp] of state.colorRamps) {
+    for (const [rampName, ramp] of colorRamps) {
       const group: Record<string, string> = { DEFAULT: ramp.anchor.hex };
       for (const [step, color] of [...ramp.steps].sort(([a], [b]) => a - b)) {
         group[String(step)] = color.hex;
@@ -167,7 +197,7 @@ export class TailwindEmitterHandler implements TailwindEmitterSpec {
     // Flat colors and pair members emit as top-level strings. Skip step entries
     // (already nested under their ramp), the bare anchor (already in group), and
     // dotted standalone-pair members (encoded via hyphen flat aliases below).
-    for (const [name, color] of state.colors) {
+    for (const [name, color] of colors) {
       if (color.rampMember) continue;
       if (color.pairRole && name.includes('.')) continue;
       result[name] = color.hex;

--- a/packages/cli/src/linter/tailwind/spec.ts
+++ b/packages/cli/src/linter/tailwind/spec.ts
@@ -51,6 +51,25 @@ export const TailwindEmitterOptionsSchema = z.object({
 });
 export type TailwindEmitterOptions = z.infer<typeof TailwindEmitterOptionsSchema>;
 
+/**
+ * Per-theme color overrides. Keyed by theme name (excluding the implicit
+ * `light` base which lives in `theme.extend.colors`). Each entry holds the
+ * theme's full color map. Consumers project these into CSS layers — typically
+ * `.dark { --color-primary: ... }` for `darkMode: 'class'` or via
+ * `tailwindcss-themer`.
+ */
+export const TailwindThemesSchema = z.record(z.object({
+  colors: z.record(z.union([z.string(), z.record(z.string())])),
+  /** Optional contrast targets for downstream tools that emit per-theme docs. */
+  contrastTarget: z.object({
+    body: z.number(),
+    large: z.number(),
+    ui: z.number(),
+  }).optional(),
+}));
+
+export type TailwindThemes = z.infer<typeof TailwindThemesSchema>;
+
 export const TailwindEmitterResultSchema = z.discriminatedUnion('success', [
   z.object({
     success: z.literal(true),
@@ -59,6 +78,12 @@ export const TailwindEmitterResultSchema = z.discriminatedUnion('success', [
         extend: TailwindThemeExtendSchema
       }),
       plugin: z.record(z.unknown()).optional(),
+      /**
+       * Per-theme overrides for non-base themes. Empty / omitted when no
+       * additional themes are declared. Authors who don't use themes see
+       * no behavioral change.
+       */
+      themes: TailwindThemesSchema.optional(),
     })
   }),
   z.object({


### PR DESCRIPTION
## Summary

Implements the foundation laid out in #7's [run-plan comment](https://github.com/joesteinkamp/design.md/issues/7#issuecomment-4320670533). Themes declare overrides on top of the implicit `light` base; the model deep-merges them per theme so the same token name can carry different values across modes. Two new parity rules surface the common failure modes; the existing contrast-ratio rule now runs per theme against per-theme contrast targets; Tailwind output gains a `themes` field that mirrors the base shape per theme.

Closes #7 — phases 1, 2, 3 (partial), 5 (basic), 7 (one example).

## What's in this PR

**Schema (`spec-config.yaml`)**
- New `Themes` canonical section (alias: `Modes`, `Themes & Modes`).
- `well_known_themes` informational list: `light`, `dark`, `high-contrast`, `comfortable`, `compact`. Open list — authors may declare other names.

**Parser**
- `RawThemeDef` carries `inheritsFrom`, color/typography/rounded/spacing/elevation overrides, and `contrastTarget`.
- `ParsedDesignSystem.themes` plumbs raw YAML through unchanged.

**Model**
- `ThemeView` carries a fully resolved per-theme view (colors, ramps, pairs, typography, spacing, rounded, elevation, contrastTarget, explicitColorOverrides). The implicit `light` base is always present.
- `DesignSystemState.themes` and `activeTheme` join the existing fields. Top-level fields still mirror the active theme so existing rules keep working unchanged.
- Theme resolution honors `inheritsFrom` chains, breaks cycles with a warning, and re-runs ramp / pair expansion within a per-theme symbol table so `{colors.primary}` resolves theme-locally.
- `ComponentDef` gains `propertyRefs` and `stateRefs` so per-theme rules can re-resolve color references through any theme view without keeping raw markdown.

**Rules**
- `theme-parity` (warning) — every base color must be explicitly overridden in each declared theme.
- `pair-parity` (warning) — half-overriding a color pair across themes silently breaks the contrast contract.
- `contrast-ratio` runs per theme against the theme's `contrastTarget` (defaults to WCAG AA; high-contrast themes typically raise body to 7).

**Tailwind exporter**
- `mapColors` is view-driven; per-theme overrides emit under a new `themes` field on the result. Authors who don't declare themes see no output change.

**Example migration**
- `examples/paws-and-paths` gains a `themes.dark` palette with a desaturated primary container, deeper night-blue surfaces, and per-theme elevations. New `## Themes` prose covers "don't invert, reconsider" / saturation-discipline / contrast-target guidelines.

## What's intentionally out of scope (follow-ups)

- `saturation-discipline`, `density-rule-violation`, `theme-elevation-mapping` rules (Phase 4).
- DTCG `$extensions['design.md'].themes` themed sets (Phase 6).
- CLI `--theme` / `--themes-split` flags (Phase 8).
- spec-gen renderer + `spec.mdx` Themes section.
- `broken-ref` / `orphaned-tokens` cross-theme awareness.
- Migration of `atmospheric-glass` and `totality-festival` examples.

## Test plan

- [x] `bun test` — 438 pass / 0 fail (was 408).
- [x] `npx tsc --noEmit` clean (excluding unrelated bun-types env warnings).
- [x] `bun run cli lint examples/paws-and-paths/DESIGN.md` — 0 errors after migration.
- [x] New tests cover: theme deep-merge, `inheritsFrom` chains and cycles, ramp/pair re-declaration per theme, typography property merge, theme-parity, pair-parity, per-theme contrast checks (including AAA target), Tailwind themes field, `THEMES.md` end-to-end fixture.

https://claude.ai/code/session_01CzQLFXGrZ372zTigJu2uu7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzQLFXGrZ372zTigJu2uu7)_