### PR TITLE
feat(layout): responsive, grid, page templates, layout rules (#9)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -290,9 +290,9 @@ Every prior content style guide (Mailchimp, Polaris, GOV.UK) is human-readable o
 
 Also known as "Layout & Spacing".
 
-This section describes the layout and spacing strategy.
+This section describes the layout, grid, breakpoints, and page-template strategy. Layout is a contract — without one, every screen the AI generates is improvised. With one, layout becomes a small, enforceable vocabulary.
 
-Many design systems follow a grid-based layout. Others, like Liquid Glass, use margins, safe areas, and dynamic padding.
+The block has four sub-systems: `breakpoints` (responsive thresholds), `grid` (columns + gutter + margins), `layoutRules` (readable measure, vertical rhythm, form-field width), and `templates` (page-level region registry).
 
 Example:
 
@@ -300,14 +300,103 @@ Example:
 ## Layout
 
 The layout follows a **Fluid Grid** model for mobile devices and a
-**Fixed-Max-Width Grid** for desktop (max 1200px).
+**Fixed-Max-Width Grid** for desktop (max 1280px). Breakpoints follow the
+mobile-first cascade — base styles target the smallest viewport and scale up.
 
-A strict 8px spacing scale (with a 4px half-step for micro-adjustments) is used to maintain a consistent rhythm. Components are grouped using "containment" principles, where related items are housed in cards with generous internal padding (24px) to emphasize the soft, approachable nature of the brand.
+A strict 8px spacing scale (with a 4px half-step for micro-adjustments) is used to maintain a consistent rhythm. Components and dimensions snap to the grid gutter; off-grid values are flagged by `off-grid-dimension`.
 ```
 
-### Design Tokens
+### Mobile-first or desktop-first
 
-The spacing section defines the spacing design tokens. These may include spacing units that are useful for implementing the layout model. For example, a fixed grid layout may have spacing units for column spans, gutters, and margins.
+Pick one and document it. Mobile-first means base styles target the smallest viewport and scale up; desktop-first the reverse. The choice changes how every breakpoint is read and is recorded as `breakpoints.philosophy: {BREAKPOINT_PHILOSOPHIES.join(' | ')}`. We recommend mobile-first as the industry default; desktop-first is supported but should be a deliberate choice.
+
+### Breakpoint philosophy
+
+Breakpoints are content-driven, not device-driven. Add a breakpoint when the layout actually breaks, not because tablets exist. Document the meaning of each breakpoint, not just its pixel value. The conventional ordering is `{BREAKPOINT_KEYS.join(' < ')}`; values must increase strictly across that sequence (`breakpoint-monotonicity`).
+
+```yaml
+breakpoints:
+  philosophy: mobile-first
+  values:
+    sm: 640px
+    md: 768px
+    lg: 1024px
+    xl: 1280px
+    "2xl": 1536px
+```
+
+### Grid usage
+
+Components and layout dimensions snap to the grid (column count or gutter multiple). The `off-grid-dimension` rule warns on layout dimensions (`width`, `height`, `padding`, `gap`, `margin`) that are neither a multiple of `grid.gutter` nor a declared `spacing` token.
+
+Off-grid is acceptable for documented exceptions only — full-bleed imagery, modal overlays, hero artwork. List those region names in `grid.bleedExceptions`.
+
+```yaml
+grid:
+  columns: 12
+  gutter: "{spacing.md}"
+  margin:
+    sm: "{spacing.md}"
+    lg: "{spacing.xl}"
+  maxWidth: 1280px
+  bleedExceptions: [hero, gallery, modal-overlay]
+```
+
+### Readable measure
+
+Body prose stays under `layoutRules.contentMaxWidth` (≈ 60–80 characters per line). Never let prose run the full width of the viewport on desktop. `layoutRules.stackSpacing` is the default vertical rhythm between blocks; `layoutRules.formFieldWidth` is the canonical width for text inputs.
+
+```yaml
+layoutRules:
+  contentMaxWidth: 720px
+  stackSpacing: "{spacing.lg}"
+  formFieldWidth: 480px
+```
+
+### Responsive content strategy
+
+Narrower viewports don't just shrink; they *restructure*. Multi-column becomes stacked; navigation collapses to a menu; tables become cards. Don't squish, reflow.
+
+### Page templates
+
+A template is a closed set of named regions for a class of page. Common templates: `marketing` (header / hero / sections / cta / footer), `app-shell` (topbar / sidebar / main / statusbar), `settings` (topbar / sidebar-nav / content). Each template declares `regions` (the named slots a page may use) and `requiredRegions` (the subset that must be present). Pages are assigned to templates via `pages:`.
+
+Once `templates` is declared the closed-world rules engage:
+
+* **`unknown-template`** (error) — `pages.X.template` references a name not in the registry.
+* **`missing-region`** (error) — a page assigned to template T whose declared regions miss a `requiredRegions` entry.
+* **`template-region-purity`** (warning) — region names whose conventional semantics conflict across templates (e.g., `header` is global identity, `topbar` is contextual to the current page).
+
+```yaml
+templates:
+  marketing:
+    regions: [header, hero, sections, cta, footer]
+    requiredRegions: [header, footer]
+    maxWidth: 1280px
+  app-shell:
+    regions: [topbar, sidebar, main, statusbar]
+    requiredRegions: [topbar, main]
+    sidebarWidth: 280px
+  settings:
+    regions: [topbar, sidebar-nav, content]
+    requiredRegions: [topbar, content]
+```
+
+### Region semantics
+
+Every template region has a defined role: `header` is identity + global nav; `topbar` is contextual to the current page; `sidebar` is persistent navigation, `aside` is contextual auxiliary content. Don't repurpose regions across templates — pick one vocabulary and hold it across the system.
+
+### Template decision tree
+
+* **`marketing`** — public-facing pages with a hero, sales-style sections, and a footer (landing pages, pricing, about). Identity-level navigation.
+* **`app-shell`** — authenticated product surfaces with persistent topbar + sidebar + main content. Contextual navigation.
+* **`settings`** — secondary surfaces inside the app, often with sub-navigation in a sidebar-nav. Inherits app chrome.
+
+Anti-pattern: marketing template used for in-app pages, or app-shell used for the public homepage. The `data-template` attribute (when source-side scanning is enabled) makes the assignment explicit per file.
+
+### Design Tokens — spacing
+
+The `spacing` section defines the spacing design tokens. These may include spacing units that are useful for implementing the layout model. For example, a fixed grid layout may have spacing units for column spans, gutters, and margins. The grid's `gutter:` typically references one of these tokens (`{spacing.md}`).
 
 It is a
 map\<string, Dimension | number> that maps the spacing scale identifier to a dimension value or a unitless number (e.g., column counts or ratios).

--- a/examples/paws-and-paths/DESIGN.md
+++ b/examples/paws-and-paths/DESIGN.md
@@ -320,6 +320,48 @@ themes:
       body: 4.5
       large: 3
       ui: 3
+breakpoints:
+  philosophy: mobile-first
+  values:
+    sm: 640px
+    md: 768px
+    lg: 1024px
+    xl: 1280px
+    "2xl": 1536px
+grid:
+  columns: 12
+  gutter: "{spacing.gutter}"
+  margin:
+    sm: "{spacing.md}"
+    lg: "{spacing.margin}"
+  maxWidth: 1280px
+  bleedExceptions:
+    - hero
+    - gallery
+    - modal-overlay
+layoutRules:
+  contentMaxWidth: 720px
+  stackSpacing: "{spacing.lg}"
+  formFieldWidth: 480px
+templates:
+  marketing:
+    regions: [header, hero, sections, cta, footer]
+    requiredRegions: [header, footer]
+    maxWidth: 1280px
+  app-shell:
+    regions: [topbar, sidebar, main, statusbar]
+    requiredRegions: [topbar, main]
+    sidebarWidth: 280px
+  settings:
+    regions: [topbar, sidebar-nav, content]
+    requiredRegions: [topbar, content]
+pages:
+  "/":
+    template: marketing
+  "/app":
+    template: app-shell
+  "/settings/*":
+    template: settings
 ---
 
 ## Brand & Style
@@ -372,7 +414,41 @@ Paws & Paths ships with a single base palette (the `light` mode) and a `dark` mo
 
 ## Layout & Spacing
 
-The layout follows a **Fixed Grid** model for mobile-first consistency, utilizing a 4-column system for handheld devices.
+The layout follows a **Fixed Grid** model for mobile-first consistency, utilizing a 12-column system at desktop widths and collapsing toward a single column on the smallest viewports.
+
+### Mobile-first
+
+Paws & Paths is mobile-first. Base styles target the smallest viewport (a phone in a coat pocket on a walk); breakpoints are progressive enhancements layered on top. The cascade is `sm 640px → md 768px → lg 1024px → xl 1280px → 2xl 1536px`. Authors who reach for a desktop-first cascade are out of step with the system.
+
+### Breakpoint philosophy
+
+Breakpoints are content-driven, not device-driven. `md` is "two-column layouts become viable"; `lg` is "the sidebar earns its keep"; `xl` is "the marketing hero gets full breathing room." We add a breakpoint when the layout actually breaks, never because a hypothetical tablet exists.
+
+### Responsive content strategy
+
+Narrower viewports restructure, they don't squish. The `card-walk-stat` row collapses from a 3-up grid to a stacked list below `md`; the `app-shell` sidebar slides into a drawer below `lg`; the `card-profile` walker grid drops from 4 → 2 → 1 columns across `lg → md → sm`.
+
+### Grid usage
+
+Components and layout dimensions snap to `grid.gutter` (16px) or to the declared spacing scale. The `off-grid-dimension` rule warns on widths, paddings, gaps, and margins that drift off-grid. The grid itself centers on screens above `grid.maxWidth` (1280px) — past that, we letterbox rather than stretch. Off-grid dimensions are reserved for the regions in `grid.bleedExceptions` (hero artwork, gallery thumbnails, modal overlays).
+
+### Readable measure
+
+Body prose and long-form content stay under `layoutRules.contentMaxWidth` (720px ≈ 65 characters per line at our body size). The "Paths" detail screens use this width even on `2xl`; the brand value of focus beats the visual symmetry of full-width text.
+
+### Page templates
+
+Three templates cover Paws & Paths today:
+
+- **`marketing`** — the public surfaces (`/`, `/pricing`, `/about`). Required regions: `header`, `footer`. The hero uses `bleedExceptions` to break out of the grid.
+- **`app-shell`** — the authenticated walker app (`/app/*`). Required regions: `topbar`, `main`. The 280px sidebar is fixed; the main column flexes against `grid.maxWidth`.
+- **`settings`** — secondary surfaces inside the app (`/settings/*`). Required regions: `topbar`, `content`. Inherits the app chrome but swaps the sidebar for `sidebar-nav`.
+
+Anti-pattern: the marketing template used for an in-app surface (it loses the topbar / sidebar context the user expects), or the app-shell wrapped around the public homepage (the global header/footer disappear).
+
+### Region semantics
+
+`header` is identity + global nav (marketing scope). `topbar` is contextual to the current page (app scope). `sidebar` is persistent navigation; `sidebar-nav` is a sub-navigation rail inside settings. We never use `header` and `topbar` interchangeably — each carries different expectations about scroll behavior and shrinkage.
 
 - **Whitespace:** A "generous" philosophy is applied. Never crowd elements; use `lg` and `xl` spacing for section vertical separation to maintain a high-end aesthetic.
 - **Rhythm:** Spacing is strictly based on an 8px scale.

--- a/examples/paws-and-paths/design_tokens.json
+++ b/examples/paws-and-paths/design_tokens.json
@@ -1332,5 +1332,171 @@
         }
       }
     }
+  },
+  "breakpoints": {
+    "$type": "dimension",
+    "sm": {
+      "$value": {
+        "value": 640,
+        "unit": "px"
+      }
+    },
+    "md": {
+      "$value": {
+        "value": 768,
+        "unit": "px"
+      }
+    },
+    "lg": {
+      "$value": {
+        "value": 1024,
+        "unit": "px"
+      }
+    },
+    "xl": {
+      "$value": {
+        "value": 1280,
+        "unit": "px"
+      }
+    },
+    "2xl": {
+      "$value": {
+        "value": 1536,
+        "unit": "px"
+      }
+    }
+  },
+  "$extensions": {
+    "design.md": {
+      "voice": {
+        "axes": {
+          "formality": 2,
+          "warmth": 5,
+          "authority": 3,
+          "playfulness": 4
+        },
+        "person": "second",
+        "tense": "present-active",
+        "oxfordComma": true,
+        "contractions": "permitted"
+      },
+      "copy": {
+        "casing": {
+          "button": "sentence-case",
+          "nav": "title-case"
+        },
+        "buttonLabelMaxWords": 3,
+        "errorPattern": "{what-happened}. {how-to-fix}.",
+        "emptyStateTone": "encouraging",
+        "bannedTerms": [
+          "seamless",
+          "leverage",
+          "revolutionary"
+        ],
+        "approvedTerms": {
+          "user": "pet parent"
+        }
+      },
+      "breakpoints": {
+        "philosophy": "mobile-first"
+      },
+      "grid": {
+        "columns": 12,
+        "gutter": {
+          "value": 16,
+          "unit": "px"
+        },
+        "maxWidth": {
+          "value": 1280,
+          "unit": "px"
+        },
+        "margin": {
+          "sm": {
+            "value": 24,
+            "unit": "px"
+          },
+          "lg": {
+            "value": 24,
+            "unit": "px"
+          }
+        },
+        "bleedExceptions": [
+          "hero",
+          "gallery",
+          "modal-overlay"
+        ]
+      },
+      "layoutRules": {
+        "contentMaxWidth": {
+          "value": 720,
+          "unit": "px"
+        },
+        "stackSpacing": {
+          "value": 40,
+          "unit": "px"
+        },
+        "formFieldWidth": {
+          "value": 480,
+          "unit": "px"
+        }
+      },
+      "templates": {
+        "marketing": {
+          "regions": [
+            "header",
+            "hero",
+            "sections",
+            "cta",
+            "footer"
+          ],
+          "requiredRegions": [
+            "header",
+            "footer"
+          ],
+          "maxWidth": {
+            "value": 1280,
+            "unit": "px"
+          }
+        },
+        "app-shell": {
+          "regions": [
+            "topbar",
+            "sidebar",
+            "main",
+            "statusbar"
+          ],
+          "requiredRegions": [
+            "topbar",
+            "main"
+          ],
+          "sidebarWidth": {
+            "value": 280,
+            "unit": "px"
+          }
+        },
+        "settings": {
+          "regions": [
+            "topbar",
+            "sidebar-nav",
+            "content"
+          ],
+          "requiredRegions": [
+            "topbar",
+            "content"
+          ]
+        }
+      },
+      "pages": {
+        "/": {
+          "template": "marketing"
+        },
+        "/app": {
+          "template": "app-shell"
+        },
+        "/settings/*": {
+          "template": "settings"
+        }
+      }
+    }
   }
 }

--- a/examples/paws-and-paths/tailwind.config.js
+++ b/examples/paws-and-paths/tailwind.config.js
@@ -171,6 +171,82 @@
         "standard": "cubic-bezier(0.4, 0, 0.2, 1)",
         "decelerate": "cubic-bezier(0, 0, 0.2, 1)",
         "accelerate": "cubic-bezier(0.4, 0, 1, 1)"
+      },
+      "screens": {
+        "sm": "640px",
+        "md": "768px",
+        "lg": "1024px",
+        "xl": "1280px",
+        "2xl": "1536px"
+      },
+      "maxWidth": {
+        "container": "1280px",
+        "prose": "720px"
+      }
+    },
+    "container": {
+      "center": true,
+      "padding": {
+        "DEFAULT": "24px",
+        "lg": "24px"
+      }
+    }
+  },
+  "themes": {
+    "dark": {
+      "colors": {
+        "surface": "#0f1420",
+        "surface-dim": "#0a0e18",
+        "surface-bright": "#1c2230",
+        "surface-container-lowest": "#070a12",
+        "surface-container-low": "#141a26",
+        "surface-container": "#1a2030",
+        "surface-container-high": "#212838",
+        "surface-container-highest": "#2a3142",
+        "on-surface": "#e7ecf8",
+        "on-surface-variant": "#bfbab2",
+        "inverse-surface": "#e7ecf8",
+        "inverse-on-surface": "#151c27",
+        "outline": "#9c8a76",
+        "outline-variant": "#574a3c",
+        "surface-tint": "#ffb95f",
+        "primary": "#ffb95f",
+        "on-primary": "#3d2400",
+        "primary-container": "#5b3500",
+        "on-primary-container": "#ffddb8",
+        "inverse-primary": "#855300",
+        "secondary": "#adc6ff",
+        "on-secondary": "#001a42",
+        "secondary-container": "#003a89",
+        "on-secondary-container": "#d8e2ff",
+        "tertiary": "#7fd0ff",
+        "on-tertiary": "#001e2d",
+        "tertiary-container": "#004966",
+        "on-tertiary-container": "#c5e7ff",
+        "error": "#ffb4ab",
+        "on-error": "#690005",
+        "error-container": "#93000a",
+        "on-error-container": "#ffdad6",
+        "primary-fixed": "#ffddb8",
+        "primary-fixed-dim": "#ffb95f",
+        "on-primary-fixed": "#2a1700",
+        "on-primary-fixed-variant": "#653e00",
+        "secondary-fixed": "#d8e2ff",
+        "secondary-fixed-dim": "#adc6ff",
+        "on-secondary-fixed": "#001a42",
+        "on-secondary-fixed-variant": "#004395",
+        "tertiary-fixed": "#c5e7ff",
+        "tertiary-fixed-dim": "#7fd0ff",
+        "on-tertiary-fixed": "#001e2d",
+        "on-tertiary-fixed-variant": "#004c6a",
+        "background": "#0f1420",
+        "on-background": "#e7ecf8",
+        "surface-variant": "#2a3142"
+      },
+      "contrastTarget": {
+        "body": 4.5,
+        "large": 3,
+        "ui": 3
       }
     }
   }

--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -89,6 +89,6 @@ describe('spec command', () => {
     const output = JSON.parse(outputStr);
     expect(output.spec).toBeDefined();
     expect(output.rules).toBeDefined();
-    expect(output.rules.length).toBe(38);
+    expect(output.rules.length).toBe(43);
   });
 });

--- a/packages/cli/src/linter/dtcg/handler.ts
+++ b/packages/cli/src/linter/dtcg/handler.ts
@@ -57,13 +57,97 @@ export class DtcgEmitterHandler implements DtcgEmitterSpec {
     const componentGroup = this.mapComponents(state);
     if (componentGroup) file['component'] = componentGroup;
 
+    const breakpointGroup = this.mapBreakpoints(state);
+    if (breakpointGroup) file['breakpoints'] = breakpointGroup;
+
+    const layoutExtension = this.mapLayoutExtension(state);
     const voiceCopyExtension = this.mapVoiceCopyExtension(state);
-    if (voiceCopyExtension) {
+    if (voiceCopyExtension || layoutExtension) {
       const existing = file.$extensions ?? {};
-      file.$extensions = { ...existing, [DESIGN_MD_EXTENSION_KEY]: voiceCopyExtension };
+      const merged: Record<string, unknown> = {
+        ...(existing[DESIGN_MD_EXTENSION_KEY] as Record<string, unknown> | undefined ?? {}),
+        ...(voiceCopyExtension ?? {}),
+        ...(layoutExtension ?? {}),
+      };
+      file.$extensions = { ...existing, [DESIGN_MD_EXTENSION_KEY]: merged };
     }
 
     return { success: true, data: file as Record<string, unknown> };
+  }
+
+  /**
+   * Emit `breakpoints.values` as a sibling DTCG `dimension` group so consumers
+   * can address `{breakpoints.md}`. Philosophy and the absence/presence of
+   * the block live under `$extensions['design.md'].breakpoints` (see
+   * `mapLayoutExtension`).
+   */
+  private mapBreakpoints(state: DesignSystemState): DtcgGroup | null {
+    if (!state.breakpoints || state.breakpoints.values.size === 0) return null;
+    const group: DtcgGroup = { $type: 'dimension' };
+    for (const [name, dim] of state.breakpoints.values) {
+      group[name] = {
+        $value: this.dimToValue(dim),
+      } as DtcgToken;
+    }
+    return group;
+  }
+
+  /**
+   * Layout primitives that have no DTCG-native types — grid, layoutRules,
+   * templates, pages, plus the breakpoint philosophy — are surfaced under
+   * `$extensions['design.md']` as opaque structured data.
+   */
+  private mapLayoutExtension(state: DesignSystemState): Record<string, unknown> | null {
+    const out: Record<string, unknown> = {};
+    if (state.breakpoints) {
+      out['breakpoints'] = { philosophy: state.breakpoints.philosophy };
+    }
+    if (state.grid) {
+      const grid: Record<string, unknown> = { columns: state.grid.columns };
+      if (state.grid.gutter) grid['gutter'] = this.dimToValue(state.grid.gutter);
+      if (state.grid.maxWidth) grid['maxWidth'] = this.dimToValue(state.grid.maxWidth);
+      if (state.grid.margin.size > 0) {
+        const margin: Record<string, unknown> = {};
+        for (const [k, v] of state.grid.margin) margin[k] = this.dimToValue(v);
+        grid['margin'] = margin;
+      }
+      if (state.grid.bleedExceptions.length > 0) {
+        grid['bleedExceptions'] = [...state.grid.bleedExceptions];
+      }
+      out['grid'] = grid;
+    }
+    if (state.layoutRules) {
+      const rules: Record<string, unknown> = {};
+      if (state.layoutRules.contentMaxWidth) rules['contentMaxWidth'] = this.dimToValue(state.layoutRules.contentMaxWidth);
+      if (state.layoutRules.stackSpacing) rules['stackSpacing'] = this.dimToValue(state.layoutRules.stackSpacing);
+      if (state.layoutRules.formFieldWidth) rules['formFieldWidth'] = this.dimToValue(state.layoutRules.formFieldWidth);
+      if (Object.keys(rules).length > 0) out['layoutRules'] = rules;
+    }
+    if (state.templates && state.templates.size > 0) {
+      const tpls: Record<string, unknown> = {};
+      for (const [name, tpl] of state.templates) {
+        const t: Record<string, unknown> = {
+          regions: [...tpl.regions],
+          requiredRegions: [...tpl.requiredRegions],
+        };
+        if (tpl.maxWidth) t['maxWidth'] = this.dimToValue(tpl.maxWidth);
+        if (tpl.sidebarWidth) t['sidebarWidth'] = this.dimToValue(tpl.sidebarWidth);
+        if (tpl.container) t['container'] = tpl.container;
+        for (const [k, v] of tpl.extras) t[k] = v;
+        tpls[name] = t;
+      }
+      out['templates'] = tpls;
+    }
+    if (state.pages && state.pages.size > 0) {
+      const pages: Record<string, unknown> = {};
+      for (const [pattern, page] of state.pages) {
+        const p: Record<string, unknown> = { template: page.template };
+        if (page.regions) p['regions'] = [...page.regions];
+        pages[pattern] = p;
+      }
+      out['pages'] = pages;
+    }
+    return Object.keys(out).length > 0 ? out : null;
   }
 
   /**

--- a/packages/cli/src/linter/linter/rules/breakpoint-monotonicity.test.ts
+++ b/packages/cli/src/linter/linter/rules/breakpoint-monotonicity.test.ts
@@ -1,0 +1,78 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { breakpointMonotonicity, breakpointMonotonicityRule } from './breakpoint-monotonicity.js';
+import { buildState } from './test-helpers.js';
+
+describe('breakpointMonotonicity', () => {
+  it('passes when values are strictly ascending', () => {
+    const state = buildState({
+      breakpoints: {
+        philosophy: 'mobile-first',
+        values: { sm: '640px', md: '768px', lg: '1024px', xl: '1280px', '2xl': '1536px' },
+      },
+    });
+    expect(breakpointMonotonicity(state)).toEqual([]);
+  });
+
+  it('flags a breakpoint that is not greater than the previous one', () => {
+    const state = buildState({
+      breakpoints: {
+        philosophy: 'mobile-first',
+        values: { sm: '640px', md: '600px', lg: '1024px' },
+      },
+    });
+    const findings = breakpointMonotonicity(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain("'md'");
+  });
+
+  it('flags equal-valued adjacent breakpoints', () => {
+    const state = buildState({
+      breakpoints: {
+        philosophy: 'mobile-first',
+        values: { sm: '640px', md: '640px' },
+      },
+    });
+    expect(breakpointMonotonicity(state).length).toBe(1);
+  });
+
+  it('mixes px and rem units consistently', () => {
+    const state = buildState({
+      breakpoints: {
+        philosophy: 'mobile-first',
+        values: { sm: '40rem', md: '48rem', lg: '64rem' }, // 640, 768, 1024 px-equivalent
+      },
+    });
+    expect(breakpointMonotonicity(state)).toEqual([]);
+  });
+
+  it('no-ops when fewer than two breakpoints are declared', () => {
+    const state = buildState({
+      breakpoints: { values: { sm: '640px' } },
+    });
+    expect(breakpointMonotonicity(state)).toEqual([]);
+  });
+
+  it('no-ops when breakpoints are absent', () => {
+    const state = buildState({});
+    expect(breakpointMonotonicity(state)).toEqual([]);
+  });
+
+  it('has a valid descriptor', () => {
+    expect(breakpointMonotonicityRule.name).toBe('breakpoint-monotonicity');
+    expect(breakpointMonotonicityRule.severity).toBe('error');
+  });
+});

--- a/packages/cli/src/linter/linter/rules/breakpoint-monotonicity.ts
+++ b/packages/cli/src/linter/linter/rules/breakpoint-monotonicity.ts
@@ -1,0 +1,68 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState, ResolvedDimension } from '../../model/spec.js';
+import { BREAKPOINT_KEYS } from '../../spec-config.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Convert a breakpoint dimension to a comparable px value. `rem`/`em` are
+ * approximated against a 16px root; that's sufficient for monotonicity since
+ * authors rarely interleave units across breakpoints.
+ */
+function toPx(dim: ResolvedDimension): number {
+  if (dim.unit === 'px') return dim.value;
+  if (dim.unit === 'rem' || dim.unit === 'em') return dim.value * 16;
+  return dim.value;
+}
+
+/**
+ * Breakpoint monotonicity — values must increase across the conventional
+ * `sm < md < lg < xl < 2xl` order. Catches typos (e.g., `md: 1280px`,
+ * `lg: 768px`) that would otherwise silently produce broken responsive
+ * cascades. Authors may declare additional keys outside the conventional
+ * order; those are ignored by this rule.
+ */
+export function breakpointMonotonicity(state: DesignSystemState): RuleFinding[] {
+  if (!state.breakpoints) return [];
+  const values = state.breakpoints.values;
+  if (values.size < 2) return [];
+
+  const findings: RuleFinding[] = [];
+  const ordered: { key: string; px: number }[] = [];
+  for (const key of BREAKPOINT_KEYS) {
+    const dim = values.get(key);
+    if (dim) ordered.push({ key, px: toPx(dim) });
+  }
+
+  for (let i = 1; i < ordered.length; i++) {
+    const prev = ordered[i - 1]!;
+    const curr = ordered[i]!;
+    if (curr.px <= prev.px) {
+      findings.push({
+        path: `breakpoints.values.${curr.key}`,
+        message: `Breakpoint '${curr.key}' (${curr.px}px) is not greater than '${prev.key}' (${prev.px}px). Conventional order is sm < md < lg < xl < 2xl.`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+export const breakpointMonotonicityRule: RuleDescriptor = {
+  name: 'breakpoint-monotonicity',
+  severity: 'error',
+  description: 'Breakpoint values must increase across the conventional sm < md < lg < xl < 2xl sequence.',
+  run: breakpointMonotonicity,
+};

--- a/packages/cli/src/linter/linter/rules/index.ts
+++ b/packages/cli/src/linter/linter/rules/index.ts
@@ -53,6 +53,11 @@ import { casingMismatchRule } from './casing-mismatch.js';
 import { approvedTermViolationRule } from './approved-term-violation.js';
 import { reservedNameFormRule } from './reserved-name-form.js';
 import { errorPatternViolationRule } from './error-pattern-violation.js';
+import { breakpointMonotonicityRule } from './breakpoint-monotonicity.js';
+import { unknownTemplateRule } from './unknown-template.js';
+import { missingRegionRule } from './missing-region.js';
+import { offGridDimensionRule } from './off-grid-dimension.js';
+import { templateRegionPurityRule } from './template-region-purity.js';
 
 /** The default set of lint rule descriptors, in order. */
 export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
@@ -94,6 +99,11 @@ export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
   approvedTermViolationRule,
   reservedNameFormRule,
   errorPatternViolationRule,
+  breakpointMonotonicityRule,
+  unknownTemplateRule,
+  missingRegionRule,
+  offGridDimensionRule,
+  templateRegionPurityRule,
 ];
 
 /** Converts a RuleDescriptor into a LintRule by injecting severity into findings. */
@@ -148,4 +158,9 @@ export { casingMismatch } from './casing-mismatch.js';
 export { approvedTermViolation } from './approved-term-violation.js';
 export { reservedNameForm } from './reserved-name-form.js';
 export { errorPatternViolation } from './error-pattern-violation.js';
+export { breakpointMonotonicity } from './breakpoint-monotonicity.js';
+export { unknownTemplate } from './unknown-template.js';
+export { missingRegion } from './missing-region.js';
+export { offGridDimension } from './off-grid-dimension.js';
+export { templateRegionPurity } from './template-region-purity.js';
 export type { LintRule } from './types.js';

--- a/packages/cli/src/linter/linter/rules/missing-region.test.ts
+++ b/packages/cli/src/linter/linter/rules/missing-region.test.ts
@@ -1,0 +1,82 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { missingRegion, missingRegionRule } from './missing-region.js';
+import type { ParsedDesignSystem } from '../../parser/spec.js';
+import { buildState } from './test-helpers.js';
+
+function withRegions(overrides: Partial<ParsedDesignSystem> & {
+  pageRegions?: Record<string, string[]>;
+}) {
+  const { pageRegions, ...rest } = overrides;
+  const state = buildState(rest);
+  if (pageRegions && state.pages) {
+    for (const [pattern, regions] of Object.entries(pageRegions)) {
+      const page = state.pages.get(pattern);
+      if (page) page.regions = regions;
+    }
+  }
+  return state;
+}
+
+describe('missingRegion', () => {
+  it('flags a page missing a required region', () => {
+    const state = withRegions({
+      templates: {
+        marketing: { regions: ['header', 'hero', 'footer'], requiredRegions: ['header', 'footer'] },
+      },
+      pages: { '/': { template: 'marketing' } },
+      pageRegions: { '/': ['hero', 'footer'] }, // missing header
+    });
+    const findings = missingRegion(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain('header');
+  });
+
+  it('passes when every required region is present', () => {
+    const state = withRegions({
+      templates: {
+        marketing: { regions: ['header', 'hero', 'footer'], requiredRegions: ['header', 'footer'] },
+      },
+      pages: { '/': { template: 'marketing' } },
+      pageRegions: { '/': ['header', 'hero', 'footer'] },
+    });
+    expect(missingRegion(state)).toEqual([]);
+  });
+
+  it('no-ops when the page declares no regions', () => {
+    const state = buildState({
+      templates: {
+        marketing: { regions: ['header', 'footer'], requiredRegions: ['header', 'footer'] },
+      },
+      pages: { '/': { template: 'marketing' } },
+    });
+    expect(missingRegion(state)).toEqual([]);
+  });
+
+  it('skips pages whose template does not exist (handled by unknown-template)', () => {
+    const state = withRegions({
+      templates: { marketing: { regions: ['header'], requiredRegions: ['header'] } },
+      pages: { '/x': { template: 'phantom' } },
+      pageRegions: { '/x': [] },
+    });
+    expect(missingRegion(state)).toEqual([]);
+  });
+
+  it('has a valid descriptor', () => {
+    expect(missingRegionRule.name).toBe('missing-region');
+    expect(missingRegionRule.severity).toBe('error');
+  });
+});

--- a/packages/cli/src/linter/linter/rules/missing-region.ts
+++ b/packages/cli/src/linter/linter/rules/missing-region.ts
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Missing region — a page declared with template T whose enumerated regions
+ * miss a `requiredRegions` entry. Today the rule reads regions from the
+ * page's optional `regions:` field in DESIGN.md `pages:`. Source-side
+ * scanning (`data-region` extraction via `--src`) plugs in here when issue
+ * #6's source scanner is extended to template/region handling.
+ *
+ * No-op when the page declares no regions (the rule has nothing to validate
+ * against without a source scanner).
+ */
+export function missingRegion(state: DesignSystemState): RuleFinding[] {
+  const templates = state.templates;
+  const pages = state.pages;
+  if (!templates || !pages) return [];
+
+  const findings: RuleFinding[] = [];
+  for (const [pattern, page] of pages) {
+    const tpl = templates.get(page.template);
+    if (!tpl) continue; // unknown-template handles this
+    if (!page.regions || page.regions.length === 0) continue;
+    const declared = new Set(page.regions);
+    for (const required of tpl.requiredRegions) {
+      if (!declared.has(required)) {
+        findings.push({
+          path: `pages.${pattern}.regions`,
+          message: `Page '${pattern}' uses template '${page.template}' but is missing required region '${required}'.`,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+export const missingRegionRule: RuleDescriptor = {
+  name: 'missing-region',
+  severity: 'error',
+  description: 'Missing region — a page is missing a region required by its template.',
+  run: missingRegion,
+};

--- a/packages/cli/src/linter/linter/rules/off-grid-dimension.test.ts
+++ b/packages/cli/src/linter/linter/rules/off-grid-dimension.test.ts
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { offGridDimension, offGridDimensionRule } from './off-grid-dimension.js';
+import { buildState } from './test-helpers.js';
+
+describe('offGridDimension', () => {
+  it('flags a width that is not a multiple of the grid gutter and not a spacing token', () => {
+    const state = buildState({
+      spacing: { md: '16px' },
+      grid: { columns: 12, gutter: '16px' },
+      components: { card: { width: '13px' } },
+    });
+    const findings = offGridDimension(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('components.card.width');
+  });
+
+  it('passes a width that is a multiple of the grid gutter', () => {
+    const state = buildState({
+      spacing: { md: '16px' },
+      grid: { columns: 12, gutter: '16px' },
+      components: { card: { width: '64px' } }, // 4 * 16
+    });
+    expect(offGridDimension(state)).toEqual([]);
+  });
+
+  it('passes a value that matches a declared spacing token', () => {
+    const state = buildState({
+      spacing: { lg: '24px' },
+      grid: { columns: 12, gutter: '16px' },
+      components: { card: { padding: '24px' } },
+    });
+    expect(offGridDimension(state)).toEqual([]);
+  });
+
+  it('skips properties that are not gridded (e.g. typography)', () => {
+    const state = buildState({
+      spacing: { md: '16px' },
+      grid: { columns: 12, gutter: '16px' },
+      components: { card: { rounded: '13px' } }, // rounded is not in GRIDDED_PROPS
+    });
+    expect(offGridDimension(state)).toEqual([]);
+  });
+
+  it('no-ops when neither grid nor spacing is declared', () => {
+    const state = buildState({
+      components: { card: { width: '13px' } },
+    });
+    expect(offGridDimension(state)).toEqual([]);
+  });
+
+  it('has a valid descriptor', () => {
+    expect(offGridDimensionRule.name).toBe('off-grid-dimension');
+    expect(offGridDimensionRule.severity).toBe('warning');
+  });
+});

--- a/packages/cli/src/linter/linter/rules/off-grid-dimension.ts
+++ b/packages/cli/src/linter/linter/rules/off-grid-dimension.ts
@@ -1,0 +1,98 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState, ResolvedDimension, ResolvedValue } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+const GRIDDED_PROPS = ['width', 'height', 'padding', 'gap', 'margin'];
+
+/**
+ * Convert a Dimension to a px value for divisibility comparison. `rem` /
+ * `em` are normalized against a 16px root. Other units are not gridded
+ * (return null) so the rule skips them.
+ */
+function toPx(dim: ResolvedDimension): number | null {
+  if (dim.unit === 'px') return dim.value;
+  if (dim.unit === 'rem' || dim.unit === 'em') return dim.value * 16;
+  return null;
+}
+
+/**
+ * Build the set of px values that count as "on grid": every spacing token
+ * value, plus every multiple of the grid gutter up to a generous ceiling.
+ */
+function buildAllowed(state: DesignSystemState): Set<number> | null {
+  const allowed = new Set<number>();
+  for (const dim of state.spacing.values()) {
+    const px = toPx(dim);
+    if (px !== null) allowed.add(px);
+  }
+  const gutter = state.grid?.gutter;
+  if (!gutter) return allowed.size > 0 ? allowed : null;
+  const gutterPx = toPx(gutter);
+  if (gutterPx === null || gutterPx <= 0) return allowed.size > 0 ? allowed : null;
+  // 0 is always on-grid; populate multiples up to a typical max layout dim.
+  allowed.add(0);
+  for (let i = 1; i * gutterPx <= 2048; i++) {
+    allowed.add(i * gutterPx);
+  }
+  return allowed;
+}
+
+function getDimension(value: ResolvedValue): ResolvedDimension | null {
+  if (typeof value === 'object' && value !== null && 'type' in value && value.type === 'dimension') {
+    return value as ResolvedDimension;
+  }
+  return null;
+}
+
+/**
+ * Off-grid dimension — components whose layout dimensions (`width`, `height`,
+ * `padding`, `gap`, `margin`) are neither a declared spacing-token value nor
+ * a multiple of `grid.gutter`. Catches one-off magic numbers (`13px`,
+ * `27px`) that drift away from the system's rhythm.
+ *
+ * No-op when neither `grid.gutter` nor any spacing token is defined — the
+ * rule needs *something* to compare against.
+ */
+export function offGridDimension(state: DesignSystemState): RuleFinding[] {
+  const allowed = buildAllowed(state);
+  if (!allowed || allowed.size === 0) return [];
+
+  const findings: RuleFinding[] = [];
+  for (const [compName, comp] of state.components) {
+    for (const propName of GRIDDED_PROPS) {
+      const value = comp.properties.get(propName);
+      if (value === undefined) continue;
+      const dim = getDimension(value);
+      if (!dim) continue;
+      const px = toPx(dim);
+      if (px === null) continue;
+      if (!allowed.has(px)) {
+        findings.push({
+          path: `components.${compName}.${propName}`,
+          message: `'${dim.value}${dim.unit}' is off-grid. Snap to a {spacing.*} token or a multiple of grid.gutter.`,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+export const offGridDimensionRule: RuleDescriptor = {
+  name: 'off-grid-dimension',
+  severity: 'warning',
+  description: 'Off-grid dimension — layout dimensions that are not a spacing token or a grid-gutter multiple.',
+  run: offGridDimension,
+};

--- a/packages/cli/src/linter/linter/rules/template-region-purity.test.ts
+++ b/packages/cli/src/linter/linter/rules/template-region-purity.test.ts
@@ -1,0 +1,81 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { templateRegionPurity, templateRegionPurityRule } from './template-region-purity.js';
+import { buildState } from './test-helpers.js';
+
+describe('templateRegionPurity', () => {
+  it('flags `header` reused across marketing and app-scoped templates', () => {
+    const state = buildState({
+      templates: {
+        // marketing-scoped (has `hero`)
+        marketing: { regions: ['header', 'hero', 'footer'], requiredRegions: [] },
+        // app-scoped (no marketing markers); reuses `header`
+        'app-shell': { regions: ['header', 'sidebar', 'main'], requiredRegions: [] },
+      },
+    });
+    const findings = templateRegionPurity(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toContain("'header'");
+    expect(findings[0]!.message).toContain('marketing');
+    expect(findings[0]!.message).toContain('app-shell');
+  });
+
+  it('passes the canonical pattern: header in marketing, topbar in app templates', () => {
+    const state = buildState({
+      templates: {
+        marketing: { regions: ['header', 'hero', 'cta', 'footer'], requiredRegions: [] },
+        'app-shell': { regions: ['topbar', 'sidebar', 'main', 'statusbar'], requiredRegions: [] },
+        settings: { regions: ['topbar', 'sidebar-nav', 'content'], requiredRegions: [] },
+      },
+    });
+    expect(templateRegionPurity(state)).toEqual([]);
+  });
+
+  it('does not flag region reuse within the same scope', () => {
+    const state = buildState({
+      templates: {
+        // both app-scoped
+        'app-shell': { regions: ['topbar', 'sidebar', 'main'], requiredRegions: [] },
+        settings: { regions: ['topbar', 'sidebar-nav', 'content'], requiredRegions: [] },
+      },
+    });
+    expect(templateRegionPurity(state)).toEqual([]);
+  });
+
+  it('no-ops when fewer than two templates are declared', () => {
+    const state = buildState({
+      templates: {
+        marketing: { regions: ['header', 'hero', 'footer'], requiredRegions: [] },
+      },
+    });
+    expect(templateRegionPurity(state)).toEqual([]);
+  });
+
+  it('no-ops when only marketing-scoped or only app-scoped templates exist', () => {
+    const state = buildState({
+      templates: {
+        marketing: { regions: ['header', 'hero', 'footer'], requiredRegions: [] },
+        'marketing-thin': { regions: ['header', 'sections'], requiredRegions: [] },
+      },
+    });
+    expect(templateRegionPurity(state)).toEqual([]);
+  });
+
+  it('has a valid descriptor', () => {
+    expect(templateRegionPurityRule.name).toBe('template-region-purity');
+    expect(templateRegionPurityRule.severity).toBe('warning');
+  });
+});

--- a/packages/cli/src/linter/linter/rules/template-region-purity.ts
+++ b/packages/cli/src/linter/linter/rules/template-region-purity.ts
@@ -1,0 +1,86 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState, TemplateDef } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * A template is "marketing-scoped" if it carries the public-page vocabulary
+ * (`hero` or `cta` or `sections`). Identity-level chrome on a marketing-scoped
+ * template means something different from chrome on an app-scoped template,
+ * even when the region name is the same.
+ */
+function isMarketingScoped(tpl: TemplateDef): boolean {
+  for (const r of tpl.regions) {
+    if (r === 'hero' || r === 'cta' || r === 'sections') return true;
+  }
+  return false;
+}
+
+/**
+ * Region names whose semantics differ between marketing pages (where they
+ * mean global identity / global nav) and app surfaces (where they're
+ * contextual to the current page). Reusing one of these across both scopes
+ * is the signal that authors should pick distinct names — typically `header`
+ * (marketing) vs `topbar` (app).
+ */
+const SCOPE_AMBIGUOUS_REGIONS = new Set(['header', 'footer', 'sidebar']);
+
+/**
+ * Template-region purity — flags a region name that appears in BOTH a
+ * marketing-scoped template (identity-level chrome, with `hero`/`cta`/
+ * `sections`) AND a non-marketing-scoped template (app-shell, settings,
+ * detail, ...). The two scopes carry different expectations: a marketing
+ * `header` is global identity; an app-level `header` is contextual to the
+ * current page. Pick distinct names so the linter — and the AI generating
+ * UI — don't have to guess which kind of chrome is meant.
+ *
+ * The recommended fix is to keep `header` for marketing and use `topbar`
+ * for app-scope chrome. (Symmetric for `footer` / `statusbar` and
+ * `sidebar` / `sidebar-nav`.)
+ */
+export function templateRegionPurity(state: DesignSystemState): RuleFinding[] {
+  const templates = state.templates;
+  if (!templates || templates.size < 2) return [];
+
+  // Bucket templates by scope.
+  const marketing: Array<{ name: string; regions: Set<string> }> = [];
+  const other: Array<{ name: string; regions: Set<string> }> = [];
+  for (const [name, tpl] of templates) {
+    const entry = { name, regions: new Set(tpl.regions) };
+    if (isMarketingScoped(tpl)) marketing.push(entry);
+    else other.push(entry);
+  }
+  if (marketing.length === 0 || other.length === 0) return [];
+
+  const findings: RuleFinding[] = [];
+  for (const region of SCOPE_AMBIGUOUS_REGIONS) {
+    const marketingHits = marketing.filter(m => m.regions.has(region)).map(m => m.name);
+    const otherHits = other.filter(o => o.regions.has(region)).map(o => o.name);
+    if (marketingHits.length > 0 && otherHits.length > 0) {
+      findings.push({
+        path: 'templates',
+        message: `Region '${region}' appears in marketing-scoped templates (${marketingHits.join(', ')}) and app-scoped templates (${otherHits.join(', ')}). The two scopes carry different semantics; pick distinct names (e.g., 'header' for marketing, 'topbar' for app).`,
+      });
+    }
+  }
+  return findings;
+}
+
+export const templateRegionPurityRule: RuleDescriptor = {
+  name: 'template-region-purity',
+  severity: 'warning',
+  description: 'Template region purity — flags region names reused across marketing and app-scoped templates.',
+  run: templateRegionPurity,
+};

--- a/packages/cli/src/linter/linter/rules/types.test.ts
+++ b/packages/cli/src/linter/linter/rules/types.test.ts
@@ -47,7 +47,7 @@ describe('LintRule type', () => {
   });
 
   it('has all rules in DEFAULT_RULE_DESCRIPTORS', () => {
-    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(38);
+    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(43);
     DEFAULT_RULE_DESCRIPTORS.forEach((rule: RuleDescriptor) => {
       expect(rule.name).toBeTruthy();
       expect(rule.severity).toBeTruthy();

--- a/packages/cli/src/linter/linter/rules/unknown-template.test.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-template.test.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { unknownTemplate, unknownTemplateRule } from './unknown-template.js';
+import { buildState } from './test-helpers.js';
+
+describe('unknownTemplate', () => {
+  it('flags a page referencing a template not in the registry', () => {
+    const state = buildState({
+      templates: {
+        marketing: { regions: ['header', 'hero', 'footer'], requiredRegions: ['header', 'footer'] },
+      },
+      pages: {
+        '/': { template: 'marketing' },
+        '/dashboard': { template: 'admin-shell' },
+      },
+    });
+    const findings = unknownTemplate(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('pages./dashboard.template');
+    expect(findings[0]!.message).toContain('admin-shell');
+  });
+
+  it('passes when every page references a known template', () => {
+    const state = buildState({
+      templates: {
+        marketing: { regions: ['header', 'footer'], requiredRegions: [] },
+        'app-shell': { regions: ['topbar', 'main'], requiredRegions: [] },
+      },
+      pages: {
+        '/': { template: 'marketing' },
+        '/app': { template: 'app-shell' },
+      },
+    });
+    expect(unknownTemplate(state)).toEqual([]);
+  });
+
+  it('no-ops when templates or pages are absent', () => {
+    expect(unknownTemplate(buildState({ pages: { '/': { template: 'x' } } }))).toEqual([]);
+    expect(unknownTemplate(buildState({}))).toEqual([]);
+  });
+
+  it('has a valid descriptor', () => {
+    expect(unknownTemplateRule.name).toBe('unknown-template');
+    expect(unknownTemplateRule.severity).toBe('error');
+  });
+});

--- a/packages/cli/src/linter/linter/rules/unknown-template.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-template.ts
@@ -1,0 +1,52 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * Unknown template — a `pages.X.template` references a name that is not in
+ * the `templates` registry. Closed-world enforcement: once a template
+ * registry exists, every page must use one of its entries.
+ *
+ * No-op when either `templates` or `pages` is absent.
+ */
+export function unknownTemplate(state: DesignSystemState): RuleFinding[] {
+  const templates = state.templates;
+  const pages = state.pages;
+  if (!templates || !pages) return [];
+
+  const findings: RuleFinding[] = [];
+  const known = templates;
+  for (const [pattern, page] of pages) {
+    if (!known.has(page.template)) {
+      const available = [...known.keys()];
+      const recognized = available.length > 0
+        ? `Recognized: ${available.join(', ')}.`
+        : 'No templates declared.';
+      findings.push({
+        path: `pages.${pattern}.template`,
+        message: `Page '${pattern}' references template '${page.template}', which is not in the templates registry. ${recognized}`,
+      });
+    }
+  }
+  return findings;
+}
+
+export const unknownTemplateRule: RuleDescriptor = {
+  name: 'unknown-template',
+  severity: 'error',
+  description: 'Unknown template — a page references a template name not in the registry.',
+  run: unknownTemplate,
+};

--- a/packages/cli/src/linter/model/handler.layout.test.ts
+++ b/packages/cli/src/linter/model/handler.layout.test.ts
@@ -1,0 +1,107 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { ModelHandler } from './handler.js';
+import type { ParsedDesignSystem } from '../parser/spec.js';
+
+function build(overrides: Partial<ParsedDesignSystem>) {
+  const parsed: ParsedDesignSystem = { sourceMap: new Map(), ...overrides };
+  return new ModelHandler().execute(parsed);
+}
+
+describe('ModelHandler — layout (breakpoints, grid, layoutRules, templates, pages)', () => {
+  it('parses a full breakpoint block and stores resolved dimensions', () => {
+    const result = build({
+      breakpoints: {
+        philosophy: 'mobile-first',
+        values: { sm: '640px', md: '768px', lg: '1024px' },
+      },
+    });
+    expect(result.designSystem.breakpoints?.philosophy).toBe('mobile-first');
+    const md = result.designSystem.breakpoints?.values.get('md');
+    expect(md?.value).toBe(768);
+    expect(md?.unit).toBe('px');
+  });
+
+  it('flags an unknown breakpoint philosophy', () => {
+    const result = build({
+      breakpoints: { philosophy: 'tablet-first', values: {} },
+    });
+    expect(result.findings.some(f => f.path === 'breakpoints.philosophy')).toBe(true);
+  });
+
+  it('resolves grid.gutter through a spacing token reference', () => {
+    const result = build({
+      spacing: { md: '16px' },
+      grid: { columns: 12, gutter: '{spacing.md}', maxWidth: '1280px' },
+    });
+    expect(result.designSystem.grid?.gutter?.value).toBe(16);
+    expect(result.designSystem.grid?.maxWidth?.value).toBe(1280);
+    expect(result.designSystem.grid?.columns).toBe(12);
+  });
+
+  it('flags non-positive integer columns', () => {
+    const result = build({
+      grid: { columns: -3 },
+    });
+    expect(result.findings.some(f => f.path === 'grid.columns')).toBe(true);
+  });
+
+  it('parses layoutRules with token references', () => {
+    const result = build({
+      spacing: { lg: '24px' },
+      layoutRules: { contentMaxWidth: '720px', stackSpacing: '{spacing.lg}', formFieldWidth: '480px' },
+    });
+    expect(result.designSystem.layoutRules?.contentMaxWidth?.value).toBe(720);
+    expect(result.designSystem.layoutRules?.stackSpacing?.value).toBe(24);
+    expect(result.designSystem.layoutRules?.formFieldWidth?.value).toBe(480);
+  });
+
+  it('validates that requiredRegions ⊆ regions', () => {
+    const result = build({
+      templates: {
+        marketing: { regions: ['header', 'hero'], requiredRegions: ['header', 'footer'] },
+      },
+    });
+    expect(result.findings.some(f =>
+      f.path === 'templates.marketing.requiredRegions' && f.message.includes('footer')
+    )).toBe(true);
+  });
+
+  it('preserves template extras', () => {
+    const result = build({
+      templates: {
+        'app-shell': {
+          regions: ['topbar', 'sidebar', 'main'],
+          requiredRegions: ['main'],
+          sidebarWidth: '280px',
+          container: 'centered',
+        },
+      },
+    });
+    const tpl = result.designSystem.templates?.get('app-shell');
+    expect(tpl?.sidebarWidth?.value).toBe(280);
+    expect(tpl?.container).toBe('centered');
+  });
+
+  it('parses pages and rejects entries without a template', () => {
+    const result = build({
+      pages: {
+        '/': { template: 'marketing' },
+      },
+    });
+    expect(result.designSystem.pages?.get('/')?.template).toBe('marketing');
+  });
+});

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { ParsedDesignSystem, RawColorValue, RawRampDef, RawPairDef, RawMotionDef, RawIconographyDef, RawRegistryEntry, RawComponentValue, RawThemeDef, RawVoice, RawCopy } from '../parser/spec.js';
+import type { ParsedDesignSystem, RawColorValue, RawRampDef, RawPairDef, RawMotionDef, RawIconographyDef, RawRegistryEntry, RawComponentValue, RawThemeDef, RawVoice, RawCopy, RawBreakpointsDef, RawGridDef, RawLayoutRulesDef, RawTemplateDef, RawPageDef } from '../parser/spec.js';
 import type {
   ModelSpec,
   ModelResult,
@@ -36,6 +36,11 @@ import type {
   BannedRegex,
   ThemeView,
   ThemeContrastTarget,
+  BreakpointsState,
+  GridState,
+  LayoutRulesState,
+  TemplateDef,
+  PageDef,
 } from './spec.js';
 import { DEFAULT_CONTRAST_TARGET } from './spec.js';
 
@@ -50,7 +55,7 @@ import {
 } from './spec.js';
 import { COMPONENT_SUB_TOKEN_VALIDATORS } from '../component-validators.js';
 import { generateRampSteps, DEFAULT_RAMP_STEPS } from './color-ramp.js';
-import { ICON_LIBRARIES, KIND_DEFAULTS, BASE_THEME_NAME, VOICE_AXES, VOICE_PERSON, CASING_VALUES, CASING_SURFACES } from '../spec-config.js';
+import { ICON_LIBRARIES, KIND_DEFAULTS, BASE_THEME_NAME, VOICE_AXES, VOICE_PERSON, CASING_VALUES, CASING_SURFACES, BREAKPOINT_PHILOSOPHIES } from '../spec-config.js';
 
 const MAX_REFERENCE_DEPTH = 10;
 
@@ -185,6 +190,23 @@ export class ModelHandler implements ModelSpec {
       if (input.iconography) {
         iconography = parseIconography(input.iconography, symbolTable, findings);
       }
+
+      // Layout: breakpoints, grid, layoutRules, templates, pages.
+      const breakpoints = input.breakpoints
+        ? parseBreakpoints(input.breakpoints, symbolTable, findings)
+        : undefined;
+      const grid = input.grid
+        ? parseGrid(input.grid, symbolTable, findings)
+        : undefined;
+      const layoutRules = input.layoutRules
+        ? parseLayoutRules(input.layoutRules, symbolTable, findings)
+        : undefined;
+      const templates = input.templates
+        ? parseTemplates(input.templates, symbolTable, findings)
+        : undefined;
+      const pages = input.pages
+        ? parsePages(input.pages, findings)
+        : undefined;
 
       // ── Phase 2: Resolve chained color references ──────────────────
       // Iterate color entries that are still raw references and resolve them
@@ -446,6 +468,11 @@ export class ModelHandler implements ModelSpec {
           colorIndex,
           voice,
           copy,
+          breakpoints,
+          grid,
+          layoutRules,
+          templates,
+          pages,
         },
         findings,
       };
@@ -1724,4 +1751,225 @@ function parseTypographyProps(
   }
 
   return result;
+}
+
+// ── Layout parsing (breakpoints, grid, layoutRules, templates, pages) ───
+
+/**
+ * Resolve a Dimension that may be a literal (`1280px`) or a token reference
+ * (`{spacing.md}`). Returns `undefined` when the input is malformed; emits an
+ * error finding in that case so authors see the failure.
+ */
+function resolveDimensionish(
+  raw: string | undefined,
+  path: string,
+  symbolTable: Map<string, ResolvedValue>,
+  findings: Finding[],
+): ResolvedDimension | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== 'string') return undefined;
+  if (isTokenReference(raw)) {
+    const refPath = raw.slice(1, -1);
+    const resolved = resolveReference(symbolTable, refPath, new Set());
+    if (resolved && typeof resolved === 'object' && 'type' in resolved && resolved.type === 'dimension') {
+      return resolved as ResolvedDimension;
+    }
+    findings.push({
+      severity: 'error',
+      path,
+      message: `'${raw}' does not resolve to a dimension token.`,
+    });
+    return undefined;
+  }
+  if (!isParseableDimension(raw)) {
+    findings.push({
+      severity: 'error',
+      path,
+      message: `'${raw}' is not a valid dimension.`,
+    });
+    return undefined;
+  }
+  return parseDimensionAsDim(raw);
+}
+
+/**
+ * Parse the `breakpoints:` block. Validates the philosophy enum and parses
+ * each value as a Dimension. The order of `values` is preserved (Map
+ * iteration follows insertion order).
+ */
+function parseBreakpoints(
+  raw: RawBreakpointsDef,
+  symbolTable: Map<string, ResolvedValue>,
+  findings: Finding[],
+): BreakpointsState {
+  const values = new Map<string, ResolvedDimension>();
+  const philosophy = raw.philosophy ?? 'mobile-first';
+  if (!(BREAKPOINT_PHILOSOPHIES as readonly string[]).includes(philosophy)) {
+    findings.push({
+      severity: 'error',
+      path: 'breakpoints.philosophy',
+      message: `breakpoints.philosophy must be one of: ${BREAKPOINT_PHILOSOPHIES.join(', ')} (got '${philosophy}').`,
+    });
+  }
+  if (raw.values) {
+    for (const [key, value] of Object.entries(raw.values)) {
+      const dim = resolveDimensionish(value, `breakpoints.values.${key}`, symbolTable, findings);
+      if (dim) {
+        values.set(key, dim);
+        symbolTable.set(`breakpoints.${key}`, dim);
+      }
+    }
+  }
+  return { philosophy, values };
+}
+
+function parseGrid(
+  raw: RawGridDef,
+  symbolTable: Map<string, ResolvedValue>,
+  findings: Finding[],
+): GridState {
+  const margin = new Map<string, ResolvedDimension>();
+  let columns = 12;
+  if (typeof raw.columns === 'number' && Number.isInteger(raw.columns) && raw.columns > 0) {
+    columns = raw.columns;
+  } else if (raw.columns !== undefined) {
+    findings.push({
+      severity: 'error',
+      path: 'grid.columns',
+      message: `grid.columns must be a positive integer (got ${JSON.stringify(raw.columns)}).`,
+    });
+  }
+  const gutter = resolveDimensionish(raw.gutter, 'grid.gutter', symbolTable, findings);
+  const maxWidth = resolveDimensionish(raw.maxWidth, 'grid.maxWidth', symbolTable, findings);
+  if (raw.margin) {
+    for (const [key, value] of Object.entries(raw.margin)) {
+      const dim = resolveDimensionish(value, `grid.margin.${key}`, symbolTable, findings);
+      if (dim) margin.set(key, dim);
+    }
+  }
+  const bleedExceptions = Array.isArray(raw.bleedExceptions)
+    ? raw.bleedExceptions.filter((s): s is string => typeof s === 'string')
+    : [];
+  const state: GridState = { columns, margin, bleedExceptions };
+  if (gutter) {
+    state.gutter = gutter;
+    symbolTable.set('grid.gutter', gutter);
+  }
+  if (maxWidth) {
+    state.maxWidth = maxWidth;
+    symbolTable.set('grid.maxWidth', maxWidth);
+  }
+  symbolTable.set('grid.columns', String(columns));
+  return state;
+}
+
+function parseLayoutRules(
+  raw: RawLayoutRulesDef,
+  symbolTable: Map<string, ResolvedValue>,
+  findings: Finding[],
+): LayoutRulesState {
+  const out: LayoutRulesState = {};
+  const cmw = resolveDimensionish(raw.contentMaxWidth, 'layoutRules.contentMaxWidth', symbolTable, findings);
+  if (cmw) {
+    out.contentMaxWidth = cmw;
+    symbolTable.set('layoutRules.contentMaxWidth', cmw);
+  }
+  const ss = resolveDimensionish(raw.stackSpacing, 'layoutRules.stackSpacing', symbolTable, findings);
+  if (ss) {
+    out.stackSpacing = ss;
+    symbolTable.set('layoutRules.stackSpacing', ss);
+  }
+  const ffw = resolveDimensionish(raw.formFieldWidth, 'layoutRules.formFieldWidth', symbolTable, findings);
+  if (ffw) {
+    out.formFieldWidth = ffw;
+    symbolTable.set('layoutRules.formFieldWidth', ffw);
+  }
+  return out;
+}
+
+/**
+ * Parse the `templates:` registry. Each template's `requiredRegions` must be
+ * a subset of `regions`; violations are flagged with an error finding.
+ * Author-defined extras (`maxWidth`, `sidebarWidth`, `container`, ...) are
+ * preserved in `extras` so exporters can pass them through.
+ */
+function parseTemplates(
+  raw: Record<string, RawTemplateDef>,
+  symbolTable: Map<string, ResolvedValue>,
+  findings: Finding[],
+): Map<string, TemplateDef> {
+  const out = new Map<string, TemplateDef>();
+  for (const [name, tpl] of Object.entries(raw)) {
+    if (!tpl || typeof tpl !== 'object' || Array.isArray(tpl)) continue;
+    const regions = Array.isArray(tpl.regions)
+      ? tpl.regions.filter((s): s is string => typeof s === 'string')
+      : [];
+    const requiredRegions = Array.isArray(tpl.requiredRegions)
+      ? tpl.requiredRegions.filter((s): s is string => typeof s === 'string')
+      : [];
+    const regionSet = new Set(regions);
+    for (const r of requiredRegions) {
+      if (!regionSet.has(r)) {
+        findings.push({
+          severity: 'error',
+          path: `templates.${name}.requiredRegions`,
+          message: `Required region '${r}' is not declared in templates.${name}.regions.`,
+        });
+      }
+    }
+    const def: TemplateDef = {
+      name,
+      regions,
+      requiredRegions,
+      extras: new Map<string, unknown>(),
+    };
+    const maxWidth = resolveDimensionish(
+      typeof tpl.maxWidth === 'string' ? tpl.maxWidth : undefined,
+      `templates.${name}.maxWidth`,
+      symbolTable,
+      findings,
+    );
+    if (maxWidth) def.maxWidth = maxWidth;
+    const sidebarWidth = resolveDimensionish(
+      typeof tpl.sidebarWidth === 'string' ? tpl.sidebarWidth : undefined,
+      `templates.${name}.sidebarWidth`,
+      symbolTable,
+      findings,
+    );
+    if (sidebarWidth) def.sidebarWidth = sidebarWidth;
+    if (typeof tpl.container === 'string') def.container = tpl.container;
+    for (const [k, v] of Object.entries(tpl)) {
+      if (k === 'regions' || k === 'requiredRegions' || k === 'maxWidth' || k === 'sidebarWidth' || k === 'container') continue;
+      def.extras.set(k, v);
+    }
+    out.set(name, def);
+    symbolTable.set(`templates.${name}.regions`, regions.join(','));
+  }
+  return out;
+}
+
+function parsePages(
+  raw: Record<string, RawPageDef>,
+  findings: Finding[],
+): Map<string, PageDef> {
+  const out = new Map<string, PageDef>();
+  for (const [pattern, entry] of Object.entries(raw)) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const tpl = (entry as RawPageDef).template;
+    if (typeof tpl !== 'string' || tpl.length === 0) {
+      findings.push({
+        severity: 'error',
+        path: `pages.${pattern}.template`,
+        message: `pages.${pattern}.template is required and must be a string.`,
+      });
+      continue;
+    }
+    const page: PageDef = { pattern, template: tpl };
+    const regionsRaw = (entry as Record<string, unknown>)['regions'];
+    if (Array.isArray(regionsRaw)) {
+      page.regions = regionsRaw.filter((s): s is string => typeof s === 'string');
+    }
+    out.set(pattern, page);
+  }
+  return out;
 }

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -273,6 +273,68 @@ export interface ThemeView {
   contrastTarget: ThemeContrastTarget;
 }
 
+// ── RESPONSIVE / LAYOUT ────────────────────────────────────────────
+
+/**
+ * Resolved breakpoints block. `philosophy` records whether the system is
+ * mobile-first (base styles target the smallest viewport, larger breakpoints
+ * are progressive enhancements) or desktop-first (the inverse). `values`
+ * maps a breakpoint key (sm, md, lg, xl, 2xl, ...) to a resolved Dimension.
+ */
+export interface BreakpointsState {
+  philosophy: string;
+  values: Map<string, ResolvedDimension>;
+}
+
+/**
+ * Resolved grid block. `gutter` and the per-key `margin` entries are
+ * Dimensions resolved through the spacing token table. `bleedExceptions` is
+ * the (informational) allow-list of region names that may break out of the
+ * grid (full-bleed hero, modal overlay).
+ */
+export interface GridState {
+  columns: number;
+  gutter?: ResolvedDimension;
+  margin: Map<string, ResolvedDimension>;
+  maxWidth?: ResolvedDimension;
+  bleedExceptions: string[];
+}
+
+/**
+ * Resolved layout-rule primitives. `contentMaxWidth` enforces a readable
+ * measure (~60–80 char) for body prose; `stackSpacing` is the default
+ * vertical rhythm; `formFieldWidth` is the canonical form-field width.
+ */
+export interface LayoutRulesState {
+  contentMaxWidth?: ResolvedDimension;
+  stackSpacing?: ResolvedDimension;
+  formFieldWidth?: ResolvedDimension;
+}
+
+/**
+ * Resolved page-template definition. `regions` lists the named regions a
+ * template instance may declare; `requiredRegions` is the subset that must
+ * be present. `extra` carries additional, exporter-readable properties
+ * (`maxWidth`, `sidebarWidth`, `container`).
+ */
+export interface TemplateDef {
+  name: string;
+  regions: string[];
+  requiredRegions: string[];
+  maxWidth?: ResolvedDimension;
+  sidebarWidth?: ResolvedDimension;
+  container?: string;
+  extras: Map<string, unknown>;
+}
+
+/** Resolved page → template assignment. */
+export interface PageDef {
+  pattern: string;
+  template: string;
+  /** Optional explicit region declarations (consumed by `missing-region`). */
+  regions?: string[];
+}
+
 // ── STATE ──────────────────────────────────────────────────────────
 export interface DesignSystemState {
   name?: string | undefined;
@@ -344,6 +406,19 @@ export interface DesignSystemState {
   voice?: Voice | undefined;
   /** Content rules — banned/approved terms, casing, error pattern, etc. Optional. */
   copy?: Copy | undefined;
+  /** Responsive breakpoints. Optional. Absent = no responsive contract. */
+  breakpoints?: BreakpointsState | undefined;
+  /** Grid system (columns, gutter, margin, maxWidth). Optional. */
+  grid?: GridState | undefined;
+  /** Layout-rule primitives (readable measure, stack spacing, form width). */
+  layoutRules?: LayoutRulesState | undefined;
+  /**
+   * Page-template registry. Keys are template names. Absent = open-world
+   * (no `unknown-template` enforcement).
+   */
+  templates?: Map<string, TemplateDef> | undefined;
+  /** Page → template assignments. Keys are route patterns. */
+  pages?: Map<string, PageDef> | undefined;
 }
 
 export interface ColorIndexEntry {

--- a/packages/cli/src/linter/parser/handler.ts
+++ b/packages/cli/src/linter/parser/handler.ts
@@ -241,6 +241,11 @@ export class ParserHandler implements ParserSpec {
         ? (raw['copy'] as ParsedDesignSystem['copy'])
         : undefined,
       themes: raw['themes'] as ParsedDesignSystem['themes'],
+      breakpoints: raw['breakpoints'] as ParsedDesignSystem['breakpoints'],
+      grid: raw['grid'] as ParsedDesignSystem['grid'],
+      layoutRules: raw['layoutRules'] as ParsedDesignSystem['layoutRules'],
+      templates: raw['templates'] as ParsedDesignSystem['templates'],
+      pages: raw['pages'] as ParsedDesignSystem['pages'],
       sourceMap,
       sections,
       documentSections,

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -95,6 +95,63 @@ export interface RawIconographyDef {
 }
 
 /**
+ * Raw `breakpoints:` block (mirrors the YAML schema). `philosophy` is one of
+ * `mobile-first` | `desktop-first`; `values` maps a breakpoint key (sm, md,
+ * lg, xl, 2xl, ...) to a Dimension string.
+ */
+export interface RawBreakpointsDef {
+  philosophy?: string;
+  values?: Record<string, string>;
+}
+
+/**
+ * Raw `grid:` block. `gutter` and `margin` accept token references; `maxWidth`
+ * is a Dimension string. `bleedExceptions` is an allow-list of region names
+ * that may break out of the grid (full-bleed hero, modal overlay).
+ */
+export interface RawGridDef {
+  columns?: number;
+  gutter?: string;
+  margin?: Record<string, string>;
+  maxWidth?: string;
+  bleedExceptions?: string[];
+}
+
+/**
+ * Raw `layoutRules:` block — the readable-measure / vertical-rhythm /
+ * form-field-width primitives. Values are Dimension strings (or token refs).
+ */
+export interface RawLayoutRulesDef {
+  contentMaxWidth?: string;
+  stackSpacing?: string;
+  formFieldWidth?: string;
+}
+
+/**
+ * Raw page-template definition. `regions` is the ordered list of region
+ * names a template instance may declare; `requiredRegions` is the subset
+ * that *must* be present. Additional template-level properties (`maxWidth`,
+ * `sidebarWidth`, `container`) are passed through verbatim — exporters
+ * read them, the linter does not.
+ */
+export interface RawTemplateDef {
+  regions?: string[];
+  requiredRegions?: string[];
+  maxWidth?: string;
+  sidebarWidth?: string;
+  container?: string;
+  /** Author-defined extras (passed through to exporters). */
+  [key: string]: unknown;
+}
+
+/**
+ * Raw `pages:` entry — a route pattern → template assignment.
+ */
+export interface RawPageDef {
+  template: string;
+}
+
+/**
  * A theme block — overrides only. Anything not overridden is inherited from
  * `inheritsFrom` (default: the implicit `light` base = the root token tree).
  * Resolution is a deep-merge of theme-over-base, scoped per token category.
@@ -211,6 +268,19 @@ export interface ParsedDesignSystem {
    * tolerated). Values are deep-merged onto the base during model build.
    */
   themes?: Record<string, RawThemeDef> | undefined;
+  /**
+   * Responsive breakpoint declarations. Optional; absent = the system declares
+   * no breakpoints (and rules that need them no-op).
+   */
+  breakpoints?: RawBreakpointsDef | undefined;
+  /** Layout grid (columns + gutter + margin + maxWidth). Optional. */
+  grid?: RawGridDef | undefined;
+  /** Top-level layout primitives (readable measure, stack spacing, form width). */
+  layoutRules?: RawLayoutRulesDef | undefined;
+  /** Page-template registry. Keys are template names. */
+  templates?: Record<string, RawTemplateDef> | undefined;
+  /** Optional page → template assignment. Keys are route patterns. */
+  pages?: Record<string, RawPageDef> | undefined;
   sourceMap: Map<string, SourceLocation>;
   /** Markdown heading names found in the document (e.g., 'Colors', 'Typography') */
   sections?: string[] | undefined;

--- a/packages/cli/src/linter/spec-config.ts
+++ b/packages/cli/src/linter/spec-config.ts
@@ -105,6 +105,9 @@ const ConfigSchema = z.object({
   casing_surfaces: z.array(z.string()).min(1),
   title_case_minor_words: z.array(z.string()).min(1),
   well_known_themes: z.array(z.string()).min(1),
+  breakpoint_philosophies: z.array(z.string()).min(1),
+  breakpoint_keys: z.array(z.string()).min(1),
+  well_known_regions: z.array(z.string()).min(1),
   recommended_tokens: z.record(z.string(), z.array(z.string())),
   examples: z.object({
     colors: z.record(z.string(), z.string()),
@@ -115,6 +118,20 @@ const ConfigSchema = z.object({
     components: z.record(z.string(), z.record(z.string(), ComponentExampleValueSchema)),
     voice: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
     copy: z.record(z.string(), z.unknown()).optional(),
+    breakpoints: z.object({
+      philosophy: z.string(),
+      values: z.record(z.string(), z.string()),
+    }).optional(),
+    grid: z.object({
+      columns: z.number(),
+      gutter: z.string(),
+      margin: z.record(z.string(), z.string()).optional(),
+      maxWidth: z.string().optional(),
+      bleedExceptions: z.array(z.string()).optional(),
+    }).optional(),
+    layoutRules: z.record(z.string(), z.string()).optional(),
+    templates: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
+    pages: z.record(z.string(), z.object({ template: z.string() })).optional(),
   }),
 });
 
@@ -225,6 +242,24 @@ export type IconLibrary = (typeof ICON_LIBRARIES)[number];
 /** CSS easing keywords accepted alongside `cubic-bezier(...)` literals. */
 export const EASING_KEYWORDS = config.easing_keywords;
 
+/** Allowed values for `breakpoints.philosophy`. */
+export const BREAKPOINT_PHILOSOPHIES: readonly string[] = config.breakpoint_philosophies;
+export type BreakpointPhilosophy = (typeof BREAKPOINT_PHILOSOPHIES)[number];
+
+/**
+ * Conventional breakpoint key order (sm → 2xl). Authors may declare additional
+ * keys; `breakpoint-monotonicity` validates that values increase across this
+ * canonical sequence, ignoring any extra (unknown) keys.
+ */
+export const BREAKPOINT_KEYS: readonly string[] = config.breakpoint_keys;
+
+/**
+ * Well-known template region names. Informational; authors may declare any
+ * region name. Used by `template-region-purity` to flag regions whose
+ * conventional semantics differ when reused across templates.
+ */
+export const WELL_KNOWN_REGIONS: readonly string[] = config.well_known_regions;
+
 /** Component kinds (button, container, etc.) and their default interactivity. */
 export const COMPONENT_KINDS: readonly ComponentKindDef[] = config.component_kinds;
 
@@ -317,6 +352,9 @@ export interface SpecConfig {
   VOICE_PERSON: typeof VOICE_PERSON;
   CASING_VALUES: typeof CASING_VALUES;
   CASING_SURFACES: typeof CASING_SURFACES;
+  BREAKPOINT_PHILOSOPHIES: typeof BREAKPOINT_PHILOSOPHIES;
+  BREAKPOINT_KEYS: typeof BREAKPOINT_KEYS;
+  WELL_KNOWN_REGIONS: typeof WELL_KNOWN_REGIONS;
   RECOMMENDED_TOKENS: typeof RECOMMENDED_TOKENS;
   EXAMPLES: typeof EXAMPLES;
 }
@@ -338,6 +376,9 @@ export const SPEC_CONFIG: SpecConfig = {
   VOICE_PERSON,
   CASING_VALUES,
   CASING_SURFACES,
+  BREAKPOINT_PHILOSOPHIES,
+  BREAKPOINT_KEYS,
+  WELL_KNOWN_REGIONS,
   RECOMMENDED_TOKENS,
   EXAMPLES,
 };

--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -129,6 +129,39 @@ easing_keywords:
   - step-start
   - step-end
 
+# Allowed values for `breakpoints.philosophy`.
+breakpoint_philosophies:
+  - mobile-first
+  - desktop-first
+
+# Conventional breakpoint key order (sm → 2xl). Informational — authors may
+# add extra keys, but `breakpoint-monotonicity` reads this order to validate
+# value progression.
+breakpoint_keys:
+  - sm
+  - md
+  - lg
+  - xl
+  - "2xl"
+
+# Well-known template region names. Informational — authors may declare
+# additional regions. Used by `template-region-purity` to flag conflicting
+# semantics across templates (e.g., `header` reused with different roles).
+well_known_regions:
+  - header
+  - footer
+  - topbar
+  - statusbar
+  - sidebar
+  - sidebar-nav
+  - hero
+  - sections
+  - cta
+  - main
+  - content
+  - aside
+  - breadcrumb
+
 typography_properties:
   - name: fontFamily
     type: string
@@ -460,3 +493,45 @@ examples:
       dashboard: Home
     reservedNames:
       - DesignMD
+  breakpoints:
+    philosophy: mobile-first
+    values:
+      sm: 640px
+      md: 768px
+      lg: 1024px
+      xl: 1280px
+      "2xl": 1536px
+  grid:
+    columns: 12
+    gutter: "{spacing.md}"
+    margin:
+      sm: "{spacing.md}"
+      lg: "{spacing.xl}"
+    maxWidth: 1280px
+    bleedExceptions:
+      - hero
+      - gallery
+      - modal-overlay
+  layoutRules:
+    contentMaxWidth: 720px
+    stackSpacing: "{spacing.lg}"
+    formFieldWidth: 480px
+  templates:
+    marketing:
+      regions: [header, hero, sections, cta, footer]
+      requiredRegions: [header, footer]
+      maxWidth: 1280px
+    app-shell:
+      regions: [topbar, sidebar, main, statusbar]
+      requiredRegions: [topbar, main]
+      sidebarWidth: 280px
+    settings:
+      regions: [topbar, sidebar-nav, content]
+      requiredRegions: [topbar, content]
+  pages:
+    "/":
+      template: marketing
+    "/app":
+      template: app-shell
+    "/settings/*":
+      template: settings

--- a/packages/cli/src/linter/spec-gen/compiler.test.ts
+++ b/packages/cli/src/linter/spec-gen/compiler.test.ts
@@ -79,6 +79,10 @@ describe('compileMdx', () => {
       copyExample: () => renderers.copyExample(cfg),
       voiceAxesTable: () => renderers.voiceAxesTable(cfg),
       casingTable: () => renderers.casingTable(cfg),
+      breakpointsExample: () => renderers.breakpointsExample(cfg),
+      gridExample: () => renderers.gridExample(cfg),
+      layoutRulesExample: () => renderers.layoutRulesExample(cfg),
+      templatesExample: () => renderers.templatesExample(cfg),
     };
 
     const result = await compileMdx(source, scope);

--- a/packages/cli/src/linter/spec-gen/generate.ts
+++ b/packages/cli/src/linter/spec-gen/generate.ts
@@ -55,6 +55,10 @@ async function main() {
     copyExample: () => renderers.copyExample(cfg),
     voiceAxesTable: () => renderers.voiceAxesTable(cfg),
     casingTable: () => renderers.casingTable(cfg),
+    breakpointsExample: () => renderers.breakpointsExample(cfg),
+    gridExample: () => renderers.gridExample(cfg),
+    layoutRulesExample: () => renderers.layoutRulesExample(cfg),
+    templatesExample: () => renderers.templatesExample(cfg),
   };
 
   const generated = await compileMdx(source, scope);

--- a/packages/cli/src/linter/spec-gen/renderers.ts
+++ b/packages/cli/src/linter/spec-gen/renderers.ts
@@ -190,6 +190,77 @@ export function voiceAxesTable(config: SpecConfig): string {
   return lines.join('\n');
 }
 
+/** Breakpoints YAML example (philosophy + values). */
+export function breakpointsExample(config: SpecConfig): string {
+  const bp = (config.EXAMPLES as { breakpoints?: { philosophy: string; values: Record<string, string> } }).breakpoints;
+  if (!bp) return yamlBlock(['breakpoints:', '  philosophy: mobile-first', '  values: {}']);
+  const lines = ['breakpoints:', `  philosophy: ${bp.philosophy}`, '  values:'];
+  for (const [name, value] of Object.entries(bp.values)) {
+    const key = /^[a-z]+$/.test(name) ? name : `"${name}"`;
+    lines.push(`    ${key}: ${value}`);
+  }
+  return yamlBlock(lines);
+}
+
+/** Grid YAML example (columns, gutter, margin, maxWidth). */
+export function gridExample(config: SpecConfig): string {
+  const grid = (config.EXAMPLES as {
+    grid?: {
+      columns: number;
+      gutter: string;
+      margin?: Record<string, string>;
+      maxWidth?: string;
+      bleedExceptions?: string[];
+    };
+  }).grid;
+  if (!grid) return yamlBlock(['grid: {}']);
+  const lines = ['grid:', `  columns: ${grid.columns}`, `  gutter: "${grid.gutter}"`];
+  if (grid.margin) {
+    lines.push('  margin:');
+    for (const [k, v] of Object.entries(grid.margin)) {
+      const val = v.startsWith('{') ? `"${v}"` : v;
+      lines.push(`    ${k}: ${val}`);
+    }
+  }
+  if (grid.maxWidth) lines.push(`  maxWidth: ${grid.maxWidth}`);
+  if (grid.bleedExceptions && grid.bleedExceptions.length > 0) {
+    lines.push(`  bleedExceptions: [${grid.bleedExceptions.join(', ')}]`);
+  }
+  return yamlBlock(lines);
+}
+
+/** Layout rules YAML example (readable measure, stack spacing, form width). */
+export function layoutRulesExample(config: SpecConfig): string {
+  const rules = (config.EXAMPLES as { layoutRules?: Record<string, string> }).layoutRules;
+  if (!rules) return yamlBlock(['layoutRules: {}']);
+  const lines = ['layoutRules:'];
+  for (const [k, v] of Object.entries(rules)) {
+    const val = v.startsWith('{') ? `"${v}"` : v;
+    lines.push(`  ${k}: ${val}`);
+  }
+  return yamlBlock(lines);
+}
+
+/** Page templates YAML example. */
+export function templatesExample(config: SpecConfig): string {
+  const templates = (config.EXAMPLES as {
+    templates?: Record<string, Record<string, unknown>>;
+  }).templates;
+  if (!templates) return yamlBlock(['templates: {}']);
+  const lines = ['templates:'];
+  for (const [name, tpl] of Object.entries(templates)) {
+    lines.push(`  ${name}:`);
+    for (const [k, v] of Object.entries(tpl)) {
+      if (Array.isArray(v)) {
+        lines.push(`    ${k}: [${v.join(', ')}]`);
+      } else {
+        lines.push(`    ${k}: ${v}`);
+      }
+    }
+  }
+  return yamlBlock(lines);
+}
+
 /** Casing values table. */
 export function casingTable(config: SpecConfig): string {
   const lines = ['| Surface | Allowed values |', '| --- | --- |'];

--- a/packages/cli/src/linter/spec-gen/spec.mdx
+++ b/packages/cli/src/linter/spec-gen/spec.mdx
@@ -1,5 +1,5 @@
-import { SPEC_VERSION, STANDARD_UNITS, SECTIONS, TYPOGRAPHY_PROPERTIES, COMPONENT_SUB_TOKENS, CORE_COLOR_ROLES, ICON_LIBRARIES, EASING_KEYWORDS, RECOMMENDED_TOKENS, EXAMPLES, VOICE_AXES, VOICE_PERSON, CASING_VALUES, CASING_SURFACES } from '../spec-config.js'
-import { frontmatterExample, colorsExample, typographyExample, componentsExample, motionExample, iconographyExample, typographyPropertyList, sectionOrderList, componentSubTokenList, recommendedTokens, voiceExample, copyExample, voiceAxesTable, casingTable } from './renderers.js'
+import { SPEC_VERSION, STANDARD_UNITS, SECTIONS, TYPOGRAPHY_PROPERTIES, COMPONENT_SUB_TOKENS, CORE_COLOR_ROLES, ICON_LIBRARIES, EASING_KEYWORDS, RECOMMENDED_TOKENS, EXAMPLES, VOICE_AXES, VOICE_PERSON, CASING_VALUES, CASING_SURFACES, BREAKPOINT_PHILOSOPHIES, BREAKPOINT_KEYS } from '../spec-config.js'
+import { frontmatterExample, colorsExample, typographyExample, componentsExample, motionExample, iconographyExample, typographyPropertyList, sectionOrderList, componentSubTokenList, recommendedTokens, voiceExample, copyExample, voiceAxesTable, casingTable, breakpointsExample, gridExample, layoutRulesExample, templatesExample } from './renderers.js'
 
 # DESIGN.md Format
 
@@ -185,9 +185,9 @@ Every prior content style guide (Mailchimp, Polaris, GOV.UK) is human-readable o
 
 Also known as "Layout & Spacing".
 
-This section describes the layout and spacing strategy.
+This section describes the layout, grid, breakpoints, and page-template strategy. Layout is a contract — without one, every screen the AI generates is improvised. With one, layout becomes a small, enforceable vocabulary.
 
-Many design systems follow a grid-based layout. Others, like Liquid Glass, use margins, safe areas, and dynamic padding.
+The block has four sub-systems: `breakpoints` (responsive thresholds), `grid` (columns + gutter + margins), `layoutRules` (readable measure, vertical rhythm, form-field width), and `templates` (page-level region registry).
 
 Example:
 
@@ -195,14 +195,66 @@ Example:
 ## Layout
 
 The layout follows a **Fluid Grid** model for mobile devices and a
-**Fixed-Max-Width Grid** for desktop (max 1200px).
+**Fixed-Max-Width Grid** for desktop (max 1280px). Breakpoints follow the
+mobile-first cascade — base styles target the smallest viewport and scale up.
 
-A strict 8px spacing scale (with a 4px half-step for micro-adjustments) is used to maintain a consistent rhythm. Components are grouped using "containment" principles, where related items are housed in cards with generous internal padding (24px) to emphasize the soft, approachable nature of the brand.
+A strict 8px spacing scale (with a 4px half-step for micro-adjustments) is used to maintain a consistent rhythm. Components and dimensions snap to the grid gutter; off-grid values are flagged by `off-grid-dimension`.
 ```
 
-### Design Tokens
+### Mobile-first or desktop-first
 
-The spacing section defines the spacing design tokens. These may include spacing units that are useful for implementing the layout model. For example, a fixed grid layout may have spacing units for column spans, gutters, and margins.
+Pick one and document it. Mobile-first means base styles target the smallest viewport and scale up; desktop-first the reverse. The choice changes how every breakpoint is read and is recorded as `breakpoints.philosophy: {BREAKPOINT_PHILOSOPHIES.join(' | ')}`. We recommend mobile-first as the industry default; desktop-first is supported but should be a deliberate choice.
+
+### Breakpoint philosophy
+
+Breakpoints are content-driven, not device-driven. Add a breakpoint when the layout actually breaks, not because tablets exist. Document the meaning of each breakpoint, not just its pixel value. The conventional ordering is `{BREAKPOINT_KEYS.join(' < ')}`; values must increase strictly across that sequence (`breakpoint-monotonicity`).
+
+{breakpointsExample()}
+
+### Grid usage
+
+Components and layout dimensions snap to the grid (column count or gutter multiple). The `off-grid-dimension` rule warns on layout dimensions (`width`, `height`, `padding`, `gap`, `margin`) that are neither a multiple of `grid.gutter` nor a declared `spacing` token.
+
+Off-grid is acceptable for documented exceptions only — full-bleed imagery, modal overlays, hero artwork. List those region names in `grid.bleedExceptions`.
+
+{gridExample()}
+
+### Readable measure
+
+Body prose stays under `layoutRules.contentMaxWidth` (≈ 60–80 characters per line). Never let prose run the full width of the viewport on desktop. `layoutRules.stackSpacing` is the default vertical rhythm between blocks; `layoutRules.formFieldWidth` is the canonical width for text inputs.
+
+{layoutRulesExample()}
+
+### Responsive content strategy
+
+Narrower viewports don't just shrink; they *restructure*. Multi-column becomes stacked; navigation collapses to a menu; tables become cards. Don't squish, reflow.
+
+### Page templates
+
+A template is a closed set of named regions for a class of page. Common templates: `marketing` (header / hero / sections / cta / footer), `app-shell` (topbar / sidebar / main / statusbar), `settings` (topbar / sidebar-nav / content). Each template declares `regions` (the named slots a page may use) and `requiredRegions` (the subset that must be present). Pages are assigned to templates via `pages:`.
+
+Once `templates` is declared the closed-world rules engage:
+- **`unknown-template`** (error) — `pages.X.template` references a name not in the registry.
+- **`missing-region`** (error) — a page assigned to template T whose declared regions miss a `requiredRegions` entry.
+- **`template-region-purity`** (warning) — region names whose conventional semantics conflict across templates (e.g., `header` is global identity, `topbar` is contextual to the current page).
+
+{templatesExample()}
+
+### Region semantics
+
+Every template region has a defined role: `header` is identity + global nav; `topbar` is contextual to the current page; `sidebar` is persistent navigation, `aside` is contextual auxiliary content. Don't repurpose regions across templates — pick one vocabulary and hold it across the system.
+
+### Template decision tree
+
+- **`marketing`** — public-facing pages with a hero, sales-style sections, and a footer (landing pages, pricing, about). Identity-level navigation.
+- **`app-shell`** — authenticated product surfaces with persistent topbar + sidebar + main content. Contextual navigation.
+- **`settings`** — secondary surfaces inside the app, often with sub-navigation in a sidebar-nav. Inherits app chrome.
+
+Anti-pattern: marketing template used for in-app pages, or app-shell used for the public homepage. The `data-template` attribute (when source-side scanning is enabled) makes the assignment explicit per file.
+
+### Design Tokens — spacing
+
+The `spacing` section defines the spacing design tokens. These may include spacing units that are useful for implementing the layout model. For example, a fixed grid layout may have spacing units for column spans, gutters, and margins. The grid's `gutter:` typically references one of these tokens (`{spacing.md}`).
 
 It is a
 map\<string, Dimension | number\> that maps the spacing scale identifier to a dimension value or a unitless number (e.g., column counts or ratios).

--- a/packages/cli/src/linter/tailwind/handler.ts
+++ b/packages/cli/src/linter/tailwind/handler.ts
@@ -17,7 +17,9 @@ import type {
   TailwindEmitterResult,
   TailwindEmitterOptions,
   TailwindComponentRule,
+  TailwindThemeExtend,
   TailwindThemes,
+  TailwindContainer,
 } from './spec.js';
 import type { ComponentDef, DesignSystemState, RampDef, ResolvedColor, ResolvedDimension, ResolvedValue, ThemeView } from '../model/spec.js';
 import { BASE_THEME_NAME } from '../spec-config.js';
@@ -57,23 +59,35 @@ const PROPERTY_TO_CSS: Record<string, string | string[]> = {
  */
 export class TailwindEmitterHandler implements TailwindEmitterSpec {
   execute(state: DesignSystemState, options?: TailwindEmitterOptions): TailwindEmitterResult {
+    const extend: TailwindThemeExtend = {
+      colors: this.mapColors(state.colors, state.colorRamps),
+      fontFamily: this.mapFontFamilies(state),
+      fontSize: this.mapFontSizes(state),
+      borderRadius: this.mapDimensions(state.rounded),
+      spacing: this.mapDimensions(state.spacing),
+      boxShadow: this.mapElevation(state),
+      transitionDuration: this.mapDurations(state),
+      transitionTimingFunction: this.mapEasings(state),
+    };
+
+    const screens = this.mapScreens(state);
+    if (screens) extend.screens = screens;
+    const maxWidth = this.mapMaxWidth(state);
+    if (maxWidth) extend.maxWidth = maxWidth;
+
     const result: TailwindEmitterResult = {
       success: true,
       data: {
         theme: {
-          extend: {
-            colors: this.mapColors(state.colors, state.colorRamps),
-            fontFamily: this.mapFontFamilies(state),
-            fontSize: this.mapFontSizes(state),
-            borderRadius: this.mapDimensions(state.rounded),
-            spacing: this.mapDimensions(state.spacing),
-            boxShadow: this.mapElevation(state),
-            transitionDuration: this.mapDurations(state),
-            transitionTimingFunction: this.mapEasings(state),
-          },
+          extend,
         },
       }
     };
+
+    const container = this.mapContainer(state);
+    if (container) {
+      result.data.theme.container = container;
+    }
 
     if (options?.components && state.components.size > 0) {
       result.data.plugin = this.mapComponents(state);
@@ -85,6 +99,58 @@ export class TailwindEmitterHandler implements TailwindEmitterSpec {
     }
 
     return result;
+  }
+
+  /**
+   * Map `breakpoints.values` → Tailwind `theme.extend.screens`. Tailwind
+   * expects min-width strings keyed by breakpoint name. Returns undefined
+   * when no breakpoints are declared.
+   */
+  private mapScreens(state: DesignSystemState): Record<string, string> | undefined {
+    if (!state.breakpoints || state.breakpoints.values.size === 0) return undefined;
+    const out: Record<string, string> = {};
+    for (const [key, dim] of state.breakpoints.values) {
+      out[key] = `${dim.value}${dim.unit}`;
+    }
+    return out;
+  }
+
+  /**
+   * Map `grid.maxWidth` and `layoutRules.contentMaxWidth` → Tailwind
+   * `theme.extend.maxWidth`. Emitted as named entries `container` (grid
+   * width) and `prose` (readable measure) so authors can use
+   * `max-w-container` / `max-w-prose` classes directly.
+   */
+  private mapMaxWidth(state: DesignSystemState): Record<string, string> | undefined {
+    const out: Record<string, string> = {};
+    if (state.grid?.maxWidth) {
+      out['container'] = `${state.grid.maxWidth.value}${state.grid.maxWidth.unit}`;
+    }
+    if (state.layoutRules?.contentMaxWidth) {
+      const cmw = state.layoutRules.contentMaxWidth;
+      out['prose'] = `${cmw.value}${cmw.unit}`;
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
+  }
+
+  /**
+   * Map `grid.margin` → Tailwind `theme.container.padding`. The container
+   * plugin wraps its children with horizontal padding that increases at
+   * higher breakpoints; we emit a DEFAULT plus per-breakpoint overrides.
+   */
+  private mapContainer(state: DesignSystemState): TailwindContainer | undefined {
+    const margin = state.grid?.margin;
+    if (!margin || margin.size === 0) return undefined;
+    const padding: Record<string, string> = {};
+    for (const [key, dim] of margin) {
+      const dest = key === 'sm' ? 'DEFAULT' : key;
+      padding[dest] = `${dim.value}${dim.unit}`;
+    }
+    if (!('DEFAULT' in padding)) {
+      const first = Object.values(padding)[0];
+      if (first) padding['DEFAULT'] = first;
+    }
+    return { center: true, padding };
   }
 
   /**

--- a/packages/cli/src/linter/tailwind/spec.ts
+++ b/packages/cli/src/linter/tailwind/spec.ts
@@ -32,7 +32,30 @@ export const TailwindThemeExtendSchema = z.object({
   transitionDuration: z.record(z.string()).optional(),
   /** Map of motion easing token name → CSS easing string (keyword or cubic-bezier). */
   transitionTimingFunction: z.record(z.string()).optional(),
+  /** Tailwind `theme.screens` — breakpoint key → min-width (e.g., '768px'). */
+  screens: z.record(z.string()).optional(),
+  /**
+   * Tailwind `theme.maxWidth` — names like `container` (grid maxWidth) and
+   * `prose` (layoutRules.contentMaxWidth) are emitted when declared.
+   */
+  maxWidth: z.record(z.string()).optional(),
 });
+
+/**
+ * Tailwind `theme.container` configuration. Emitted when a grid is declared
+ * with margin entries; maps to Tailwind's container plugin.
+ */
+export const TailwindContainerSchema = z.object({
+  center: z.boolean().optional(),
+  padding: z.union([
+    z.string(),
+    z.object({
+      DEFAULT: z.string().optional(),
+    }).catchall(z.string()),
+  ]).optional(),
+});
+
+export type TailwindContainer = z.infer<typeof TailwindContainerSchema>;
 
 export type TailwindThemeExtend = z.infer<typeof TailwindThemeExtendSchema>;
 
@@ -75,7 +98,9 @@ export const TailwindEmitterResultSchema = z.discriminatedUnion('success', [
     success: z.literal(true),
     data: z.object({
       theme: z.object({
-        extend: TailwindThemeExtendSchema
+        extend: TailwindThemeExtendSchema,
+        /** Top-level `theme.container` config (outside `extend`). */
+        container: TailwindContainerSchema.optional(),
       }),
       plugin: z.record(z.unknown()).optional(),
       /**


### PR DESCRIPTION
## Summary

Closes the responsive / layout gap from #9. Adds four new top-level primitives (`breakpoints`, `grid`, `layoutRules`, `templates` + `pages`), five new linter rules, and the corresponding exporter + spec doc updates so layout becomes a contract instead of a per-screen improvisation.

### Schema additions
- `breakpoints` — `philosophy` (`mobile-first` | `desktop-first`) + `values` (sm/md/lg/xl/2xl, but open to extension).
- `grid` — `columns`, `gutter`, `margin`, `maxWidth`, `bleedExceptions`. `gutter` and `margin.*` accept token references (`{spacing.md}`).
- `layoutRules` — `contentMaxWidth` (readable measure ≈ 60–80 char), `stackSpacing` (default vertical rhythm), `formFieldWidth`.
- `templates` — page-level region registry. Each entry declares `regions` and `requiredRegions` (the subset that must be present); also passes through `maxWidth`, `sidebarWidth`, `container`, plus author-defined extras.
- `pages` — optional route → template assignment.

### New linter rules
| Rule | Severity | What it catches |
| --- | --- | --- |
| `breakpoint-monotonicity` | error | sm < md < lg < xl < 2xl violations (typos) |
| `unknown-template` | error | `pages.X.template` references a name not in the registry |
| `missing-region` | error | a page declares regions but is missing one of its template's `requiredRegions` |
| `off-grid-dimension` | warning | component `width`/`height`/`padding`/`gap`/`margin` that's neither a spacing token nor a multiple of `grid.gutter` |
| `template-region-purity` | warning | the same region name (`header`, `footer`, `sidebar`) reused across a marketing-scoped template (`hero`/`cta`) and an app-scoped one — pick distinct names (`header` vs `topbar`) |

`broken-ref` needs no changes — `breakpoints.*`, `grid.*`, `layoutRules.*` are seeded into the symbol table during model build, so existing reference resolution catches typos for free.

### Exporters
- **Tailwind** — emits `theme.extend.screens` from breakpoints, `theme.extend.maxWidth` (`container` from `grid.maxWidth`, `prose` from `layoutRules.contentMaxWidth`), and `theme.container.padding` from `grid.margin`.
- **DTCG** — emits `breakpoints` as a sibling `dimension` group (so `{breakpoints.md}` is resolvable as a token) and surfaces `grid` / `layoutRules` / `templates` / `pages` under `$extensions['design.md']`.

### Docs + examples
- `spec.mdx` — Layout section restructured with required prose subsections (mobile-first, breakpoint philosophy, grid usage, readable measure, responsive content strategy, page templates, region semantics, template decision tree). Spec regenerated.
- `paws-and-paths` example — declares three templates (`marketing`, `app-shell`, `settings`), full breakpoint set, grid, layoutRules, and pages. New prose subsections populated. `design_tokens.json` and `tailwind.config.js` regenerated.

### Out of scope (deferred from the plan)
- Source-side `--src` scanner extension (`data-template`, `data-region` extraction) — depends on issue #6's component scanner, which isn't landed yet.
- `prose-content-max-width` rule — depends on the prose subsection registry from #4.
- Migrating `atmospheric-glass` and `totality-festival`. Mentioned as one of 8 rollout phases; doing one example end-to-end keeps the diff focused.

## Test plan

- [x] `bun test` — 518 pass, 0 fail (was 482 before)
- [x] New tests: `model/handler.layout.test.ts`, `linter/rules/breakpoint-monotonicity.test.ts`, `unknown-template.test.ts`, `missing-region.test.ts`, `off-grid-dimension.test.ts`, `template-region-purity.test.ts`
- [x] `bun run packages/cli/src/index.ts lint examples/{paws-and-paths,atmospheric-glass,totality-festival}/DESIGN.md` — all 0 errors
- [x] `bun run packages/cli/src/index.ts export examples/paws-and-paths/DESIGN.md --format dtcg|tailwind` — outputs include the new layout fields
- [x] `bun run spec:gen` — regenerates `docs/spec.md` cleanly

https://claude.ai/code/session_01Ph1qdmfpqFnUUFzEG99CoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ph1qdmfpqFnUUFzEG99CoF)_