### PR TITLE
test(evals,tailwind): cover scoring engine and CSS renderer

### DIFF
--- a/packages/cli/src/linter/tailwind/css.test.ts
+++ b/packages/cli/src/linter/tailwind/css.test.ts
@@ -1,0 +1,162 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+import { describe, expect, it } from 'bun:test';
+
+import { ModelHandler } from '../model/handler.js';
+import type { ParsedDesignSystem } from '../parser/spec.js';
+import { renderTailwindThemeCss } from './css.js';
+import { TailwindEmitterHandler } from './handler.js';
+import type { TailwindEmitterResult } from './spec.js';
+
+const emitter = new TailwindEmitterHandler();
+const modelHandler = new ModelHandler();
+
+function buildResult(overrides: Partial<ParsedDesignSystem> = {}): TailwindEmitterResult {
+  const parsed: ParsedDesignSystem = { sourceMap: new Map(), ...overrides };
+  const model = modelHandler.execute(parsed);
+  const hasErrors = model.findings.some((d) => d.severity === 'error');
+  if (hasErrors) {
+    throw new Error(`Model failed: ${model.findings.map((d) => d.message).join(', ')}`);
+  }
+  return emitter.execute(model.designSystem);
+}
+
+describe('renderTailwindThemeCss — preamble', () => {
+  it('emits the tailwindcss import and dark custom-variant up top', () => {
+    const css = renderTailwindThemeCss(buildResult({ colors: { primary: '#000000' } }));
+    expect(css.startsWith('@import "tailwindcss";')).toBe(true);
+    expect(css).toContain('@custom-variant dark (&:is(.dark *));');
+  });
+
+  it('always emits an @theme inline block', () => {
+    const css = renderTailwindThemeCss(buildResult({ colors: { primary: '#000000' } }));
+    expect(css).toContain('@theme inline {');
+    expect(css.trimEnd().endsWith('}')).toBe(true);
+  });
+
+  it('terminates output with a newline', () => {
+    const css = renderTailwindThemeCss(buildResult({ colors: { primary: '#000' } }));
+    expect(css.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('renderTailwindThemeCss — colors', () => {
+  it('lifts flat colors into :root as `--<name>` and aliases under `--color-<name>`', () => {
+    const css = renderTailwindThemeCss(
+      buildResult({ colors: { primary: '#1A1C1E', accent: '#B8422E' } }),
+    );
+    expect(css).toContain('  --primary: #1a1c1e;');
+    expect(css).toContain('  --accent: #b8422e;');
+    expect(css).toContain('  --color-primary: var(--primary);');
+    expect(css).toContain('  --color-accent: var(--accent);');
+  });
+
+  it('emits a :root block even when no color values are defined (empty containers still truthy)', () => {
+    const css = renderTailwindThemeCss(buildResult({}));
+    expect(css).toContain(':root {');
+    // No `--<name>:` declarations should appear in the empty :root.
+    const rootBlock = /:root\s*\{([^}]*)\}/.exec(css)?.[1] ?? '';
+    expect(rootBlock.trim()).toBe('');
+  });
+});
+
+describe('renderTailwindThemeCss — radius', () => {
+  it('emits radius under :root and aliases under @theme', () => {
+    const css = renderTailwindThemeCss(
+      buildResult({ rounded: { sm: '4px', md: '8px' } }),
+    );
+    expect(css).toContain('  --rounded-sm: 4px;');
+    expect(css).toContain('  --rounded-md: 8px;');
+    expect(css).toContain('  --radius-sm: var(--rounded-sm);');
+    expect(css).toContain('  --radius-md: var(--rounded-md);');
+  });
+});
+
+describe('renderTailwindThemeCss — non-color tokens', () => {
+  it('emits typography fontFamily and fontSize with metadata', () => {
+    const css = renderTailwindThemeCss(
+      buildResult({
+        colors: { primary: '#000' },
+        typography: {
+          h1: {
+            fontFamily: 'Public Sans',
+            fontSize: '3rem',
+            fontWeight: 700,
+            lineHeight: '1.1',
+            letterSpacing: '-0.02em',
+          },
+        },
+      }),
+    );
+    expect(css).toContain('--font-h1:');
+    expect(css).toContain('Public Sans');
+    expect(css).toContain('--text-h1: 3rem;');
+    expect(css).toContain('--text-h1--line-height: 1.1;');
+    expect(css).toContain('--text-h1--letter-spacing: -0.02em;');
+    expect(css).toContain('--text-h1--font-weight: 700;');
+  });
+
+  it('emits spacing tokens as `--spacing-<name>`', () => {
+    const css = renderTailwindThemeCss(
+      buildResult({
+        colors: { primary: '#000' },
+        spacing: { sm: '8px', md: '16px' },
+      }),
+    );
+    expect(css).toContain('--spacing-sm: 8px;');
+    expect(css).toContain('--spacing-md: 16px;');
+  });
+});
+
+describe('renderTailwindThemeCss — themes', () => {
+  it('emits per-theme blocks alongside :root for non-base themes', () => {
+    const css = renderTailwindThemeCss(
+      buildResult({
+        colors: { primary: '#1A1C1E' },
+        themes: {
+          dark: { colors: { primary: '#F7F5F2' } },
+        },
+      }),
+    );
+    expect(css).toContain(':root {');
+    expect(css).toContain('.dark {');
+    // The dark block must contain the overridden primary value.
+    const darkBlock = /\.dark\s*\{[^}]*\}/m.exec(css)?.[0] ?? '';
+    expect(darkBlock).toContain('--primary: #f7f5f2;');
+  });
+
+  it('does not emit theme blocks when no themes are declared', () => {
+    const css = renderTailwindThemeCss(
+      buildResult({ colors: { primary: '#1A1C1E' } }),
+    );
+    expect(css).not.toMatch(/^\.\w+ \{/m);
+  });
+});
+
+describe('renderTailwindThemeCss — failure path', () => {
+  it('throws a helpful error when given a failed emitter result', () => {
+    const failed: TailwindEmitterResult = {
+      success: false,
+      error: { code: 'TEST', message: 'simulated' },
+    };
+    expect(() => renderTailwindThemeCss(failed)).toThrow(/simulated/);
+  });
+});
+
+describe('renderTailwindThemeCss — structural ordering', () => {
+  it('places :root before @theme inline', () => {
+    const css = renderTailwindThemeCss(
+      buildResult({ colors: { primary: '#1A1C1E' } }),
+    );
+    const rootIdx = css.indexOf(':root {');
+    const themeIdx = css.indexOf('@theme inline {');
+    expect(rootIdx).toBeGreaterThan(-1);
+    expect(themeIdx).toBeGreaterThan(rootIdx);
+  });
+});

--- a/packages/evals/src/copy.test.ts
+++ b/packages/evals/src/copy.test.ts
@@ -1,0 +1,127 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { lint } from '@google/design.md/linter';
+import type { DesignSystemState } from '@google/design.md/linter';
+
+import { buildVirtualState, scoreCopy } from './copy.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+const FIXTURE_PATH = join(REPO_ROOT, 'examples/paws-and-paths/DESIGN.md');
+
+// Lint the bundled fixture once to obtain a realistic DesignSystemState that
+// carries voice/copy/themes/etc. The copy rules read those fields directly;
+// `buildVirtualState` swaps in synthesized components and sections.
+const FIXTURE_STATE: DesignSystemState = lint(readFileSync(FIXTURE_PATH, 'utf8')).designSystem;
+
+describe('buildVirtualState', () => {
+  test('synthesizes a button component for each <button>', () => {
+    const html = '<button>Save</button><button>Cancel</button>';
+    const { state, labelCount } = buildVirtualState(html, FIXTURE_STATE);
+    expect(labelCount).toBe(2);
+    expect(state.components.has('button-1')).toBe(true);
+    expect(state.components.has('button-2')).toBe(true);
+    expect(state.componentRegistry?.get('button-1')?.kind).toBe('button');
+  });
+
+  test('synthesizes section-heading components for h1/h2/h3', () => {
+    const html = '<h1>Top</h1><h2>Sub</h2><h3>Detail</h3>';
+    const { state, labelCount } = buildVirtualState(html, FIXTURE_STATE);
+    expect(labelCount).toBe(3);
+    expect(state.componentRegistry?.get('heading-1')?.kind).toBe('section-heading');
+  });
+
+  test('synthesizes navigation components for nav > a only', () => {
+    const html = '<nav><a>Home</a><a>About</a></nav><a>Footer link</a>';
+    const { state, labelCount } = buildVirtualState(html, FIXTURE_STATE);
+    expect(labelCount).toBe(2);
+    expect(state.componentRegistry?.get('nav-link-1')?.kind).toBe('navigation');
+    expect(state.components.has('nav-link-3')).toBe(false);
+  });
+
+  test('skips elements with whitespace-only text', () => {
+    const html = '<button>   </button><h1></h1><button>Real</button>';
+    const { labelCount, state } = buildVirtualState(html, FIXTURE_STATE);
+    // Only the labelled button counts.
+    expect(labelCount).toBe(3); // labelCount counts iterations, but unlabeled aren't registered
+    expect(state.components.has('button-1')).toBe(false);
+    expect(state.components.has('button-2')).toBe(true);
+  });
+
+  test('produces exactly one synthesized document section', () => {
+    const html = '<p>Hello world</p>';
+    const { state } = buildVirtualState(html, FIXTURE_STATE);
+    expect(state.documentSections.length).toBe(1);
+    expect(state.documentSections[0]!.heading).toBe('rendered');
+    expect(state.documentSections[0]!.content).toContain('Hello world');
+  });
+
+  test('strips <html>, <body>, and doctype before parsing', () => {
+    const html = '<!doctype html><html><body><h1>Welcome</h1></body></html>';
+    const { state, labelCount } = buildVirtualState(html, FIXTURE_STATE);
+    expect(labelCount).toBe(1);
+    expect(state.components.has('heading-1')).toBe(true);
+  });
+
+  test('reuses the cached state\'s voice/copy/themes (type-shape parity)', () => {
+    const html = '<button>Hi</button>';
+    const { state } = buildVirtualState(html, FIXTURE_STATE);
+    // copy block is fixture-defined; rules consume it directly.
+    expect(state.copy).toBe(FIXTURE_STATE.copy);
+    expect(state.voice).toBe(FIXTURE_STATE.voice);
+  });
+});
+
+describe('scoreCopy', () => {
+  test('returns score 1.0 and no findings when nothing is synthesized', () => {
+    const out = scoreCopy('<div></div>', FIXTURE_STATE);
+    expect(out.score).toBe(1);
+    expect(out.findings).toEqual([]);
+  });
+
+  test('returns score 1.0 for compliant copy (sentence-case button under word limit)', () => {
+    const html = '<button>Save changes</button>';
+    const out = scoreCopy(html, FIXTURE_STATE);
+    expect(out.score).toBe(1);
+    expect(out.findings).toEqual([]);
+  });
+
+  test('button-exceeds-word-limit fires when label is longer than fixture limit (3)', () => {
+    // Fixture buttonLabelMaxWords = 3.
+    const html = '<button>Save all my urgent changes</button>';
+    const out = scoreCopy(html, FIXTURE_STATE);
+    expect(out.score).toBeLessThan(1);
+    expect(out.findings.some((f) => f.rule === 'button-exceeds-word-limit')).toBe(true);
+  });
+
+  test('banned-term-in-prose fires when body text contains a banned term', () => {
+    // Fixture banned: "seamless".
+    const html = '<p>Our app provides a seamless experience.</p>';
+    const out = scoreCopy(html, FIXTURE_STATE);
+    expect(out.findings.some((f) => f.rule === 'banned-term-in-prose')).toBe(true);
+  });
+
+  test('score floor is 0 (many findings cannot drive it negative)', () => {
+    // Many violations against a single synthesized label.
+    const html = '<button>seamless seamless seamless seamless seamless</button>';
+    const out = scoreCopy(html, FIXTURE_STATE);
+    expect(out.score).toBeGreaterThanOrEqual(0);
+    expect(out.score).toBeLessThanOrEqual(1);
+  });
+
+  test('findings include severity and rule metadata', () => {
+    const html = '<button>Save all my urgent changes</button>';
+    const out = scoreCopy(html, FIXTURE_STATE);
+    const f = out.findings.find((x) => x.rule === 'button-exceeds-word-limit');
+    expect(f).toBeDefined();
+    expect(['error', 'warning', 'info']).toContain(f!.severity);
+    expect(typeof f!.message).toBe('string');
+  });
+});

--- a/packages/evals/src/score.test.ts
+++ b/packages/evals/src/score.test.ts
@@ -1,0 +1,344 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+import { describe, expect, test } from 'bun:test';
+
+import type { ParsedDesign } from './formats.js';
+import {
+  COLOR_TOLERANCE,
+  DIM_TOLERANCE,
+  colorDistance,
+  combineScore,
+  extract,
+  meanScore,
+  normalizeHex,
+  resolveTokenRef,
+  score,
+  tokenColors,
+} from './score.js';
+import { DEFAULT_WEIGHTS, type Score } from './types.js';
+
+function makeDesign(frontmatter: Record<string, any>): ParsedDesign {
+  return { raw: '', frontmatter, body: '' };
+}
+
+describe('normalizeHex', () => {
+  test('expands 3-digit shorthand and lowercases', () => {
+    expect(normalizeHex('#FFF')).toBe('#ffffff');
+    expect(normalizeHex('#aBc')).toBe('#aabbcc');
+  });
+
+  test('expands 4-digit shorthand and drops alpha', () => {
+    expect(normalizeHex('#abcd')).toBe('#aabbcc');
+  });
+
+  test('truncates 8-digit alpha hex to 6 digits', () => {
+    expect(normalizeHex('#11223344')).toBe('#112233');
+    expect(normalizeHex('#11223380')).toBe('#112233');
+  });
+
+  test('passes 6-digit through, lowercased', () => {
+    expect(normalizeHex('#1A1C1E')).toBe('#1a1c1e');
+  });
+
+  test('tolerates leading-hash variants', () => {
+    expect(normalizeHex('1A1C1E')).toBe('#1a1c1e');
+  });
+});
+
+describe('colorDistance', () => {
+  test('returns 0 for identical colors', () => {
+    expect(colorDistance('#000000', '#000000')).toBe(0);
+    expect(colorDistance('#FFFFFF', '#ffffff')).toBe(0);
+  });
+
+  test('returns 1 for black vs white (maximum distance)', () => {
+    expect(colorDistance('#000000', '#ffffff')).toBeCloseTo(1, 6);
+  });
+
+  test('is symmetric', () => {
+    const a = colorDistance('#112233', '#aabbcc');
+    const b = colorDistance('#aabbcc', '#112233');
+    expect(a).toBe(b);
+  });
+
+  test('shorthand and longhand of the same color are equivalent', () => {
+    expect(colorDistance('#fff', '#ffffff')).toBe(0);
+    expect(colorDistance('#abc', '#aabbcc')).toBe(0);
+  });
+
+  test('returns a value in [0, 1]', () => {
+    const samples = [
+      colorDistance('#111111', '#222222'),
+      colorDistance('#abcdef', '#fedcba'),
+      colorDistance('#ff0000', '#00ff00'),
+    ];
+    for (const v of samples) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test('very small differences fall under COLOR_TOLERANCE', () => {
+    // #000000 vs #050505 -> sqrt(75)/sqrt(195075) ≈ 0.0196 < 0.05
+    expect(colorDistance('#000000', '#050505')).toBeLessThan(COLOR_TOLERANCE);
+  });
+});
+
+describe('extract', () => {
+  test('returns empty buckets for empty input', () => {
+    expect(extract('')).toEqual({
+      colors: [],
+      fontFamilies: [],
+      pxDimensions: [],
+      remDimensions: [],
+    });
+  });
+
+  test('normalizes hex colors', () => {
+    const html = '<div style="color: #fff; background: #abcdef;">';
+    const out = extract(html);
+    expect(out.colors).toContain('#ffffff');
+    expect(out.colors).toContain('#abcdef');
+  });
+
+  test('splits font-family lists on commas', () => {
+    const html = '<p style="font-family: Public Sans, Space Grotesk, sans-serif;">';
+    const out = extract(html);
+    expect(out.fontFamilies).toContain('Public Sans');
+    expect(out.fontFamilies).toContain('Space Grotesk');
+    expect(out.fontFamilies).toContain('sans-serif');
+  });
+
+  test('collects px and rem dimensions separately, deduplicated', () => {
+    const html = '<div style="padding: 16px 16px 8px; margin: 1rem 1rem 0.5rem;">';
+    const out = extract(html);
+    expect([...out.pxDimensions].sort((a, b) => a - b)).toEqual([8, 16]);
+    expect([...out.remDimensions].sort((a, b) => a - b)).toEqual([0.5, 1]);
+  });
+
+  test('ignores partial / non-css occurrences gracefully', () => {
+    const html = '<p>no styles here</p><span style="display:flex;"></span>';
+    const out = extract(html);
+    expect(out.colors).toEqual([]);
+    expect(out.fontFamilies).toEqual([]);
+    expect(out.pxDimensions).toEqual([]);
+  });
+});
+
+describe('tokenColors', () => {
+  test('returns normalized hex values from colors block', () => {
+    const colors = tokenColors({ colors: { primary: '#1A1C1E', accent: '#FFF' } });
+    expect(colors).toEqual(['#1a1c1e', '#ffffff']);
+  });
+
+  test('skips non-string and non-hex values', () => {
+    const colors = tokenColors({
+      colors: {
+        primary: '#1A1C1E',
+        bad: 'rebeccapurple',
+        nested: { ramp: '#aabbcc' },
+      },
+    });
+    expect(colors).toEqual(['#1a1c1e']);
+  });
+
+  test('returns empty array when no colors block is present', () => {
+    expect(tokenColors({})).toEqual([]);
+  });
+});
+
+describe('score', () => {
+  const design = makeDesign({
+    colors: { primary: '#1A1C1E', accent: '#B8422E' },
+    typography: { h1: { fontFamily: 'Public Sans' }, body: { fontFamily: 'Inter, sans-serif' } },
+    spacing: { sm: '8px', md: '16px' },
+    rounded: { md: '8px' },
+  });
+
+  test('color subscore: 1.0 when every extracted color is on-palette', () => {
+    const out = score(
+      { colors: ['#1a1c1e', '#b8422e'], fontFamilies: [], pxDimensions: [], remDimensions: [] },
+      design,
+    );
+    expect(out.colorScore).toBe(1);
+  });
+
+  test('color subscore: 0.5 when half are off-palette', () => {
+    const out = score(
+      { colors: ['#1a1c1e', '#ff00ff'], fontFamilies: [], pxDimensions: [], remDimensions: [] },
+      design,
+    );
+    expect(out.colorScore).toBe(0.5);
+  });
+
+  test('color subscore: 0 when there are no extracted colors', () => {
+    const out = score(
+      { colors: [], fontFamilies: [], pxDimensions: [], remDimensions: [] },
+      design,
+    );
+    expect(out.colorScore).toBe(0);
+  });
+
+  test('color subscore: 0 when design has no palette', () => {
+    const out = score(
+      { colors: ['#1a1c1e'], fontFamilies: [], pxDimensions: [], remDimensions: [] },
+      makeDesign({}),
+    );
+    expect(out.colorScore).toBe(0);
+  });
+
+  test('typography subscore: matches against the font-family set', () => {
+    const out = score(
+      { colors: [], fontFamilies: ['Public Sans', 'Comic Sans MS'], pxDimensions: [], remDimensions: [] },
+      design,
+    );
+    expect(out.typographyScore).toBe(0.5);
+  });
+
+  test('typography subscore: includes families with comma fallbacks', () => {
+    const out = score(
+      { colors: [], fontFamilies: ['Inter'], pxDimensions: [], remDimensions: [] },
+      design,
+    );
+    expect(out.typographyScore).toBe(1);
+  });
+
+  test('spacing subscore: matches px and rem against their respective scales', () => {
+    const out = score(
+      { colors: [], fontFamilies: [], pxDimensions: [8, 16], remDimensions: [] },
+      design,
+    );
+    expect(out.spacingScore).toBe(1);
+  });
+
+  test('spacing subscore: 0 when no dimensions extracted', () => {
+    const out = score(
+      { colors: [], fontFamilies: [], pxDimensions: [], remDimensions: [] },
+      design,
+    );
+    expect(out.spacingScore).toBe(0);
+  });
+
+  test('spacing subscore: uses DIM_TOLERANCE for near-matches', () => {
+    const out = score(
+      { colors: [], fontFamilies: [], pxDimensions: [8 + DIM_TOLERANCE], remDimensions: [] },
+      design,
+    );
+    expect(out.spacingScore).toBe(1);
+  });
+});
+
+describe('combineScore', () => {
+  test('drops absent subscores from numerator and denominator', () => {
+    const tokensOnly = combineScore({ colorScore: 1, typographyScore: 1, spacingScore: 1 });
+    // (0.30 + 0.10 + 0.10) / (0.30 + 0.10 + 0.10) = 1
+    expect(tokensOnly).toBe(1);
+  });
+
+  test('zero in one layer pulls the aggregate down proportionally', () => {
+    const result = combineScore({ colorScore: 0, typographyScore: 1, spacingScore: 1 });
+    // (0*0.30 + 1*0.10 + 1*0.10) / 0.50 = 0.20 / 0.50 = 0.4
+    expect(result).toBeCloseTo(0.4, 6);
+  });
+
+  test('returns 0 when nothing scored', () => {
+    expect(combineScore({})).toBe(0);
+  });
+
+  test('honors custom weights', () => {
+    const result = combineScore(
+      { colorScore: 1, typographyScore: 0 },
+      { ...DEFAULT_WEIGHTS, color: 1, typography: 1 },
+    );
+    expect(result).toBe(0.5);
+  });
+
+  test('includes every optional layer when present', () => {
+    const all: Score = {
+      colorScore: 1,
+      typographyScore: 1,
+      spacingScore: 1,
+      copyScore: 1,
+      semanticScore: 1,
+      structuralScore: 1,
+      visionScore: 1,
+      aggregate: 0,
+    };
+    expect(combineScore(all)).toBeCloseTo(1, 6);
+  });
+});
+
+describe('resolveTokenRef', () => {
+  const fm = {
+    colors: { primary: '#1A1C1E' },
+    typography: { h1: { fontFamily: 'Public Sans', fontSize: '3rem' } },
+  };
+
+  test('resolves a simple token path', () => {
+    expect(resolveTokenRef('{colors.primary}', fm)).toBe('#1A1C1E');
+  });
+
+  test('resolves a nested object reference', () => {
+    expect(resolveTokenRef('{typography.h1}', fm)).toEqual({
+      fontFamily: 'Public Sans',
+      fontSize: '3rem',
+    });
+  });
+
+  test('resolves nested-property paths', () => {
+    expect(resolveTokenRef('{typography.h1.fontSize}', fm)).toBe('3rem');
+  });
+
+  test('returns undefined when a path step is missing', () => {
+    expect(resolveTokenRef('{colors.missing}', fm)).toBeUndefined();
+    expect(resolveTokenRef('{nope.nada}', fm)).toBeUndefined();
+  });
+
+  test('returns undefined for non-reference strings', () => {
+    expect(resolveTokenRef('#abcdef', fm)).toBeUndefined();
+    expect(resolveTokenRef('plain', fm)).toBeUndefined();
+  });
+
+  test('trims surrounding whitespace', () => {
+    expect(resolveTokenRef('  {colors.primary}  ', fm)).toBe('#1A1C1E');
+  });
+});
+
+describe('meanScore', () => {
+  test('returns the zero-valued empty score for an empty list', () => {
+    expect(meanScore([])).toEqual({
+      colorScore: 0,
+      typographyScore: 0,
+      spacingScore: 0,
+      aggregate: 0,
+    });
+  });
+
+  test('averages the required subscores', () => {
+    const a: Score = { colorScore: 1, typographyScore: 1, spacingScore: 1, aggregate: 1 };
+    const b: Score = { colorScore: 0, typographyScore: 0, spacingScore: 0, aggregate: 0 };
+    const mean = meanScore([a, b]);
+    expect(mean.colorScore).toBe(0.5);
+    expect(mean.typographyScore).toBe(0.5);
+    expect(mean.spacingScore).toBe(0.5);
+    expect(mean.aggregate).toBe(0.5);
+  });
+
+  test('only averages optional subscores over the runs that produced them', () => {
+    const a: Score = { colorScore: 1, typographyScore: 1, spacingScore: 1, copyScore: 1, aggregate: 1 };
+    const b: Score = { colorScore: 1, typographyScore: 1, spacingScore: 1, aggregate: 1 };
+    const mean = meanScore([a, b]);
+    expect(mean.copyScore).toBe(1);
+  });
+
+  test('leaves optional subscores undefined when no run produced them', () => {
+    const a: Score = { colorScore: 1, typographyScore: 1, spacingScore: 1, aggregate: 1 };
+    const mean = meanScore([a]);
+    expect(mean.copyScore).toBeUndefined();
+    expect(mean.semanticScore).toBeUndefined();
+    expect(mean.structuralScore).toBeUndefined();
+    expect(mean.visionScore).toBeUndefined();
+  });
+});

--- a/packages/evals/src/semantic.test.ts
+++ b/packages/evals/src/semantic.test.ts
@@ -1,0 +1,200 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+import { describe, expect, test } from 'bun:test';
+
+import type { ParsedDesign } from './formats.js';
+import { scoreSemantic, scoreStructural } from './semantic.js';
+import type { SemanticAssertion, Task } from './types.js';
+
+function makeDesign(frontmatter: Record<string, any>): ParsedDesign {
+  return { raw: '', frontmatter, body: '' };
+}
+
+function makeTask(partial: Partial<Task>): Task {
+  return { id: 't', prompt: '', ...partial };
+}
+
+const DESIGN = makeDesign({
+  colors: { primary: '#1A1C1E', accent: '#B8422E', surface: '#F7F5F2' },
+  typography: { h1: { fontFamily: 'Public Sans', fontSize: '3rem' } },
+  spacing: { sm: '8px', md: '16px' },
+});
+
+describe('scoreSemantic', () => {
+  test('returns undefined when the task has no assertions', () => {
+    expect(scoreSemantic('<div></div>', DESIGN, makeTask({}))).toBeUndefined();
+    expect(
+      scoreSemantic('<div></div>', DESIGN, makeTask({ assertions: [] })),
+    ).toBeUndefined();
+  });
+
+  test('marks an assertion as failed when no element matches the selector', () => {
+    const task = makeTask({
+      assertions: [{ selector: '.missing', expect: { backgroundColor: '#1A1C1E' } }],
+    });
+    const out = scoreSemantic('<div></div>', DESIGN, task)!;
+    expect(out.score).toBe(0);
+    expect(out.results[0]!.passed).toBe(false);
+    expect(out.results[0]!.detail).toContain('no element matched');
+  });
+
+  test('passes a background-color check against a token reference', () => {
+    const html = '<button class="cta" style="background-color: #1A1C1E; color: #ffffff;">Go</button>';
+    const task = makeTask({
+      assertions: [
+        {
+          selector: '.cta',
+          expect: { backgroundColor: '{colors.primary}', color: '#ffffff' },
+        },
+      ],
+    });
+    const out = scoreSemantic(html, DESIGN, task)!;
+    expect(out.score).toBe(1);
+    expect(out.results[0]!.passed).toBe(true);
+  });
+
+  test('passes when inline `background:` shorthand carries the hex', () => {
+    const html = '<button class="cta" style="background: #1a1c1e;">Go</button>';
+    const task = makeTask({
+      assertions: [{ selector: '.cta', expect: { backgroundColor: '#1A1C1E' } }],
+    });
+    const out = scoreSemantic(html, DESIGN, task)!;
+    expect(out.results[0]!.passed).toBe(true);
+  });
+
+  test('fails on an off-token background color and reports the mismatch', () => {
+    const html = '<button class="cta" style="background-color: #ff00ff;">Go</button>';
+    const task = makeTask({
+      assertions: [{ selector: '.cta', expect: { backgroundColor: '{colors.primary}' } }],
+    });
+    const out = scoreSemantic(html, DESIGN, task)!;
+    expect(out.results[0]!.passed).toBe(false);
+    expect(out.results[0]!.detail).toContain('background');
+  });
+
+  test('resolves font-family from a typography token object', () => {
+    const html = '<h1 class="title" style="font-family: Public Sans;">Hello</h1>';
+    const task = makeTask({
+      assertions: [
+        { selector: '.title', expect: { fontFamily: '{typography.h1}' } },
+      ],
+    });
+    const out = scoreSemantic(html, DESIGN, task)!;
+    expect(out.results[0]!.passed).toBe(true);
+  });
+
+  test('font-family check is case-insensitive', () => {
+    const html = '<h1 class="title" style="font-family: public sans;">Hello</h1>';
+    const task = makeTask({
+      assertions: [{ selector: '.title', expect: { fontFamily: 'Public Sans' } }],
+    });
+    const out = scoreSemantic(html, DESIGN, task)!;
+    expect(out.results[0]!.passed).toBe(true);
+  });
+
+  test('minFontSize resolves a rem token to px and applies DIM_TOLERANCE', () => {
+    // 3rem = 48px; assertion uses {typography.h1.fontSize} which is "3rem".
+    const html = '<h1 class="title" style="font-size: 47.6px;">Hi</h1>'; // within 0.5 tolerance
+    const task = makeTask({
+      assertions: [
+        { selector: '.title', expect: { minFontSize: '{typography.h1.fontSize}' } },
+      ],
+    });
+    const out = scoreSemantic(html, DESIGN, task)!;
+    expect(out.results[0]!.passed).toBe(true);
+  });
+
+  test('minFontSize fails when actual is below tolerance', () => {
+    const html = '<h1 class="title" style="font-size: 30px;">Hi</h1>';
+    const task = makeTask({
+      assertions: [
+        { selector: '.title', expect: { minFontSize: '{typography.h1.fontSize}' } },
+      ],
+    });
+    const out = scoreSemantic(html, DESIGN, task)!;
+    expect(out.results[0]!.passed).toBe(false);
+    expect(out.results[0]!.detail).toContain('font-size');
+  });
+
+  test('textPattern matches the trimmed textContent', () => {
+    const html = '<button class="cta"> Submit </button>';
+    const task = makeTask({
+      assertions: [{ selector: '.cta', expect: { textPattern: /^Submit$/ } }],
+    });
+    const out = scoreSemantic(html, DESIGN, task)!;
+    expect(out.results[0]!.passed).toBe(true);
+  });
+
+  test('minChildren counts direct element children', () => {
+    const html = '<ul class="nav"><li>a</li><li>b</li><li>c</li></ul>';
+    const taskPass = makeTask({
+      assertions: [{ selector: '.nav', expect: { minChildren: 3 } }],
+    });
+    const taskFail = makeTask({
+      assertions: [{ selector: '.nav', expect: { minChildren: 4 } }],
+    });
+    expect(scoreSemantic(html, DESIGN, taskPass)!.results[0]!.passed).toBe(true);
+    expect(scoreSemantic(html, DESIGN, taskFail)!.results[0]!.passed).toBe(false);
+  });
+
+  test('aggregates multiple assertions into a fractional score', () => {
+    const html = '<button class="cta" style="background-color: #1A1C1E; color: #ffffff;">Go</button>';
+    const assertions: SemanticAssertion[] = [
+      { selector: '.cta', expect: { backgroundColor: '{colors.primary}' } },
+      { selector: '.cta', expect: { backgroundColor: '#ff00ff' } },
+    ];
+    const out = scoreSemantic(html, DESIGN, makeTask({ assertions }))!;
+    expect(out.score).toBe(0.5);
+    expect(out.results.length).toBe(2);
+  });
+
+  test('returns undefined-resolved tokens as failures (no silent passes)', () => {
+    const html = '<button class="cta" style="background-color: #1A1C1E;">Go</button>';
+    const task = makeTask({
+      assertions: [{ selector: '.cta', expect: { backgroundColor: '{colors.does-not-exist}' } }],
+    });
+    const out = scoreSemantic(html, DESIGN, task)!;
+    expect(out.results[0]!.passed).toBe(false);
+  });
+
+  test('preserves the role field in the result when supplied', () => {
+    const html = '<button class="cta">Go</button>';
+    const task = makeTask({
+      assertions: [
+        {
+          selector: '.cta',
+          role: 'primary-cta',
+          expect: { textPattern: /Go/ },
+        },
+      ],
+    });
+    const out = scoreSemantic(html, DESIGN, task)!;
+    expect(out.results[0]!.role).toBe('primary-cta');
+  });
+});
+
+describe('scoreStructural', () => {
+  test('returns undefined when the task has no expectedElements', () => {
+    expect(scoreStructural('<div></div>', makeTask({}))).toBeUndefined();
+    expect(scoreStructural('<div></div>', makeTask({ expectedElements: [] }))).toBeUndefined();
+  });
+
+  test('returns 1.0 when every selector matches at least one element', () => {
+    const html = '<nav></nav><h1></h1><button></button>';
+    const out = scoreStructural(html, makeTask({ expectedElements: ['nav', 'h1', 'button'] }));
+    expect(out).toBe(1);
+  });
+
+  test('returns the fraction of matched selectors', () => {
+    const html = '<nav></nav><h1></h1>';
+    const out = scoreStructural(html, makeTask({ expectedElements: ['nav', 'h1', 'button', 'footer'] }));
+    expect(out).toBe(0.5);
+  });
+
+  test('returns 0 when nothing matches', () => {
+    const out = scoreStructural('<div></div>', makeTask({ expectedElements: ['nav', 'h1'] }));
+    expect(out).toBe(0);
+  });
+});

--- a/packages/evals/src/vision.test.ts
+++ b/packages/evals/src/vision.test.ts
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+
+import { describe, expect, test } from 'bun:test';
+
+import { parseJudgeResponse } from './vision.js';
+
+describe('parseJudgeResponse', () => {
+  test('parses a well-formed JSON judge response', () => {
+    const out = parseJudgeResponse('{"score": 0.75, "rationale": "Good fidelity overall."}');
+    expect(out.score).toBe(0.75);
+    expect(out.rationale).toBe('Good fidelity overall.');
+  });
+
+  test('strips ```json fences before parsing', () => {
+    const out = parseJudgeResponse('```json\n{"score": 0.4, "rationale": "Mixed."}\n```');
+    expect(out.score).toBe(0.4);
+    expect(out.rationale).toBe('Mixed.');
+  });
+
+  test('strips a bare ``` closing fence', () => {
+    const out = parseJudgeResponse('{"score": 0.5, "rationale": "ok"}\n```');
+    expect(out.score).toBe(0.5);
+  });
+
+  test('clamps scores above 1 to 1', () => {
+    const out = parseJudgeResponse('{"score": 1.5, "rationale": "Off-scale."}');
+    expect(out.score).toBe(1);
+  });
+
+  test('clamps negative scores to 0', () => {
+    const out = parseJudgeResponse('{"score": -0.2, "rationale": "Subzero."}');
+    expect(out.score).toBe(0);
+  });
+
+  test('coerces NaN / non-finite score to 0', () => {
+    const out = parseJudgeResponse('{"score": "not-a-number", "rationale": "Junk."}');
+    expect(out.score).toBe(0);
+  });
+
+  test('coerces a missing rationale to empty string', () => {
+    const out = parseJudgeResponse('{"score": 0.8}');
+    expect(out.score).toBe(0.8);
+    expect(out.rationale).toBe('');
+  });
+
+  test('returns score 0 and a diagnostic rationale on unparseable input', () => {
+    const out = parseJudgeResponse('not even close to JSON');
+    expect(out.score).toBe(0);
+    expect(out.rationale).toContain('unparseable judge response');
+    expect(out.rationale).toContain('not even close to JSON');
+  });
+
+  test('truncates very long unparseable input in the rationale', () => {
+    const huge = 'x'.repeat(500);
+    const out = parseJudgeResponse(huge);
+    expect(out.rationale.length).toBeLessThan(huge.length);
+  });
+
+  test('handles JSON with extra surrounding whitespace', () => {
+    const out = parseJudgeResponse('   {"score": 0.5, "rationale": "ok"}   ');
+    expect(out.score).toBe(0.5);
+  });
+});

--- a/packages/evals/src/vision.ts
+++ b/packages/evals/src/vision.ts
@@ -66,7 +66,7 @@ export async function scoreVision(
   return parseJudgeResponse(text);
 }
 
-function parseJudgeResponse(text: string): { score: number; rationale: string } {
+export function parseJudgeResponse(text: string): { score: number; rationale: string } {
   const cleaned = text.replace(/```json\s*/i, '').replace(/```\s*$/i, '').trim();
   try {
     const parsed = JSON.parse(cleaned);


### PR DESCRIPTION
## Summary

A test-coverage audit identified the evals scoring engine and the Tailwind CSS renderer as the highest-correctness-risk modules — a silent bug in either silently distorts real outputs (eval fidelity numbers, generated stylesheets). Before this PR, those modules had **zero co-located unit tests**; `packages/evals` had a single `runner.test.ts` that mocked the scorers, and `tailwind/css.ts` (179 LOC of string rendering) was untested in isolation.

This PR adds 96 unit tests across 5 new test files. Suite goes from **577 → 673 tests, all passing**.

- `packages/evals/src/score.test.ts` (43 tests) — hex normalization, color distance symmetry / tolerance, dimension extraction, token resolution, subscore math (`combineScore` drops absent layers; `meanScore` averages only over runs that produced each layer).
- `packages/evals/src/semantic.test.ts` (18 tests) — DOM-driven CSS assertions, token references resolved against `frontmatter`, font-family case-insensitivity, `minFontSize` rem→px with `DIM_TOLERANCE`, structural element scoring.
- `packages/evals/src/copy.test.ts` (13 tests) — virtual component synthesis from HTML (`<button>`, `h1/h2/h3`, `nav > a`), copy-rule scoring against the `paws-and-paths` fixture (sentence-case, word limits, banned terms), score floor at 0.
- `packages/evals/src/vision.test.ts` (10 tests) — judge-response parsing including fenced JSON, clamping (`>1`, `<0`, `NaN`), missing rationale, unparseable input.
- `packages/cli/src/linter/tailwind/css.test.ts` (12 tests) — Tailwind v4 CSS rendering: preamble, `:root` / `@theme inline` indirection, flat colors, radii under `--rounded-*` → `--radius-*` aliasing, typography metadata, spacing, per-theme blocks (`.dark`), failed-result throw path, structural ordering.

A single non-functional change in `packages/evals/src/vision.ts`: exported `parseJudgeResponse` so it can be unit-tested without mocking the Anthropic SDK.

## Test plan

- [x] `bun test` → 673 pass / 0 fail (was 577 pass before this PR)
- [x] `bun run build` in `packages/cli` → JS bundles produced (pre-existing TS declaration warning in `model/handler.ts` unrelated to this PR)
- [x] All new tests assert observable behavior, not implementation details (no snapshot files; readable inline expectations)

https://claude.ai/code/session_01DMQPxqRYzUA5xyV7FY4dCh

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMQPxqRYzUA5xyV7FY4dCh)_