### PR TITLE
Sync fork with upstream v0.3.0 (37 commits)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - uses: oven-sh/setup-bun@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,3 +52,22 @@ jobs:
         npx design.md lint DESIGN.md
         node -e "import('@google/design.md/linter').then(m => console.log('OK:', Object.keys(m).length, 'exports'))"
 
+  npm-registry-smoke-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+        registry-url: https://registry.npmjs.org
+
+    - name: Install @google/design.md from the public npm registry
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "$RUNNER_TEMP/npm-registry-smoke"
+        cd "$RUNNER_TEMP/npm-registry-smoke"
+        npm init -y
+        npm install "@google/design.md@latest"
+        node node_modules/@google/design.md/dist/index.js spec --rules-only --format json > /dev/null
+        node -e "import('@google/design.md/linter').then(m => console.log('OK:', Object.keys(m).length, 'exports'))"
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
         npm install $GITHUB_WORKSPACE/packages/cli/google-design.md-*.tgz
         echo -e '---\ncolors:\n  primary: "#0000ff"\n---' > DESIGN.md
         npx design.md lint DESIGN.md
+        npx design.md spec > /dev/null
         node -e "import('@google/design.md/linter').then(m => console.log('OK:', Object.keys(m).length, 'exports'))"
 
   npm-registry-smoke-windows:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,16 +28,19 @@ jobs:
     
     - uses: oven-sh/setup-bun@v2
       with:
-        bun-version: latest
+        bun-version: 1.3.9  # Must match root package.json "packageManager"
         
     - name: Install dependencies
       run: bun install
       
+    - name: Lint
+      run: bun run lint
+
     - name: Run tests
-      run: bun test
+      run: bun run test
 
     - name: Build CLI
-      run: cd packages/cli && bun run build
+      run: bun run build
 
     - name: Node.js Smoke Test
       run: node packages/cli/dist/index.js lint examples/atmospheric-glass/DESIGN.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,20 +24,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - uses: oven-sh/setup-bun@v2
       with:
-        bun-version: latest
+        bun-version: 1.3.9  # Must match root package.json "packageManager"
         
     - name: Install dependencies
       run: bun install
       
+    - name: Lint
+      run: bun run lint
+
     - name: Run tests
-      run: bun test
+      run: bun run test
 
     - name: Build CLI
-      run: cd packages/cli && bun run build
+      run: bun run build
 
     - name: Node.js Smoke Test
       run: node packages/cli/dist/index.js lint examples/atmospheric-glass/DESIGN.md
@@ -50,5 +53,25 @@ jobs:
         npm install $GITHUB_WORKSPACE/packages/cli/google-design.md-*.tgz
         echo -e '---\ncolors:\n  primary: "#0000ff"\n---' > DESIGN.md
         npx design.md lint DESIGN.md
+        npx design.md spec > /dev/null
+        node -e "import('@google/design.md/linter').then(m => console.log('OK:', Object.keys(m).length, 'exports'))"
+
+  npm-registry-smoke-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+        registry-url: https://registry.npmjs.org
+
+    - name: Install @google/design.md from the public npm registry
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "$RUNNER_TEMP/npm-registry-smoke"
+        cd "$RUNNER_TEMP/npm-registry-smoke"
+        npm init -y
+        npm install "@google/design.md@latest"
+        node node_modules/@google/design.md/dist/index.js spec --rules-only --format json > /dev/null
         node -e "import('@google/design.md/linter').then(m => console.log('OK:', Object.keys(m).length, 'exports'))"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Change Log
+
+AI-made changes to this fork, with the decisions behind them. Newest first.
+
+## 2026-07-24 — Synced fork with upstream v0.3.0 (branch `sync/upstream-0.3.0`, Claude)
+
+**Ask:** analyze upstream's 37-commit lead, then merge it.
+
+**What changed:** all upstream 0.2.0/0.3.0 work merged — css-vars export, CSS Color
+Module parser (named colors, hwb, lch, color-mix), nested token declarations with
+collision detection, unknown-key / token-like-ignored lint rules, typography
+sub-property warnings, export/lint exit-code fixes, TTY/ENOENT guards, Windows
+`designmd` alias, PHILOSOPHY.md. Fork primitives (ramps, pairs, themes, voice,
+copy, motion, iconography, layout, component states, evals) untouched.
+
+**Why this approach:** union merges where features were additive; fork-wins on the
+model pipeline and shadcn Tailwind output (deliberate fork identity), upstream-wins
+on CLI exit codes, color fallback parsing, and format naming. Color support is the
+union of both engines: the fork's parser (incl. display-p3) first, upstream's
+`parseCssColor` as fallback.
+
+**Considered and rejected:** adopting upstream's `tailwind`→`json-tailwind` alias
+(would silently change fork output — the fork keeps `tailwind` aliased to the
+shadcn-style `css-tailwind` CSS); replacing the fork's color parser wholesale with
+upstream's (would lose display-p3 and the `format`/`raw` round-trip metadata).

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -1,0 +1,110 @@
+# DESIGN.md Philosophy
+
+DESIGN.md captures how a design looks, feels, and behaves. The prose is where the design lives. Everything else in the document exists to support it.
+
+```
+---
+name: Technical Handout
+---
+
+## Overview
+
+A graduate-level computer science lecture handout in the tradition of an old established university. The audience is graduate students and research engineers reading a printed handout distributed at the beginning of a seminar.
+
+The handout is austere, informationally dense, and proudly unconcerned with first impressions. The audience knows why they are there and the handout's job is to do work, not to seduce.
+```
+
+**The quality of a generated design is determined less by the precision of its values than by how clearly the intent is described.**
+
+## Prose, not Tokens, is the focus of the specification
+
+DESIGN.md contains two primary aspects: tokens and prose. The specification is focused on describing this design context to keep designs consistent between generations and to provide an area of creative exploration. The prose is the most vital part of the specification. 
+
+````
+## Colors
+
+```yaml
+# Tokens
+colors:
+  paper: '#F4F0E4'
+  ink: '#1E1A14'
+  vermilion: '#C3402A'
+  rule-gray: '#B8B0A2'
+```
+<!-- Prose -->
+A single-ink-plus-accent system.
+- **Paper** {colors.paper} is the canvas — warmed xerox stock, never pure white.
+- **Ink** {colors.ink} is graphite-warm and carries all typography, all rules, all diagram strokes; never pure black.
+- **Vermilion** {colors.vermilion} is the single accent and appears only inside diagrams and chart annotations — never on typography, never on page numerals, never on metadata of any kind.
+- **Rule gray** {colors.rule-gray} is reserved for hairline rules inside content (chart baselines, table dividers); never used as page-frame chrome.
+````
+
+The token values serve as context and are not rendering instructions. Generally, we do not accept or recommend token requirements in the specification. 
+
+This keeps tokens as context that serves as a reference in the prose and focuses DESIGN.md on documenting the nature of the design and not trying to reinvent the decades long work established by languages and tools that came before us.
+
+This document communicates the narrative and philosophy of DESIGN.md to clarify what problems it solves and how it currently attempts to solve them.
+
+## A specific reference carries more than a list of adjectives
+
+A design that references "A 1970s graduate lecture handout in the tradition of an old and established university" evokes a complete world: the one color of ink, the generous margins, the serif set at a reading size, and the absence of decoration. That single sentence carries more useful information than a dozen metric values. It carries the reasoning behind the values.
+
+"Modern, clean, trustworthy, premium" evokes nothing specific. A model creates something in the center of what those words describe, creating an output that is typically generic. Adjectives describe a region. A specific reference describes a point.
+
+## Negative Constraints: What you leave out defines the character
+
+A clear design reference carries its restrictions automatically. A model knows what a lecture handout is, and it knows what a lecture handout is not. It does not glow or use a gradient. You don't have to list these. Naming the object names them, the same way naming a dog tells the model that dogs don't meow.
+
+The negative constraints arrive for free when the reference is specific enough. An intentional list of "don'ts" is useful. A long rambling list is often a sign the description was too vague to carry them. A strong reference and an intentional list of do's and don'ts working together is the sweet spot.
+
+```
+## Do's and Don'ts
+
+- **Don't** add a hero moment to the title page. A real handout title
+  page is the first page of content, not a magazine cover.
+- **Don't** reach for an italic standfirst beneath a large title.
+  That is the Substack register.
+- **Don't** add corner ornaments, chapter marks, or abstract glyphs
+  in the margins.
+- **Don't** color the page numeral or any other piece of metadata.
+  Vermilion lives in diagrams only.
+- **Don't** use a display-class serif. One family at four modest sizes.
+- **Don't** use Bold. Anywhere.
+- **Don't** use sans-serif for any role other than monospace metadata.
+- **Don't** introduce dark mode, gradients, glows, glass surfaces,
+  drop shadows, or rounded corners.
+- **Do** treat the handout as a printed object. The screen is the
+  substrate; the design is the page.
+- **Do** keep vermilion inside diagrams. Its scarcity outside is what
+  makes its presence inside meaningful.
+- **Do** trust modest size differences. The section title is only
+  ~1.9× body, not 5× body.
+- **Do** let pages have visible white space. A page that ends
+  two-thirds of the way down is correct, not under-filled.
+```
+
+## The format grows through its users, not its spec
+
+The spec defines the structural minimum that every DESIGN.md shares: a name, and a small set of categories (colors, typography, spacing, rounded, components) that are universal enough to standardize. Everything beyond that minimum is yours to define. The format accepts any key, any section, any structure your design system needs.
+
+The spec standardizes the categories where consistency helps. It leaves open the categories where flexibility helps more: motion, iconography, elevation, text casing, paragraph measure. One team's motion tokens are CSS animation curves. Another's are audio-domain time constants measured in buffer blocks. The right shape is specific to each system, and the format already lets you define it:
+
+````
+## Motion
+
+```yaml
+motion:
+  feedback: 120ms
+  content: 250ms
+  easing: 'cubic-bezier(0.2, 0, 0, 1)'
+```
+
+Transitions are quick and mechanical. Nothing bounces, nothing overshoots, nothing lingers. State changes should feel like a light switch, not a door closing.
+
+- Interactive feedback (hover, press, toggle): {motion.feedback}, always {motion.easing}.
+- Content transitions (page, panel, modal): {motion.content}, same curve.
+- Nothing in the UI animates longer than 300ms. If something takes longer, cut it.
+- Respect `prefers-reduced-motion`: all durations collapse to 0ms.
+````
+
+The linter accepts these values and agents read the prose. No spec change was needed because the tokens themselves are context rather than instruction.

--- a/README.md
+++ b/README.md
@@ -255,17 +255,18 @@ Exit code `1` if regressions are detected (more errors or warnings in the "after
 
 ### `export`
 
-Export DESIGN.md tokens to other formats (tailwind, dtcg).
+Export DESIGN.md tokens to other formats (tailwind, tailwind-v3, dtcg). `tailwind` targets the latest Tailwind (v4, CSS `@theme`); use `tailwind-v3` for legacy `tailwind.config.js` output.
 
 ```bash
-npx @google/design.md export --format tailwind DESIGN.md > tailwind.theme.json
+npx @google/design.md export --format tailwind DESIGN.md > theme.css
+npx @google/design.md export --format tailwind-v3 DESIGN.md > tailwind.theme.json
 npx @google/design.md export --format dtcg DESIGN.md > tokens.json
 ```
 
 | Option | Type | Default | Description |
 |:-------|:-----|:--------|:------------|
 | `file` | positional | required | Path to DESIGN.md (or `-` for stdin) |
-| `--format` | `tailwind` \| `dtcg` | required | Output format |
+| `--format` | `tailwind` \| `tailwind-v3` \| `dtcg` | required | Output format |
 
 ### `spec`
 
@@ -316,7 +317,8 @@ console.log(report.designSystem);   // Parsed DesignSystemState
 
 DESIGN.md tokens are inspired by the [W3C Design Token Format](https://www.designtokens.org/). The `export` command converts tokens to other formats:
 
-- **Tailwind theme config** — `npx @google/design.md export --format tailwind DESIGN.md`
+- **Tailwind CSS (v4, default)** — `npx @google/design.md export --format tailwind DESIGN.md` — emits a CSS `@theme { ... }` block using Tailwind v4's CSS-variable token namespaces (`--color-*`, `--font-*`, `--text-*`, `--leading-*`, `--tracking-*`, `--font-weight-*`, `--radius-*`, `--spacing-*`). Output is CSS text.
+- **Tailwind v3 config** — `npx @google/design.md export --format tailwind-v3 DESIGN.md` — emits the legacy `tailwind.config.js` `theme.extend` JSON shape for Tailwind v3.
 - **DTCG tokens.json** ([W3C Design Tokens Format Module](https://tr.designtokens.org/format/)) — `npx @google/design.md export --format dtcg DESIGN.md`
 
 ## Status

--- a/README.md
+++ b/README.md
@@ -179,11 +179,29 @@ Variants (hover, active, pressed) are expressed as separate component entries wi
 npm install @google/design.md
 ```
 
-Or run directly:
+On **Windows**, quote the package name if your shell treats `@` specially (PowerShell, some terminals):
+
+```bash
+npm install "@google/design.md"
+```
+
+Or run directly (always resolves from the public npm registry):
 
 ```bash
 npx @google/design.md lint DESIGN.md
 ```
+
+#### `npm error ENOVERSIONS` (“No versions available for @google/design.md”)
+
+The CLI is published as [`@google/design.md` on npm](https://www.npmjs.com/package/@google/design.md). `ENOVERSIONS` almost always means npm is not querying the public registry (custom `registry=` in `.npmrc`, a corporate mirror that has not synced this package, or a misconfigured `@google:registry` for the `@google` scope).
+
+Check your effective registry:
+
+```bash
+npm config get registry
+```
+
+For a normal install from the internet it should be `https://registry.npmjs.org/`. After fixing config, retry with `npm cache clean --force` if a stale 404 was cached.
 
 All commands accept a file path or `-` for stdin. Output defaults to JSON.
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,21 @@ npx @google/design.md lint DESIGN.md
 
 All commands accept a file path or `-` for stdin. Output defaults to JSON.
 
+> **Windows tip**: when invoking the CLI directly from a `package.json` script
+> (rather than through `npx`), use the `designmd` alias instead of `design.md`.
+> The `.md` suffix in the original bin name confuses Windows command resolution
+> with the file association for Markdown files. The `designmd` shim resolves to
+> the same entrypoint and works identically across all platforms.
+>
+> ```jsonc
+> // package.json
+> {
+>   "scripts": {
+>     "design:lint": "designmd lint DESIGN.md"
+>   }
+> }
+> ```
+
 ### `lint`
 
 Validate a DESIGN.md file for structural correctness.

--- a/README.md
+++ b/README.md
@@ -255,18 +255,25 @@ Exit code `1` if regressions are detected (more errors or warnings in the "after
 
 ### `export`
 
-Export DESIGN.md tokens to other formats (tailwind, tailwind-v3, dtcg). `tailwind` targets the latest Tailwind (v4, CSS `@theme`); use `tailwind-v3` for legacy `tailwind.config.js` output.
+Export DESIGN.md tokens to other formats.
 
 ```bash
-npx @google/design.md export --format tailwind DESIGN.md > theme.css
-npx @google/design.md export --format tailwind-v3 DESIGN.md > tailwind.theme.json
+npx @google/design.md export --format json-tailwind DESIGN.md > tailwind.theme.json
+npx @google/design.md export --format css-tailwind DESIGN.md > theme.css
 npx @google/design.md export --format dtcg DESIGN.md > tokens.json
 ```
 
 | Option | Type | Default | Description |
 |:-------|:-----|:--------|:------------|
 | `file` | positional | required | Path to DESIGN.md (or `-` for stdin) |
-| `--format` | `tailwind` \| `tailwind-v3` \| `dtcg` | required | Output format |
+| `--format` | `json-tailwind` \| `css-tailwind` \| `tailwind` \| `dtcg` | required | Output format |
+
+| Format | Output | Description |
+|:-------|:-------|:------------|
+| `json-tailwind` | JSON | Tailwind v3 `theme.extend` config object |
+| `css-tailwind` | CSS | Tailwind v4 `@theme { ... }` block with CSS custom properties |
+| `tailwind` | JSON | Alias for `json-tailwind` |
+| `dtcg` | JSON | W3C Design Tokens Format Module |
 
 ### `spec`
 
@@ -317,8 +324,8 @@ console.log(report.designSystem);   // Parsed DesignSystemState
 
 DESIGN.md tokens are inspired by the [W3C Design Token Format](https://www.designtokens.org/). The `export` command converts tokens to other formats:
 
-- **Tailwind CSS (v4, default)** — `npx @google/design.md export --format tailwind DESIGN.md` — emits a CSS `@theme { ... }` block using Tailwind v4's CSS-variable token namespaces (`--color-*`, `--font-*`, `--text-*`, `--leading-*`, `--tracking-*`, `--font-weight-*`, `--radius-*`, `--spacing-*`). Output is CSS text.
-- **Tailwind v3 config** — `npx @google/design.md export --format tailwind-v3 DESIGN.md` — emits the legacy `tailwind.config.js` `theme.extend` JSON shape for Tailwind v3.
+- **Tailwind v3 config (JSON)** — `npx @google/design.md export --format json-tailwind DESIGN.md` — emits a `theme.extend` JSON object for `tailwind.config.js`. `--format tailwind` is a backwards-compatible alias.
+- **Tailwind v4 theme (CSS)** — `npx @google/design.md export --format css-tailwind DESIGN.md` — emits a CSS `@theme { ... }` block using Tailwind v4's CSS-variable token namespaces (`--color-*`, `--font-*`, `--text-*`, `--leading-*`, `--tracking-*`, `--font-weight-*`, `--radius-*`, `--spacing-*`).
 - **DTCG tokens.json** ([W3C Design Tokens Format Module](https://tr.designtokens.org/format/)) — `npx @google/design.md export --format dtcg DESIGN.md`
 
 ## Status

--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ npx @google/design.md export --format dtcg DESIGN.md > tokens.json
 | `tailwind` | JSON | Alias for `json-tailwind` |
 | `dtcg` | JSON | W3C Design Tokens Format Module |
 
+Exit code `0` on a successful export (regardless of any lint findings in the source — run `lint` to gate on those), `1` on an invalid `--format` or an emitter error, and `2` if the input file cannot be read.
+
 ### `spec`
 
 Output the DESIGN.md format specification (useful for injecting spec context into agent prompts).

--- a/README.md
+++ b/README.md
@@ -191,6 +191,19 @@ Or run directly (always resolves from the public npm registry):
 npx @google/design.md lint DESIGN.md
 ```
 
+On **Windows/PowerShell**, this direct form can produce no output (or open
+`DESIGN.md` in your Markdown editor) because the `.md` suffix in the `design.md`
+bin name collides with the Windows Markdown file association during command
+resolution. Run the dot-free `designmd` alias instead — point `npx` at the
+package with `-p`, then invoke `designmd`:
+
+```bash
+npx -p @google/design.md designmd lint DESIGN.md
+```
+
+The `designmd` shim resolves to the same entrypoint and works identically across
+all platforms.
+
 #### `npm error ENOVERSIONS` (“No versions available for @google/design.md”)
 
 The CLI is published as [`@google/design.md` on npm](https://www.npmjs.com/package/@google/design.md). `ENOVERSIONS` almost always means npm is not querying the public registry (custom `registry=` in `.npmrc`, a corporate mirror that has not synced this package, or a misconfigured `@google:registry` for the `@google` scope).

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ components:
 
 | Type | Format | Example |
 |:-----|:-------|:--------|
-| Color | `#` + hex (sRGB) | `"#1A1C1E"` |
+| Color | Any CSS color (hex, `rgb()`, `oklch()`, named, etc.) | `"#1A1C1E"`, `"oklch(62% 0.18 250)"` |
 | Dimension | number + unit (`px`, `em`, `rem`) | `48px`, `-0.02em` |
 | Token Reference | `{path.to.token}` | `{colors.primary}` |
 | Typography | object with `fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing`, `fontFeature`, `fontVariation` | See example above |

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ npx @google/design.md spec --rules-only --format json
 
 ## Linting Rules
 
-The linter runs seven rules against a parsed DESIGN.md. Each rule produces findings at a fixed severity level.
+The linter runs nine rules against a parsed DESIGN.md. Each rule produces findings at a fixed severity level.
 
 | Rule | Severity | What it checks |
 |:-----|:---------|:---------------|
@@ -305,6 +305,7 @@ The linter runs seven rules against a parsed DESIGN.md. Each rule produces findi
 | `missing-sections` | info | Optional sections (spacing, rounded) absent when other tokens exist |
 | `missing-typography` | warning | Colors are defined but no typography tokens exist — agents will use default fonts |
 | `section-order` | warning | Sections appear out of the canonical order defined by the spec |
+| `unknown-key` | warning | A top-level YAML key looks like a typo of a known schema key (e.g. `colours:` → `colors:`); custom extension keys stay silent |
 
 ### Programmatic API
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ components:
 
 | Type | Format | Example |
 |:-----|:-------|:--------|
-| Color | hex (sRGB) or any CSS color function: `rgb()`, `hsl()`, `oklch()`, `oklab()`, `lab()`, `color(display-p3 …)` | `"#1A1C1E"`, `"oklch(70% 0.15 200)"` |
+| Color | any CSS color: hex, named colors, `rgb()`, `hsl()`, `hwb()`, `oklch()`, `oklab()`, `lab()`, `lch()`, `color(display-p3 …)`, `color-mix()` | `"#1A1C1E"`, `"oklch(70% 0.15 200)"` |
 | Dimension | number + unit (`px`, `em`, `rem`) | `48px`, `-0.02em` |
 | Token Reference | `{path.to.token}` | `{colors.primary}` |
 | Typography | object with `fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing`, `fontFeature`, `fontVariation` | See example above |
@@ -203,7 +203,47 @@ Then run the CLI from the repo root via the `cli` script defined in `package.jso
 bun run cli lint DESIGN.md
 ```
 
+On **Windows/PowerShell**, this direct form can produce no output (or open
+`DESIGN.md` in your Markdown editor) because the `.md` suffix in the `design.md`
+bin name collides with the Windows Markdown file association during command
+resolution. Run the dot-free `designmd` alias instead — point `npx` at the
+package with `-p`, then invoke `designmd`:
+
+```bash
+npx -p @google/design.md designmd lint DESIGN.md
+```
+
+The `designmd` shim resolves to the same entrypoint and works identically across
+all platforms.
+
+#### `npm error ENOVERSIONS` (“No versions available for @google/design.md”)
+
+The CLI is published as [`@google/design.md` on npm](https://www.npmjs.com/package/@google/design.md). `ENOVERSIONS` almost always means npm is not querying the public registry (custom `registry=` in `.npmrc`, a corporate mirror that has not synced this package, or a misconfigured `@google:registry` for the `@google` scope).
+
+Check your effective registry:
+
+```bash
+npm config get registry
+```
+
+For a normal install from the internet it should be `https://registry.npmjs.org/`. After fixing config, retry with `npm cache clean --force` if a stale 404 was cached.
+
 All commands accept a file path or `-` for stdin. Output defaults to JSON.
+
+> **Windows tip**: when invoking the CLI directly from a `package.json` script
+> (rather than through `npx`), use the `designmd` alias instead of `design.md`.
+> The `.md` suffix in the original bin name confuses Windows command resolution
+> with the file association for Markdown files. The `designmd` shim resolves to
+> the same entrypoint and works identically across all platforms.
+>
+> ```jsonc
+> // package.json
+> {
+>   "scripts": {
+>     "design:lint": "designmd lint DESIGN.md"
+>   }
+> }
+> ```
 
 ### `lint`
 
@@ -257,11 +297,13 @@ Exit code `1` if regressions are detected (more errors or warnings in the "after
 
 ### `export`
 
-Export DESIGN.md tokens to other formats (tailwind, dtcg).
+Export DESIGN.md tokens to other formats.
 
 ```bash
-bun run cli export --format tailwind DESIGN.md > theme.css
+bun run cli export --format css-tailwind DESIGN.md > theme.css
+bun run cli export --format json-tailwind DESIGN.md > tailwind.theme.json
 bun run cli export --format dtcg DESIGN.md > tokens.json
+bun run cli export --format css-vars DESIGN.md > tokens.css
 ```
 
 The `tailwind` format emits a Tailwind v4 `@theme` stylesheet — Tailwind v4 deprecates `tailwind.config.js` in favor of CSS-first configuration via `@theme { --color-*; --font-*; ... }`. Import the generated file from your app's main stylesheet alongside `@import "tailwindcss";`.
@@ -269,7 +311,16 @@ The `tailwind` format emits a Tailwind v4 `@theme` stylesheet — Tailwind v4 de
 | Option | Type | Default | Description |
 |:-------|:-----|:--------|:------------|
 | `file` | positional | required | Path to DESIGN.md (or `-` for stdin) |
-| `--format` | `tailwind` \| `dtcg` | required | Output format |
+| `--format` | `json-tailwind` \| `css-tailwind` \| `tailwind` \| `dtcg` | required | Output format |
+
+| Format | Output | Description |
+|:-------|:-------|:------------|
+| `json-tailwind` | JSON | Tailwind v3 `theme.extend` config object |
+| `css-tailwind` | CSS | Tailwind v4 `@theme { ... }` block with CSS custom properties |
+| `tailwind` | JSON | Alias for `json-tailwind` |
+| `dtcg` | JSON | W3C Design Tokens Format Module |
+
+Exit code `0` on a successful export (regardless of any lint findings in the source — run `lint` to gate on those), `1` on an invalid `--format` or an emitter error, and `2` if the input file cannot be read.
 
 ### `spec`
 
@@ -289,7 +340,7 @@ bun run cli spec --rules-only --format json
 
 ## Linting Rules
 
-The linter runs seven rules against a parsed DESIGN.md. Each rule produces findings at a fixed severity level.
+The linter runs nine rules against a parsed DESIGN.md. Each rule produces findings at a fixed severity level.
 
 | Rule | Severity | What it checks |
 |:-----|:---------|:---------------|
@@ -301,6 +352,7 @@ The linter runs seven rules against a parsed DESIGN.md. Each rule produces findi
 | `missing-sections` | info | Optional sections (spacing, rounded) absent when other tokens exist |
 | `missing-typography` | warning | Colors are defined but no typography tokens exist — agents will use default fonts |
 | `section-order` | warning | Sections appear out of the canonical order defined by the spec |
+| `unknown-key` | warning | A top-level YAML key looks like a typo of a known schema key (e.g. `colours:` → `colors:`); custom extension keys stay silent |
 
 ### Programmatic API
 
@@ -320,7 +372,9 @@ console.log(report.designSystem);   // Parsed DesignSystemState
 
 DESIGN.md tokens are inspired by the [W3C Design Token Format](https://www.designtokens.org/). The `export` command converts tokens to other formats:
 
-- **Tailwind v4 `@theme` CSS** — `bun run cli export --format tailwind DESIGN.md`
+- **Tailwind v4 theme (CSS)** — `bun run cli export --format css-tailwind DESIGN.md` — emits a shadcn-style `:root` + `@theme inline` stylesheet. `--format tailwind` is a backwards-compatible alias.
+- **Tailwind v3 config (JSON)** — `bun run cli export --format json-tailwind DESIGN.md` — emits a `theme.extend` JSON object for `tailwind.config.js`.
+- **CSS custom properties** — `bun run cli export --format css-vars DESIGN.md` — emits a plain `:root { --token: value }` stylesheet.
 - **DTCG tokens.json** ([W3C Design Tokens Format Module](https://tr.designtokens.org/format/)) — `bun run cli export --format dtcg DESIGN.md`
 
 ## Status

--- a/bun.lock
+++ b/bun.lock
@@ -13,17 +13,13 @@
     },
     "packages/cli": {
       "name": "@google/design.md",
-      "version": "0.1.1",
+      "version": "0.3.0",
       "bin": {
         "design.md": "./dist/index.js",
+        "designmd": "./dist/index.js",
       },
       "dependencies": {
-        "@json-render/core": "^0.16.0",
-        "@json-render/ink": "^0.16.0",
         "citty": "^0.1.6",
-        "ink": "^7.0.0",
-        "mdast": "^3.0.0",
-        "react": "^19.2.5",
         "remark-frontmatter": "^5.0.0",
         "remark-mdx": "^3.1.1",
         "remark-parse": "^11.0.0",
@@ -37,7 +33,6 @@
         "@types/bun": "latest",
         "@types/mdast": "^4.0.4",
         "@types/node": "^20.11.24",
-        "@types/react": "^19.2.14",
         "bun-types": "^1.3.12",
         "tailwindcss": "3",
         "typescript": "^5.7.3",
@@ -61,8 +56,6 @@
     },
   },
   "packages": {
-    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
-
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.30.1", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-nuKvp7wOIz6BFei8WrTdhmSsx5mwnArYyJgh4+vYu3V4J0Ltb8Xm3odPm51n1aSI0XxNCrDl7O88cxCtUdAkaw=="],
@@ -78,10 +71,6 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
-    "@json-render/core": ["@json-render/core@0.16.0", "", { "dependencies": { "zod": "^4.3.6" } }, "sha512-qQp8BB/3pWYapTGXBDSBMXRCdrC05VJPLL3drXMPX/QbUB3nuvtyXUGmAZFUz8eLUy7JImODvb3GNIq38dGzhQ=="],
-
-    "@json-render/ink": ["@json-render/ink@0.16.0", "", { "dependencies": { "@json-render/core": "0.16.0", "marked": "^17.0.0" }, "peerDependencies": { "ink": "^6.0.0", "react": "^19.0.0" } }, "sha512-oJ/MbW0zLkv3i6MSZVk8QiI6mbyvtA0XZpJEuJBTCf1yjMMdxN16Mz/uW/5AV9FMOBjZXohQPONLMxvSxil6Bg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -101,7 +90,7 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
@@ -119,8 +108,6 @@
 
     "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
-    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
-
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
@@ -131,12 +118,6 @@
 
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
-    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
-
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
@@ -145,13 +126,11 @@
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
-    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
-
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
-    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+    "boolbase": ["boolbase@2.0.0", "", {}, "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -162,8 +141,6 @@
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
-
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
@@ -177,31 +154,19 @@
 
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
-    "cli-boxes": ["cli-boxes@4.0.1", "", {}, "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw=="],
-
-    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
-
-    "cli-truncate": ["cli-truncate@6.0.0", "", { "dependencies": { "slice-ansi": "^9.0.0", "string-width": "^8.2.0" } }, "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA=="],
-
-    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
-
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
-    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+    "css-select": ["css-select@7.0.0", "", { "dependencies": { "boolbase": "^2.0.0", "css-what": "^8.0.0", "domhandler": "^6.0.1", "domutils": "^4.0.2", "nth-check": "^3.0.1" } }, "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g=="],
 
-    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
-
-    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+    "css-what": ["css-what@8.0.0", "", {}, "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
-
-    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -217,31 +182,27 @@
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
-    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+    "dom-serializer": ["dom-serializer@3.1.1", "", { "dependencies": { "domelementtype": "^3.0.0", "domhandler": "^6.0.0", "entities": "^8.0.0" } }, "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw=="],
 
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
-    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+    "domhandler": ["domhandler@6.0.1", "", { "dependencies": { "domelementtype": "^3.0.0" } }, "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg=="],
 
-    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+    "domutils": ["domutils@4.0.2", "", { "dependencies": { "dom-serializer": "^3.0.0", "domelementtype": "^3.0.0", "domhandler": "^6.0.0" } }, "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
-    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
-
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
-    "es-toolkit": ["es-toolkit@1.46.0", "", {}, "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="],
-
-    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
@@ -261,7 +222,7 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
-    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
     "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
 
@@ -272,8 +233,6 @@
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
-
-    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
@@ -295,10 +254,6 @@
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
-    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
-
-    "ink": ["ink@7.0.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.3.0", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.3", "auto-bind": "^5.0.1", "chalk": "^5.6.2", "cli-boxes": "^4.0.1", "cli-cursor": "^4.0.0", "cli-truncate": "^6.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.45.1", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^9.0.0", "stack-utils": "^2.0.6", "string-width": "^8.2.0", "terminal-size": "^4.0.1", "type-fest": "^5.5.0", "widest-line": "^6.0.0", "wrap-ansi": "^10.0.0", "ws": "^8.20.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.2.0", "react": ">=19.2.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-o6LAC268PLawlGVYrXTyaTfke4VtJftEheuwbgkQf7yvSXyWp1nRwBbAyKEkWXFZZsW/la5wrMuNbuBvZK2C1w=="],
-
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
@@ -311,13 +266,9 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
-
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
-
-    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -329,15 +280,11 @@
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
-    "linkedom": ["linkedom@0.18.12", "", { "dependencies": { "css-select": "^5.1.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.0.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q=="],
+    "linkedom": ["linkedom@0.18.13", "", { "dependencies": { "css-select": "^7.0.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.1.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
-    "marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
-
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
-
-    "mdast": ["mdast@3.0.0", "", {}, "sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g=="],
 
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
 
@@ -423,8 +370,6 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
-    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
-
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
@@ -437,17 +382,13 @@
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
-    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+    "nth-check": ["nth-check@3.0.1", "", { "dependencies": { "boolbase": "^2.0.0" } }, "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
 
-    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
-
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
-
-    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
@@ -459,9 +400,9 @@
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
-    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
 
-    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
@@ -479,10 +420,6 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
-    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
-
-    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
-
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
@@ -497,37 +434,19 @@
 
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
-    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
-
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
-    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
-
-    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
-    "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
-
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
-    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
-
-    "string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
-
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
-
-    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
-
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
-
-    "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -544,8 +463,6 @@
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
     "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
-
-    "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
@@ -577,15 +494,7 @@
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
-    "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
-
-    "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
-
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
-
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
-
-    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -595,27 +504,39 @@
 
     "@google/design.md/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
-    "@google/design.md/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "@google/design.md/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@google/design.md/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "@google/design.md-evals/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "@google/design.md-evals/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@google/design.md-evals/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "@json-render/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "dom-serializer/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
+    "dom-serializer/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "domhandler/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
+    "domutils/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
+    "es-set-tostringtag/hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "mdast-util-frontmatter/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+    "form-data/hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "get-intrinsic/hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "htmlparser2/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "htmlparser2/domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
@@ -626,5 +547,9 @@
     "@google/design.md/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@google/design.md/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "htmlparser2/domutils/dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "htmlparser2/domutils/dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -13,34 +13,41 @@
     },
     "packages/cli": {
       "name": "@google/design.md",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "design.md": "./dist/index.js",
         "designmd": "./dist/index.js",
       },
       "dependencies": {
+        "@json-render/core": "^0.16.0",
+        "@json-render/ink": "^0.16.0",
+        "citty": "^0.1.6",
+        "ink": "^7.0.0",
+        "mdast": "^3.0.0",
+        "react": "^19.2.5",
+        "remark-frontmatter": "^5.0.0",
+        "remark-mdx": "^3.1.1",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0",
+        "yaml": "^2.7.1",
         "zod": "^3.24.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/mdast": "^4.0.4",
         "@types/node": "^20.11.24",
+        "@types/react": "^19.2.14",
         "bun-types": "^1.3.12",
-        "citty": "^0.1.6",
-        "mdast": "^3.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-mdx": "^3.1.1",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
         "tailwindcss": "3",
         "typescript": "^5.7.3",
-        "unified": "^11.0.5",
-        "unist-util-visit": "^5.1.0",
-        "yaml": "^2.7.1",
       },
     },
   },
   "packages": {
+    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@google/design.md": ["@google/design.md@workspace:packages/cli"],
@@ -52,6 +59,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@json-render/core": ["@json-render/core@0.16.0", "", { "dependencies": { "zod": "^4.3.6" } }, "sha512-qQp8BB/3pWYapTGXBDSBMXRCdrC05VJPLL3drXMPX/QbUB3nuvtyXUGmAZFUz8eLUy7JImODvb3GNIq38dGzhQ=="],
+
+    "@json-render/ink": ["@json-render/ink@0.16.0", "", { "dependencies": { "@json-render/core": "0.16.0", "marked": "^17.0.0" }, "peerDependencies": { "ink": "^6.0.0", "react": "^19.0.0" } }, "sha512-oJ/MbW0zLkv3i6MSZVk8QiI6mbyvtA0XZpJEuJBTCf1yjMMdxN16Mz/uW/5AV9FMOBjZXohQPONLMxvSxil6Bg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -71,7 +82,7 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
 
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
@@ -87,17 +98,27 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
+
+    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -111,6 +132,8 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
@@ -123,11 +146,23 @@
 
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
+    "cli-boxes": ["cli-boxes@4.0.1", "", {}, "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw=="],
+
+    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
+
+    "cli-truncate": ["cli-truncate@6.0.0", "", { "dependencies": { "slice-ansi": "^9.0.0", "string-width": "^8.2.0" } }, "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA=="],
+
+    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
+
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
+    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -141,9 +176,13 @@
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+    "es-toolkit": ["es-toolkit@1.46.1", "", {}, "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="],
+
+    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
@@ -167,9 +206,15 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
+
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "ink": ["ink@7.0.2", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.3.0", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.3", "auto-bind": "^5.0.1", "chalk": "^5.6.2", "cli-boxes": "^4.0.1", "cli-cursor": "^4.0.0", "cli-truncate": "^6.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.45.1", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^9.0.0", "stack-utils": "^2.0.6", "string-width": "^8.2.0", "terminal-size": "^4.0.1", "type-fest": "^5.5.0", "widest-line": "^6.0.0", "wrap-ansi": "^10.0.0", "ws": "^8.20.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.2.0", "react": ">=19.2.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-cnkE2SsDC/gieJ+BD8+gWpXrZPMInv7agBYN5gcKVlQZYp+IKa/FKM5bp1OIuJFp3ZIuRK7ZNxY4MZR3tUzyfQ=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -183,9 +228,13 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -198,6 +247,8 @@
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
 
     "mdast": ["mdast@3.0.0", "", {}, "sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g=="],
 
@@ -281,6 +332,8 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
@@ -293,7 +346,11 @@
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
 
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
+    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
@@ -321,6 +378,10 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
+
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
@@ -335,19 +396,37 @@
 
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
+    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
+
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
+
+    "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -362,6 +441,8 @@
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
     "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
+
+    "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
@@ -385,7 +466,15 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
+    "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
+
+    "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -395,9 +484,15 @@
 
     "@google/design.md/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
+    "@json-render/core/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "mdast-util-frontmatter/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,18 +13,13 @@
     },
     "packages/cli": {
       "name": "@google/design.md",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "bin": {
         "design.md": "./dist/index.js",
         "designmd": "./dist/index.js",
       },
       "dependencies": {
-        "@json-render/core": "^0.16.0",
-        "@json-render/ink": "^0.16.0",
         "citty": "^0.1.6",
-        "ink": "^7.0.0",
-        "mdast": "^3.0.0",
-        "react": "^19.2.5",
         "remark-frontmatter": "^5.0.0",
         "remark-mdx": "^3.1.1",
         "remark-parse": "^11.0.0",
@@ -38,7 +33,6 @@
         "@types/bun": "latest",
         "@types/mdast": "^4.0.4",
         "@types/node": "^20.11.24",
-        "@types/react": "^19.2.14",
         "bun-types": "^1.3.12",
         "tailwindcss": "3",
         "typescript": "^5.7.3",
@@ -46,8 +40,6 @@
     },
   },
   "packages": {
-    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
-
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@google/design.md": ["@google/design.md@workspace:packages/cli"],
@@ -59,10 +51,6 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
-    "@json-render/core": ["@json-render/core@0.16.0", "", { "dependencies": { "zod": "^4.3.6" } }, "sha512-qQp8BB/3pWYapTGXBDSBMXRCdrC05VJPLL3drXMPX/QbUB3nuvtyXUGmAZFUz8eLUy7JImODvb3GNIq38dGzhQ=="],
-
-    "@json-render/ink": ["@json-render/ink@0.16.0", "", { "dependencies": { "@json-render/core": "0.16.0", "marked": "^17.0.0" }, "peerDependencies": { "ink": "^6.0.0", "react": "^19.0.0" } }, "sha512-oJ/MbW0zLkv3i6MSZVk8QiI6mbyvtA0XZpJEuJBTCf1yjMMdxN16Mz/uW/5AV9FMOBjZXohQPONLMxvSxil6Bg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -82,7 +70,7 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
@@ -98,27 +86,17 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
-    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
-
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
-
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
-
-    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -132,8 +110,6 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
-
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
@@ -146,23 +122,11 @@
 
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
-    "cli-boxes": ["cli-boxes@4.0.1", "", {}, "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw=="],
-
-    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
-
-    "cli-truncate": ["cli-truncate@6.0.0", "", { "dependencies": { "slice-ansi": "^9.0.0", "string-width": "^8.2.0" } }, "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA=="],
-
-    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
-
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
-    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
-
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
-
-    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -176,13 +140,9 @@
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
-    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
-
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
-    "es-toolkit": ["es-toolkit@1.46.1", "", {}, "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="],
-
-    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
@@ -206,15 +166,9 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
-    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
-
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
-
-    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
-
-    "ink": ["ink@7.0.2", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.3.0", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.3", "auto-bind": "^5.0.1", "chalk": "^5.6.2", "cli-boxes": "^4.0.1", "cli-cursor": "^4.0.0", "cli-truncate": "^6.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.45.1", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^9.0.0", "stack-utils": "^2.0.6", "string-width": "^8.2.0", "terminal-size": "^4.0.1", "type-fest": "^5.5.0", "widest-line": "^6.0.0", "wrap-ansi": "^10.0.0", "ws": "^8.20.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.2.0", "react": ">=19.2.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-cnkE2SsDC/gieJ+BD8+gWpXrZPMInv7agBYN5gcKVlQZYp+IKa/FKM5bp1OIuJFp3ZIuRK7ZNxY4MZR3tUzyfQ=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -228,13 +182,9 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
-
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
-
-    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -247,10 +197,6 @@
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
-
-    "marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
-
-    "mdast": ["mdast@3.0.0", "", {}, "sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g=="],
 
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
 
@@ -332,8 +278,6 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
-
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
@@ -346,11 +290,7 @@
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
 
-    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
-
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
-
-    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
@@ -378,10 +318,6 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
-    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
-
-    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
-
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
@@ -396,37 +332,19 @@
 
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
-    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
-
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
-    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
-
-    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
-    "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
-
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
-    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
-
-    "string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
-
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
-
-    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
-
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
-
-    "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -441,8 +359,6 @@
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
     "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
-
-    "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
@@ -466,15 +382,7 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
-
-    "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
-
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
-
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
-
-    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -482,22 +390,22 @@
 
     "@google/design.md/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
+    "@google/design.md/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "@google/design.md/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "@json-render/core/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
-    "@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "mdast-util-frontmatter/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "@google/design.md/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@google/design.md/bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
   }
 }

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -59,17 +59,23 @@ components:
 
 The `<scale-level>` placeholder represents a named level in a sizing or spacing scale. Common level names include `xs`, `sm`, `md`, `lg`, `xl`, and `full`. Any descriptive string key is valid.
 
-**Color**: A color value is any valid CSS color string. Supported formats include:
+**Color**: A color value is any valid CSS color string.
 
-* Hex: `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`
-* Named colors: `red`, `cornflowerblue`, `transparent`
-* Functional: `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()`
-* Wide-gamut: `oklch()`, `oklab()`, `lch()`, `lab()`
-* Mixing: `color-mix(in srgb, ...)`
+Supported formats include:
+
+- Hex: `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`
+- Named colors: `red`, `cornflowerblue`, `transparent`
+- Functional: `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()`
+- Wide-gamut: `oklch()`, `oklab()`, `lch()`, `lab()`
+- Mixing: `color-mix(in srgb, ...)`
 
 All color values are internally converted to sRGB for WCAG contrast checking. The original format is preserved for display and export.
 
 Hex notation (`#RRGGBB`) remains the recommended default for simplicity and broad tooling support.
+
+**Dimension**: A dimension value is a string with a unit suffix.
+
+Valid units are: px, em, rem.
 
 - `fontFamily` (string)
 - `fontSize` (Dimension)
@@ -80,8 +86,6 @@ Hex notation (`#RRGGBB`) remains the recommended default for simplicity and broa
   [`font-feature-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-feature-settings).
 - `fontVariation` (string) - configures
   [`font-variation-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-variation-settings).
-
-**Dimension**: A dimension value is a string with a unit suffix. Valid units are: px, em, rem.
 
 **Token References**: A token reference must be wrapped in curly braces, and contain an object path to another value in the YAML tree. For most token groups, the reference must point to a primitive value (e.g., `colors.primary-60`), not a group (e.g., `colors`). Within the `components` section, references to composite values (e.g., `{typography.label-md}`) are permitted.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -59,7 +59,17 @@ components:
 
 The `<scale-level>` placeholder represents a named level in a sizing or spacing scale. Common level names include `xs`, `sm`, `md`, `lg`, `xl`, and `full`. Any descriptive string key is valid.
 
-**Color**: A color value must start with "#" followed by a hex color code in the SRGB color space.
+**Color**: A color value is any valid CSS color string. Supported formats include:
+
+* Hex: `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`
+* Named colors: `red`, `cornflowerblue`, `transparent`
+* Functional: `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()`
+* Wide-gamut: `oklch()`, `oklab()`, `lch()`, `lab()`
+* Mixing: `color-mix(in srgb, ...)`
+
+All color values are internally converted to sRGB for WCAG contrast checking. The original format is preserved for display and export.
+
+Hex notation (`#RRGGBB`) remains the recommended default for simplicity and broad tooling support.
 
 - `fontFamily` (string)
 - `fontSize` (Dimension)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -59,14 +59,23 @@ components:
 
 The `<scale-level>` placeholder represents a named level in a sizing or spacing scale. Common level names include `xs`, `sm`, `md`, `lg`, `xl`, and `full`. Any descriptive string key is valid.
 
-**Color**: A color value is any CSS color notation. The recommended forms are:
+**Color**: A color value is any valid CSS color string.
 
-* **Hex** (sRGB): `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`
-* **`rgb()` / `rgba()`** and **`hsl()` / `hsla()`**
-* **`oklch()`**, **`oklab()`**, **`lab()`** for perceptually uniform color
-* **`color(display-p3 …)`** for wide-gamut display colors
+Supported formats include:
 
-The linter computes WCAG contrast in sRGB; wide-gamut inputs are converted and clamped for that purpose, but emitters preserve the original notation when the target supports it (e.g., Tailwind v4).
+- Hex: `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`
+- Named colors: `red`, `cornflowerblue`, `transparent`
+- Functional: `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()`
+- Wide-gamut: `oklch()`, `oklab()`, `lch()`, `lab()`, `color(display-p3 ...)`
+- Mixing: `color-mix(in srgb, ...)`
+
+All color values are internally converted to sRGB for WCAG contrast checking (wide-gamut inputs are clamped for that purpose). The original notation is preserved for display and export when the target supports it (e.g., Tailwind v4).
+
+Hex notation (`#RRGGBB`) remains the recommended default for simplicity and broad tooling support.
+
+**Dimension**: A dimension value is a string with a unit suffix.
+
+Valid units are: px, em, rem.
 
 - `fontFamily` (string)
 - `fontSize` (Dimension)
@@ -77,8 +86,6 @@ The linter computes WCAG contrast in sRGB; wide-gamut inputs are converted and c
   [`font-feature-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-feature-settings).
 - `fontVariation` (string) - configures
   [`font-variation-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-variation-settings).
-
-**Dimension**: A dimension value is a string with a unit suffix. Valid units are: px, em, rem.
 
 **Token References**: A token reference must be wrapped in curly braces, and contain an object path to another value in the YAML tree. For most token groups, the reference must point to a primitive value (e.g., `colors.primary-60`), not a group (e.g., `colors`). Within the `components` section, references to composite values (e.g., `{typography.label-md}`) are permitted.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2625 @@
+{
+  "name": "design-monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "design-monorepo",
+      "workspaces": [
+        "packages/*"
+      ],
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "bun-types": "^1.3.12",
+        "turbo": "latest",
+        "typescript": "latest"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google/design.md": {
+      "resolved": "packages/cli",
+      "link": true
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@turbo/darwin-64": {
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.18.tgz",
+      "integrity": "sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/darwin-arm64": {
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.18.tgz",
+      "integrity": "sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/linux-64": {
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.18.tgz",
+      "integrity": "sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/linux-arm64": {
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.18.tgz",
+      "integrity": "sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/windows-64": {
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.18.tgz",
+      "integrity": "sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@turbo/windows-arm64": {
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.18.tgz",
+      "integrity": "sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.14.tgz",
+      "integrity": "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.14"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.14.tgz",
+      "integrity": "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/remark-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/turbo": {
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.18.tgz",
+      "integrity": "sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "@turbo/darwin-64": "2.9.18",
+        "@turbo/darwin-arm64": "2.9.18",
+        "@turbo/linux-64": "2.9.18",
+        "@turbo/linux-arm64": "2.9.18",
+        "@turbo/windows-64": "2.9.18",
+        "@turbo/windows-arm64": "2.9.18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/cli": {
+      "name": "@google/design.md",
+      "version": "0.2.0",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "remark-frontmatter": "^5.0.0",
+        "remark-mdx": "^3.1.1",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0",
+        "yaml": "^2.7.1",
+        "zod": "^3.24.0"
+      },
+      "bin": {
+        "design.md": "dist/index.js",
+        "designmd": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/mdast": "^4.0.4",
+        "@types/node": "^20.11.24",
+        "bun-types": "^1.3.12",
+        "tailwindcss": "3",
+        "typescript": "^5.7.3"
+      }
+    },
+    "packages/cli/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/cli/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/cli/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "workspaces": [
     "packages/*"
   ],
+  "packageManager": "bun@1.3.9",
   "scripts": {
     "build": "turbo build",
     "test": "turbo test",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,8 @@
   "private": false,
   "type": "module",
   "bin": {
-    "design.md": "./dist/index.js"
+    "design.md": "./dist/index.js",
+    "designmd": "./dist/index.js"
   },
   "exports": {
     ".": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/design.md",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Bridging design systems and code: a linter and exporter for the DESIGN.md format",
   "keywords": [
     "design.md"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bun build src/index.ts src/linter/index.ts --outdir dist --target node && npx tsc --project tsconfig.build.json --emitDeclarationOnly --skipLibCheck && cp src/linter/spec-config.yaml dist/linter/ && cp src/linter/spec-config.yaml dist/ && cp ../../docs/spec.md dist/linter/",
+    "build": "bun build src/index.ts src/linter/index.ts --outdir dist --target node && npx tsc --project tsconfig.build.json --emitDeclarationOnly --skipLibCheck && cp src/linter/spec-config.yaml dist/linter/ && cp src/linter/spec-config.yaml dist/ && cp ../../docs/spec.md dist/linter/ && cp ../../docs/spec.md dist/",
     "dev": "bun run src/index.ts",
     "test": "bun test",
     "lint": "tsc --noEmit --skipLibCheck",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/design.md",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Bridging design systems and code: a linter and exporter for the DESIGN.md format",
   "keywords": [
     "design.md"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,16 +41,12 @@
     "build": "bun build src/index.ts src/linter/index.ts --outdir dist --target node && npx tsc --project tsconfig.build.json --emitDeclarationOnly --skipLibCheck && cp src/linter/spec-config.yaml dist/linter/ && cp src/linter/spec-config.yaml dist/ && cp ../../docs/spec.md dist/linter/",
     "dev": "bun run src/index.ts",
     "test": "bun test",
+    "lint": "tsc --noEmit --skipLibCheck",
     "spec:gen": "bun run src/linter/spec-gen/generate.ts",
     "check-package": "bun run scripts/check-package.ts"
   },
   "dependencies": {
-    "@json-render/core": "^0.16.0",
-    "@json-render/ink": "^0.16.0",
     "citty": "^0.1.6",
-    "ink": "^7.0.0",
-    "mdast": "^3.0.0",
-    "react": "^19.2.5",
     "remark-frontmatter": "^5.0.0",
     "remark-mdx": "^3.1.1",
     "remark-parse": "^11.0.0",
@@ -64,7 +60,6 @@
     "@types/bun": "latest",
     "@types/mdast": "^4.0.4",
     "@types/node": "^20.11.24",
-    "@types/react": "^19.2.14",
     "bun-types": "^1.3.12",
     "tailwindcss": "3",
     "typescript": "^5.7.3"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/design.md",
-  "version": "0.1.1",
+  "version": "0.3.0",
   "description": "Bridging design systems and code: a linter and exporter for the DESIGN.md format",
   "keywords": [
     "design.md"
@@ -20,7 +20,8 @@
   "private": false,
   "type": "module",
   "bin": {
-    "design.md": "./dist/index.js"
+    "design.md": "./dist/index.js",
+    "designmd": "./dist/index.js"
   },
   "exports": {
     ".": {
@@ -37,19 +38,15 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bun build src/index.ts src/linter/index.ts --outdir dist --target node && npx tsc --project tsconfig.build.json --emitDeclarationOnly --skipLibCheck && cp src/linter/spec-config.yaml dist/linter/ && cp src/linter/spec-config.yaml dist/ && cp ../../docs/spec.md dist/linter/",
+    "build": "bun build src/index.ts src/linter/index.ts --outdir dist --target node && npx tsc --project tsconfig.build.json --emitDeclarationOnly --skipLibCheck && cp src/linter/spec-config.yaml dist/linter/ && cp src/linter/spec-config.yaml dist/ && cp ../../docs/spec.md dist/linter/ && cp ../../docs/spec.md dist/",
     "dev": "bun run src/index.ts",
     "test": "bun test",
+    "lint": "tsc --noEmit --skipLibCheck",
     "spec:gen": "bun run src/linter/spec-gen/generate.ts",
     "check-package": "bun run scripts/check-package.ts"
   },
   "dependencies": {
-    "@json-render/core": "^0.16.0",
-    "@json-render/ink": "^0.16.0",
     "citty": "^0.1.6",
-    "ink": "^7.0.0",
-    "mdast": "^3.0.0",
-    "react": "^19.2.5",
     "remark-frontmatter": "^5.0.0",
     "remark-mdx": "^3.1.1",
     "remark-parse": "^11.0.0",
@@ -63,7 +60,6 @@
     "@types/bun": "latest",
     "@types/mdast": "^4.0.4",
     "@types/node": "^20.11.24",
-    "@types/react": "^19.2.14",
     "bun-types": "^1.3.12",
     "tailwindcss": "3",
     "typescript": "^5.7.3"

--- a/packages/cli/scripts/check-package.ts
+++ b/packages/cli/scripts/check-package.ts
@@ -108,6 +108,19 @@ function phase1_config() {
   const types = pkg.types as string | undefined;
   check('#5  `types` field exists', !!types,
     'Missing "types" field in package.json');
+
+  // 5c. bin map exposes a Windows-friendly alias (no dot in the name).
+  // The `design.md` bin file is unrunnable on Windows because the `.md`
+  // suffix collides with the Markdown file association, so PowerShell
+  // opens the shim in the user's Markdown editor instead of executing it.
+  // A dot-free alias such as `designmd` lets the npm CMD/PowerShell shims
+  // resolve cleanly via PATHEXT. See https://github.com/google-labs-code/design.md/issues/54.
+  const bin = pkg.bin as Record<string, string> | string | undefined;
+  const binEntries = typeof bin === 'object' && bin !== null ? Object.keys(bin) : [];
+  const hasDotFreeAlias = binEntries.some((name) => !name.includes('.'));
+  check('#5c bin map exposes a Windows-friendly alias (no dot in the name)',
+    hasDotFreeAlias,
+    `bin entries: ${binEntries.join(', ') || '(none)'} — add an alias without a dot for Windows compatibility`);
 }
 
 function phase1_paths() {

--- a/packages/cli/src/commands/cli-errors.test.ts
+++ b/packages/cli/src/commands/cli-errors.test.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { join } from 'node:path';
+
+const CLI = join(import.meta.dir, '../index.ts');
+
+function runCli(args: string[]): { code: number | null; stdout: string; stderr: string } {
+  const proc = Bun.spawnSync(['bun', 'run', CLI, ...args], { stdout: 'pipe', stderr: 'pipe' });
+  return {
+    code: proc.exitCode,
+    stdout: Buffer.from(proc.stdout).toString('utf-8'),
+    stderr: Buffer.from(proc.stderr).toString('utf-8'),
+  };
+}
+
+describe('CLI error output', () => {
+  it('exits 2 with a friendly error and no stack trace when the input file is missing', () => {
+    const { code, stdout, stderr } = runCli(['lint', 'definitely-does-not-exist-90af.md']);
+    expect(code).toBe(2);
+    expect(stdout).toBe('');
+    // Exactly one line on stderr — no second, stack-trace error.
+    const lines = stderr.trim().split('\n').filter(Boolean);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain('not found');
+    expect(lines[0]).toContain('definitely-does-not-exist-90af.md');
+  });
+
+  it('reports an unknown export format with a coded error envelope and exit 1', () => {
+    // Format is validated before any input is read, so the file path is unused.
+    const { code, stderr } = runCli(['export', '--format', 'bogus', 'unused.md']);
+    expect(code).toBe(1);
+    const err = JSON.parse(stderr.trim());
+    expect(err.error).toBe('INVALID_FORMAT');
+    expect(err.message).toContain('Invalid format');
+  });
+});

--- a/packages/cli/src/commands/diff.test.ts
+++ b/packages/cli/src/commands/diff.test.ts
@@ -1,0 +1,99 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { lint } from '../linter/index.js';
+import { diffMaps } from '../utils.js';
+import type { ComponentDef } from '../linter/model/spec.js';
+
+function serializeComponents(components: Map<string, ComponentDef>): Map<string, Record<string, unknown>> {
+  const result = new Map<string, Record<string, unknown>>();
+  for (const [name, comp] of components) {
+    result.set(name, Object.fromEntries(comp.properties));
+  }
+  return result;
+}
+
+const BASE = `---
+name: Base
+colors:
+  primary: "#1A1C1E"
+  secondary: "#6C7278"
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "#ffffff"
+    padding: 12px
+---
+`;
+
+describe('diff: components', () => {
+  it('reports no component changes when files are identical', () => {
+    const before = lint(BASE);
+    const after = lint(BASE);
+    const result = diffMaps(
+      serializeComponents(before.designSystem.components),
+      serializeComponents(after.designSystem.components),
+    );
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+    expect(result.modified).toEqual([]);
+  });
+
+  it('detects an added component', () => {
+    const afterContent = BASE.replace(
+      'padding: 12px',
+      'padding: 12px\n  button-secondary:\n    backgroundColor: "{colors.secondary}"\n    textColor: "#ffffff"',
+    );
+    const before = lint(BASE);
+    const after = lint(afterContent);
+    const result = diffMaps(
+      serializeComponents(before.designSystem.components),
+      serializeComponents(after.designSystem.components),
+    );
+    expect(result.added).toContain('button-secondary');
+    expect(result.removed).toEqual([]);
+  });
+
+  it('detects a removed component', () => {
+    const afterContent = `---
+name: After
+colors:
+  primary: "#1A1C1E"
+  secondary: "#6C7278"
+---
+`;
+    const before = lint(BASE);
+    const after = lint(afterContent);
+    const result = diffMaps(
+      serializeComponents(before.designSystem.components),
+      serializeComponents(after.designSystem.components),
+    );
+    expect(result.removed).toContain('button-primary');
+    expect(result.added).toEqual([]);
+  });
+
+  it('detects a modified component property', () => {
+    const afterContent = BASE.replace('padding: 12px', 'padding: 16px');
+    const before = lint(BASE);
+    const after = lint(afterContent);
+    const result = diffMaps(
+      serializeComponents(before.designSystem.components),
+      serializeComponents(after.designSystem.components),
+    );
+    expect(result.modified).toContain('button-primary');
+    expect(result.added).toEqual([]);
+    expect(result.removed).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -14,7 +14,8 @@
 
 import { defineCommand } from 'citty';
 import { lint } from '../linter/index.js';
-import { readInput, formatOutput, diffMaps, serializeDesignSystem } from '../utils.js';
+import { readInput, formatOutput, diffMaps } from '../utils.js';
+import type { ComponentDef } from '../linter/model/spec.js';
 
 export default defineCommand({
   meta: {
@@ -51,6 +52,10 @@ export default defineCommand({
         typography: diffMaps(beforeReport.designSystem.typography, afterReport.designSystem.typography),
         rounded: diffMaps(beforeReport.designSystem.rounded, afterReport.designSystem.rounded),
         spacing: diffMaps(beforeReport.designSystem.spacing, afterReport.designSystem.spacing),
+        components: diffMaps(
+          serializeComponents(beforeReport.designSystem.components),
+          serializeComponents(afterReport.designSystem.components),
+        ),
       },
       findings: {
         before: beforeReport.summary,
@@ -68,3 +73,11 @@ export default defineCommand({
     process.exitCode = diff.regression ? 1 : 0;
   },
 });
+
+function serializeComponents(components: Map<string, ComponentDef>): Map<string, Record<string, unknown>> {
+  const result = new Map<string, Record<string, unknown>>();
+  for (const [name, comp] of components) {
+    result.set(name, Object.fromEntries(comp.properties));
+  }
+  return result;
+}

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -14,7 +14,8 @@
 
 import { defineCommand } from 'citty';
 import { lint } from '../linter/index.js';
-import { readInput, formatOutput, diffMaps, serializeDesignSystem } from '../utils.js';
+import { readInput, formatOutput, diffMaps, FileReadError } from '../utils.js';
+import type { ComponentDef } from '../linter/model/spec.js';
 
 export default defineCommand({
   meta: {
@@ -39,8 +40,18 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const beforeContent = await readInput(args.before);
-    const afterContent = await readInput(args.after);
+    let beforeContent: string, afterContent: string;
+    try {
+      beforeContent = await readInput(args.before);
+      afterContent = await readInput(args.after);
+    } catch (error) {
+      if (error instanceof FileReadError) {
+        process.stderr.write(`Error: ${error.friendlyMessage}\n`);
+        process.exitCode = 2;
+        return;
+      }
+      throw error;
+    }
 
     const beforeReport = lint(beforeContent);
     const afterReport = lint(afterContent);
@@ -51,6 +62,10 @@ export default defineCommand({
         typography: diffMaps(beforeReport.designSystem.typography, afterReport.designSystem.typography),
         rounded: diffMaps(beforeReport.designSystem.rounded, afterReport.designSystem.rounded),
         spacing: diffMaps(beforeReport.designSystem.spacing, afterReport.designSystem.spacing),
+        components: diffMaps(
+          serializeComponents(beforeReport.designSystem.components),
+          serializeComponents(afterReport.designSystem.components),
+        ),
       },
       findings: {
         before: beforeReport.summary,
@@ -68,3 +83,11 @@ export default defineCommand({
     process.exitCode = diff.regression ? 1 : 0;
   },
 });
+
+function serializeComponents(components: Map<string, ComponentDef>): Map<string, Record<string, unknown>> {
+  const result = new Map<string, Record<string, unknown>>();
+  for (const [name, comp] of components) {
+    result.set(name, Object.fromEntries(comp.properties));
+  }
+  return result;
+}

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -14,7 +14,7 @@
 
 import { defineCommand } from 'citty';
 import { lint } from '../linter/index.js';
-import { readInput, formatOutput, diffMaps } from '../utils.js';
+import { readInput, formatOutput, diffMaps, FileReadError } from '../utils.js';
 import type { ComponentDef } from '../linter/model/spec.js';
 
 export default defineCommand({
@@ -40,8 +40,18 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const beforeContent = await readInput(args.before);
-    const afterContent = await readInput(args.after);
+    let beforeContent: string, afterContent: string;
+    try {
+      beforeContent = await readInput(args.before);
+      afterContent = await readInput(args.after);
+    } catch (error) {
+      if (error instanceof FileReadError) {
+        process.stderr.write(`Error: ${error.friendlyMessage}\n`);
+        process.exitCode = 2;
+        return;
+      }
+      throw error;
+    }
 
     const beforeReport = lint(beforeContent);
     const afterReport = lint(afterContent);

--- a/packages/cli/src/commands/export-exit-code.test.ts
+++ b/packages/cli/src/commands/export-exit-code.test.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, afterAll } from 'bun:test';
+import { join } from 'node:path';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+const CLI = join(import.meta.dir, '../index.ts');
+
+function run(args: string[]): { code: number | null; stdout: string } {
+  const proc = Bun.spawnSync(['bun', 'run', CLI, ...args], { stdout: 'pipe', stderr: 'pipe' });
+  return { code: proc.exitCode, stdout: Buffer.from(proc.stdout).toString('utf-8') };
+}
+
+describe('export exit code', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'designmd-export-'));
+  const badFile = join(dir, 'DESIGN.md');
+  // An invalid color is a lint *error*, but the export itself still succeeds.
+  writeFileSync(badFile, '---\ncolors:\n  primary: "notacolor"\n---\n## Colors\n');
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('exits 0 on a successful export even when the source has lint errors', () => {
+    const { code, stdout } = run(['export', '--format', 'json-tailwind', badFile]);
+    expect(code).toBe(0);
+    expect(stdout.trim().length).toBeGreaterThan(0);
+  });
+
+  it('lint still exits 1 on the same source (the validation gate)', () => {
+    const { code } = run(['lint', badFile]);
+    expect(code).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/export.test.ts
+++ b/packages/cli/src/commands/export.test.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+import exportCommand from './export.js';
+
+const FIXTURE_PATH = fileURLToPath(new URL('../linter/fixtures/DESIGN-test.md', import.meta.url));
+
+describe('export command', () => {
+  let logSpy: any;
+  let errorSpy: any;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    process.exitCode = 0;
+  });
+
+  it('outputs css-vars custom properties with an optional prefix', async () => {
+    await exportCommand.run!({
+      args: {
+        file: FIXTURE_PATH,
+        format: 'css-vars',
+        prefix: 'ds',
+      },
+    } as any);
+
+    expect(errorSpy.mock.calls.length).toBe(0);
+    expect(logSpy.mock.calls.length).toBe(1);
+    const output = logSpy.mock.calls[0][0];
+
+    expect(output).toStartWith(':root {\n');
+    expect(output).toContain('  --ds-color-primary: #006b5a;');
+    expect(output).toContain('  --ds-spacing-unit: 8px;');
+    expect(output).toContain('  --ds-rounded-sm: 0.25rem;');
+    expect(output).toEndWith('}\n');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('errors with exit code 1 for invalid export formats', async () => {
+    await exportCommand.run!({
+      args: {
+        file: FIXTURE_PATH,
+        format: 'not-a-format',
+      },
+    } as any);
+
+    expect(logSpy.mock.calls.length).toBe(0);
+    expect(errorSpy.mock.calls.length).toBe(1);
+    const error = JSON.parse(errorSpy.mock.calls[0][0]);
+    expect(error.error).toContain('Invalid format "not-a-format"');
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/export.test.ts
+++ b/packages/cli/src/commands/export.test.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+import exportCommand from './export.js';
+
+const FIXTURE_PATH = fileURLToPath(new URL('../linter/fixtures/DESIGN-test.md', import.meta.url));
+
+describe('export command', () => {
+  let logSpy: any;
+  let errorSpy: any;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    process.exitCode = 0;
+  });
+
+  it('outputs css-vars custom properties with an optional prefix', async () => {
+    await exportCommand.run!({
+      args: {
+        file: FIXTURE_PATH,
+        format: 'css-vars',
+        prefix: 'ds',
+      },
+    } as any);
+
+    expect(errorSpy.mock.calls.length).toBe(0);
+    expect(logSpy.mock.calls.length).toBe(1);
+    const output = logSpy.mock.calls[0][0];
+
+    expect(output).toStartWith(':root {\n');
+    expect(output).toContain('  --ds-color-primary: #006b5a;');
+    expect(output).toContain('  --ds-spacing-unit: 8px;');
+    expect(output).toContain('  --ds-rounded-sm: 0.25rem;');
+    expect(output).toEndWith('}\n');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('errors with exit code 1 for invalid export formats', async () => {
+    await exportCommand.run!({
+      args: {
+        file: FIXTURE_PATH,
+        format: 'not-a-format',
+      },
+    } as any);
+
+    expect(logSpy.mock.calls.length).toBe(0);
+    expect(errorSpy.mock.calls.length).toBe(1);
+    const error = JSON.parse(errorSpy.mock.calls[0][0]);
+    expect(error.message).toContain('Invalid format "not-a-format"');
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/export.test.ts
+++ b/packages/cli/src/commands/export.test.ts
@@ -66,7 +66,7 @@ describe('export command', () => {
     expect(logSpy.mock.calls.length).toBe(0);
     expect(errorSpy.mock.calls.length).toBe(1);
     const error = JSON.parse(errorSpy.mock.calls[0][0]);
-    expect(error.error).toContain('Invalid format "not-a-format"');
+    expect(error.message).toContain('Invalid format "not-a-format"');
     expect(process.exitCode).toBe(1);
   });
 });

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -13,17 +13,17 @@
 // limitations under the License.
 
 import { defineCommand } from 'citty';
-import { lint, TailwindEmitterHandler } from '../linter/index.js';
+import { lint, TailwindEmitterHandler, TailwindV4EmitterHandler, serializeTailwindV4 } from '../linter/index.js';
 import { DtcgEmitterHandler } from '../linter/dtcg/handler.js';
 import { readInput } from '../utils.js';
 
-const FORMATS = ['tailwind', 'dtcg'] as const;
+const FORMATS = ['tailwind', 'tailwind-v3', 'dtcg'] as const;
 type ExportFormat = typeof FORMATS[number];
 
 export default defineCommand({
   meta: {
     name: 'export',
-    description: 'Export DESIGN.md tokens to other formats (tailwind, dtcg).',
+    description: 'Export DESIGN.md tokens to other formats (tailwind, tailwind-v3, dtcg). `tailwind` targets the latest (v4) CSS @theme syntax; use `tailwind-v3` for legacy tailwind.config.js output.',
   },
   args: {
     file: {
@@ -53,6 +53,17 @@ export default defineCommand({
     const report = lint(content);
 
     if (format === 'tailwind') {
+      const handler = new TailwindV4EmitterHandler();
+      const result = handler.execute(report.designSystem);
+
+      if (!result.success) {
+        console.error(JSON.stringify({ error: result.error.message }));
+        process.exitCode = 1;
+        return;
+      }
+
+      console.log(serializeTailwindV4(result.data.theme));
+    } else if (format === 'tailwind-v3') {
       const handler = new TailwindEmitterHandler();
       const result = handler.execute(report.designSystem);
 

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -17,13 +17,13 @@ import { lint, TailwindEmitterHandler, TailwindV4EmitterHandler, serializeTailwi
 import { DtcgEmitterHandler } from '../linter/dtcg/handler.js';
 import { readInput } from '../utils.js';
 
-const FORMATS = ['tailwind', 'tailwind-v3', 'dtcg'] as const;
+const FORMATS = ['css-tailwind', 'json-tailwind', 'tailwind', 'dtcg'] as const;
 type ExportFormat = typeof FORMATS[number];
 
 export default defineCommand({
   meta: {
     name: 'export',
-    description: 'Export DESIGN.md tokens to other formats (tailwind, tailwind-v3, dtcg). `tailwind` targets the latest (v4) CSS @theme syntax; use `tailwind-v3` for legacy tailwind.config.js output.',
+    description: 'Export DESIGN.md tokens to other formats. `css-tailwind` emits Tailwind v4 CSS @theme; `json-tailwind` emits Tailwind v3 theme.extend JSON; `tailwind` is an alias for `json-tailwind`; `dtcg` emits W3C Design Tokens.',
   },
   args: {
     file: {
@@ -52,7 +52,7 @@ export default defineCommand({
     const content = await readInput(args.file);
     const report = lint(content);
 
-    if (format === 'tailwind') {
+    if (format === 'css-tailwind') {
       const handler = new TailwindV4EmitterHandler();
       const result = handler.execute(report.designSystem);
 
@@ -63,7 +63,7 @@ export default defineCommand({
       }
 
       console.log(serializeTailwindV4(result.data.theme));
-    } else if (format === 'tailwind-v3') {
+    } else if (format === 'json-tailwind' || format === 'tailwind') {
       const handler = new TailwindEmitterHandler();
       const result = handler.execute(report.designSystem);
 

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -98,6 +98,8 @@ export default defineCommand({
       console.log(JSON.stringify(result.data, null, 2));
     }
 
-    process.exitCode = report.summary.errors > 0 ? 1 : 0;
+    // A successful export exits 0 even if the source has lint findings; those
+    // are surfaced by `lint`, not by whether the export itself produced output.
+    // The error branches above set a non-zero code and return before this point.
   },
 });

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -43,7 +43,8 @@ export default defineCommand({
     // Validate --format against closed enum
     if (!FORMATS.includes(format as ExportFormat)) {
       console.error(JSON.stringify({
-        error: `Invalid format "${format}". Valid formats: ${FORMATS.join(', ')}`,
+        error: 'INVALID_FORMAT',
+        message: `Invalid format "${format}". Valid formats: ${FORMATS.join(', ')}`,
       }));
       process.exitCode = 1;
       return;
@@ -67,7 +68,7 @@ export default defineCommand({
       const result = handler.execute(report.designSystem);
 
       if (!result.success) {
-        console.error(JSON.stringify({ error: result.error.message }));
+        console.error(JSON.stringify({ error: result.error.code, message: result.error.message }));
         process.exitCode = 1;
         return;
       }
@@ -78,7 +79,7 @@ export default defineCommand({
       const result = handler.execute(report.designSystem);
 
       if (!result.success) {
-        console.error(JSON.stringify({ error: result.error.message }));
+        console.error(JSON.stringify({ error: result.error.code, message: result.error.message }));
         process.exitCode = 1;
         return;
       }
@@ -89,7 +90,7 @@ export default defineCommand({
       const result = handler.execute(report.designSystem);
 
       if (!result.success) {
-        console.error(JSON.stringify({ error: result.error.message }));
+        console.error(JSON.stringify({ error: result.error.code, message: result.error.message }));
         process.exitCode = 1;
         return;
       }

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -62,7 +62,7 @@ export default defineCommand({
         return;
       }
 
-      console.log(serializeTailwindV4(result.data.theme));
+      process.stdout.write(serializeTailwindV4(result.data.theme));
     } else if (format === 'json-tailwind' || format === 'tailwind') {
       const handler = new TailwindEmitterHandler();
       const result = handler.execute(report.designSystem);

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -15,7 +15,7 @@
 import { defineCommand } from 'citty';
 import { lint, TailwindEmitterHandler, TailwindV4EmitterHandler, serializeTailwindV4 } from '../linter/index.js';
 import { DtcgEmitterHandler } from '../linter/dtcg/handler.js';
-import { readInput } from '../utils.js';
+import { readInput, FileReadError } from '../utils.js';
 
 const FORMATS = ['css-tailwind', 'json-tailwind', 'tailwind', 'dtcg'] as const;
 type ExportFormat = typeof FORMATS[number];
@@ -49,7 +49,17 @@ export default defineCommand({
       return;
     }
 
-    const content = await readInput(args.file);
+    let content: string;
+    try {
+      content = await readInput(args.file);
+    } catch (error) {
+      if (error instanceof FileReadError) {
+        process.stderr.write(`Error: ${error.friendlyMessage}\n`);
+        process.exitCode = 2;
+        return;
+      }
+      throw error;
+    }
     const report = lint(content);
 
     if (format === 'css-tailwind') {

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -13,17 +13,17 @@
 // limitations under the License.
 
 import { defineCommand } from 'citty';
-import { lint, TailwindEmitterHandler, TailwindV4EmitterHandler, serializeTailwindV4 } from '../linter/index.js';
+import { lint, TailwindEmitterHandler, TailwindV4EmitterHandler, serializeTailwindV4, CssVarsEmitterHandler, serializeCssVars } from '../linter/index.js';
 import { DtcgEmitterHandler } from '../linter/dtcg/handler.js';
 import { readInput, FileReadError } from '../utils.js';
 
-const FORMATS = ['css-tailwind', 'json-tailwind', 'tailwind', 'dtcg'] as const;
+const FORMATS = ['css-tailwind', 'json-tailwind', 'tailwind', 'dtcg', 'css-vars'] as const;
 type ExportFormat = typeof FORMATS[number];
 
 export default defineCommand({
   meta: {
     name: 'export',
-    description: 'Export DESIGN.md tokens to other formats. `css-tailwind` emits Tailwind v4 CSS @theme; `json-tailwind` emits Tailwind v3 theme.extend JSON; `tailwind` is an alias for `json-tailwind`; `dtcg` emits W3C Design Tokens.',
+    description: 'Export DESIGN.md tokens to other formats. `css-tailwind` emits Tailwind v4 CSS @theme; `json-tailwind` emits Tailwind v3 theme.extend JSON; `tailwind` is an alias for `json-tailwind`; `dtcg` emits W3C Design Tokens; `css-vars` emits CSS custom properties.',
   },
   args: {
     file: {
@@ -36,9 +36,15 @@ export default defineCommand({
       description: `Output format: ${FORMATS.join(', ')}`,
       required: true,
     },
+    prefix: {
+      type: 'string',
+      description: 'Optional CSS custom property prefix for css-vars output.',
+      required: false,
+    },
   },
   async run({ args }) {
     const format = args.format as string;
+    const prefix = typeof args.prefix === 'string' ? args.prefix : undefined;
 
     // Validate --format against closed enum
     if (!FORMATS.includes(format as ExportFormat)) {
@@ -96,6 +102,17 @@ export default defineCommand({
       }
 
       console.log(JSON.stringify(result.data, null, 2));
+    } else if (format === 'css-vars') {
+      const handler = new CssVarsEmitterHandler();
+      const result = handler.execute(report.designSystem);
+
+      if (!result.success) {
+        console.error(JSON.stringify({ error: result.error.message }));
+        process.exitCode = 1;
+        return;
+      }
+
+      console.log(serializeCssVars(result.data.declarations, { prefix }));
     }
 
     // A successful export exits 0 even if the source has lint findings; those

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -118,5 +118,6 @@ export default defineCommand({
     // A successful export exits 0 even if the source has lint findings; those
     // are surfaced by `lint`, not by whether the export itself produced output.
     // The error branches above set a non-zero code and return before this point.
+    process.exitCode = 0;
   },
 });

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 import { defineCommand } from 'citty';
-import { lint, TailwindEmitterHandler } from '../linter/index.js';
+import { lint, TailwindEmitterHandler, CssVarsEmitterHandler, serializeCssVars } from '../linter/index.js';
 import { renderTailwindThemeCss } from '../linter/tailwind/css.js';
 import { DtcgEmitterHandler } from '../linter/dtcg/handler.js';
-import { readInput } from '../utils.js';
+import { readInput, FileReadError } from '../utils.js';
 
-const FORMATS = ['tailwind', 'dtcg'] as const;
+const FORMATS = ['css-tailwind', 'json-tailwind', 'tailwind', 'dtcg', 'css-vars'] as const;
 type ExportFormat = typeof FORMATS[number];
 
 export default defineCommand({
   meta: {
     name: 'export',
-    description: 'Export DESIGN.md tokens to other formats (tailwind, dtcg). The tailwind format emits a Tailwind v4 `@theme` CSS stylesheet.',
+    description: 'Export DESIGN.md tokens to other formats. `css-tailwind` emits a Tailwind v4 `@theme` CSS stylesheet (shadcn-style :root indirection); `tailwind` is an alias for `css-tailwind`; `json-tailwind` emits Tailwind v3 theme.extend JSON; `dtcg` emits W3C Design Tokens; `css-vars` emits CSS custom properties.',
   },
   args: {
     file: {
@@ -42,35 +42,74 @@ export default defineCommand({
       description: 'Include components in the export. Ignored by the tailwind CSS emitter; component styles should be authored alongside the @theme stylesheet.',
       default: false,
     },
+    prefix: {
+      type: 'string',
+      description: 'Optional CSS custom property prefix for css-vars output.',
+      required: false,
+    },
   },
   async run({ args }) {
     const format = args.format as string;
+    const prefix = typeof args.prefix === 'string' ? args.prefix : undefined;
 
     // Validate --format against closed enum
     if (!FORMATS.includes(format as ExportFormat)) {
       console.error(JSON.stringify({
-        error: `Invalid format "${format}". Valid formats: ${FORMATS.join(', ')}`,
+        error: 'INVALID_FORMAT',
+        message: `Invalid format "${format}". Valid formats: ${FORMATS.join(', ')}`,
       }));
       process.exitCode = 1;
       return;
     }
 
-    const content = await readInput(args.file);
+    let content: string;
+    try {
+      content = await readInput(args.file);
+    } catch (error) {
+      if (error instanceof FileReadError) {
+        process.stderr.write(`Error: ${error.friendlyMessage}\n`);
+        process.exitCode = 2;
+        return;
+      }
+      throw error;
+    }
     const report = lint(content);
 
-    if (format === 'tailwind') {
+    if (format === 'css-tailwind' || format === 'tailwind') {
       const handler = new TailwindEmitterHandler();
       const result = handler.execute(report.designSystem);
 
       if (!result.success) {
-        console.error(JSON.stringify({ error: result.error.message }));
+        console.error(JSON.stringify({ error: result.error.code, message: result.error.message }));
         process.exitCode = 1;
         return;
       }
 
       console.log(renderTailwindThemeCss(result));
+    } else if (format === 'json-tailwind') {
+      const handler = new TailwindEmitterHandler();
+      const result = handler.execute(report.designSystem);
+
+      if (!result.success) {
+        console.error(JSON.stringify({ error: result.error.code, message: result.error.message }));
+        process.exitCode = 1;
+        return;
+      }
+
+      console.log(JSON.stringify(result.data, null, 2));
     } else if (format === 'dtcg') {
       const handler = new DtcgEmitterHandler();
+      const result = handler.execute(report.designSystem);
+
+      if (!result.success) {
+        console.error(JSON.stringify({ error: result.error.code, message: result.error.message }));
+        process.exitCode = 1;
+        return;
+      }
+
+      console.log(JSON.stringify(result.data, null, 2));
+    } else if (format === 'css-vars') {
+      const handler = new CssVarsEmitterHandler();
       const result = handler.execute(report.designSystem);
 
       if (!result.success) {
@@ -79,9 +118,12 @@ export default defineCommand({
         return;
       }
 
-      console.log(JSON.stringify(result.data, null, 2));
+      console.log(serializeCssVars(result.data.declarations, { prefix }));
     }
 
-    process.exitCode = report.summary.errors > 0 ? 1 : 0;
+    // A successful export exits 0 even if the source has lint findings; those
+    // are surfaced by `lint`, not by whether the export itself produced output.
+    // The error branches above set a non-zero code and return before this point.
+    process.exitCode = 0;
   },
 });

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -14,7 +14,7 @@
 
 import { defineCommand } from 'citty';
 import { lint } from '../linter/index.js';
-import { readInput, formatOutput } from '../utils.js';
+import { readInput, formatOutput, FileReadError } from '../utils.js';
 
 export default defineCommand({
   meta: {
@@ -34,7 +34,17 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const content = await readInput(args.file);
+    let content: string;
+    try {
+      content = await readInput(args.file);
+    } catch (error) {
+      if (error instanceof FileReadError) {
+        process.stderr.write(`Error: ${error.friendlyMessage}\n`);
+        process.exitCode = 2;
+        return;
+      }
+      throw error;
+    }
     const report = lint(content);
 
     const output = {

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -15,7 +15,7 @@
 import { writeFileSync } from 'node:fs';
 import { defineCommand } from 'citty';
 import { lint, fixSectionOrder } from '../linter/index.js';
-import { readInput, formatOutput } from '../utils.js';
+import { readInput, formatOutput, FileReadError } from '../utils.js';
 
 export default defineCommand({
   meta: {
@@ -39,7 +39,17 @@ export default defineCommand({
     },
   },
   async run({ args }) {
-    const content = await readInput(args.file);
+    let content: string;
+    try {
+      content = await readInput(args.file);
+    } catch (error) {
+      if (error instanceof FileReadError) {
+        process.stderr.write(`Error: ${error.friendlyMessage}\n`);
+        process.exitCode = 2;
+        return;
+      }
+      throw error;
+    }
     let workingContent = content;
     let fixedDetails: { beforeOrder: string[]; afterOrder: string[] } | undefined;
 

--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -89,6 +89,6 @@ describe('spec command', () => {
     const output = JSON.parse(outputStr);
     expect(output.spec).toBeDefined();
     expect(output.rules).toBeDefined();
-    expect(output.rules.length).toBe(9);
+    expect(output.rules.length).toBe(10);
   });
 });

--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -89,6 +89,6 @@ describe('spec command', () => {
     const output = JSON.parse(outputStr);
     expect(output.spec).toBeDefined();
     expect(output.rules).toBeDefined();
-    expect(output.rules.length).toBe(8);
+    expect(output.rules.length).toBe(9);
   });
 });

--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -89,6 +89,6 @@ describe('spec command', () => {
     const output = JSON.parse(outputStr);
     expect(output.spec).toBeDefined();
     expect(output.rules).toBeDefined();
-    expect(output.rules.length).toBe(43);
+    expect(output.rules.length).toBe(45);
   });
 });

--- a/packages/cli/src/linter/component-validators.test.ts
+++ b/packages/cli/src/linter/component-validators.test.ts
@@ -43,8 +43,10 @@ describe('validateColor', () => {
   it('accepts token references', () => {
     expect(validateColor('{colors.primary}').ok).toBe(true);
   });
+  it('accepts CSS named colors', () => {
+    expect(validateColor('red').ok).toBe(true);
+  });
   it('rejects garbage', () => {
-    expect(validateColor('red').ok).toBe(false);
     expect(validateColor('not-a-color').ok).toBe(false);
     expect(validateColor('oklch()').ok).toBe(false);
   });
@@ -121,8 +123,11 @@ describe('validateBorder', () => {
   it('rejects bad width', () => {
     expect(validateBorder('thick solid #000').ok).toBe(false);
   });
+  it('accepts named border colors', () => {
+    expect(validateBorder('1px solid red').ok).toBe(true);
+  });
   it('rejects bad color', () => {
-    expect(validateBorder('1px solid red').ok).toBe(false);
+    expect(validateBorder('1px solid nocolor').ok).toBe(false);
   });
 });
 

--- a/packages/cli/src/linter/css-vars/handler.test.ts
+++ b/packages/cli/src/linter/css-vars/handler.test.ts
@@ -1,0 +1,135 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, test, expect } from 'bun:test';
+import { CssVarsEmitterHandler } from './handler.js';
+import { serializeCssVars } from './serialize.js';
+import type { DesignSystemState, ResolvedColor, ResolvedDimension } from '../model/spec.js';
+
+function emptyState(overrides?: Partial<DesignSystemState>): DesignSystemState {
+  return {
+    colors: new Map(),
+    typography: new Map(),
+    rounded: new Map(),
+    spacing: new Map(),
+    components: new Map(),
+    symbolTable: new Map(),
+    ...overrides,
+  };
+}
+
+function makeColor(hex: string, r: number, g: number, b: number): ResolvedColor {
+  return { type: 'color', hex, r, g, b, luminance: 0 };
+}
+
+function makeDim(value: number, unit: string): ResolvedDimension {
+  return { type: 'dimension', value, unit };
+}
+
+describe('CssVarsEmitterHandler', () => {
+  const handler = new CssVarsEmitterHandler();
+
+  test('empty state produces valid empty :root block', () => {
+    const result = handler.execute(emptyState());
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data.declarations).toEqual([]);
+    expect(serializeCssVars(result.data.declarations)).toBe(':root {\n}\n');
+  });
+
+  test('colors emit --color-* declarations with lowercase hex values', () => {
+    const state = emptyState({
+      colors: new Map([
+        ['primary', makeColor('#1A1C1E', 0x1A, 0x1C, 0x1E)],
+        ['white', makeColor('#FFFFFF', 255, 255, 255)],
+      ]),
+    });
+
+    const result = handler.execute(state);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(serializeCssVars(result.data.declarations)).toBe(
+      ':root {\n'
+      + '  --color-primary: #1a1c1e;\n'
+      + '  --color-white: #ffffff;\n'
+      + '}\n',
+    );
+  });
+
+  test('spacing and rounded dimensions preserve numeric values and units', () => {
+    const state = emptyState({
+      spacing: new Map([
+        ['sm', makeDim(8, 'px')],
+        ['md', makeDim(1, 'rem')],
+      ]),
+      rounded: new Map([
+        ['card', makeDim(12, 'px')],
+      ]),
+    });
+
+    const result = handler.execute(state);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(serializeCssVars(result.data.declarations)).toBe(
+      ':root {\n'
+      + '  --spacing-sm: 8px;\n'
+      + '  --spacing-md: 1rem;\n'
+      + '  --rounded-card: 12px;\n'
+      + '}\n',
+    );
+  });
+
+  test('nested token names collapse dots to hyphens for valid CSS property names', () => {
+    const state = emptyState({
+      colors: new Map([
+        ['background.light', makeColor('#FFFFFF', 255, 255, 255)],
+      ]),
+      spacing: new Map([
+        ['gap.lg', makeDim(24, 'px')],
+      ]),
+    });
+
+    const result = handler.execute(state);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(serializeCssVars(result.data.declarations)).toBe(
+      ':root {\n'
+      + '  --color-background-light: #ffffff;\n'
+      + '  --spacing-gap-lg: 24px;\n'
+      + '}\n',
+    );
+  });
+
+  test('prefix option adds a custom prefix to emitted property names', () => {
+    const state = emptyState({
+      colors: new Map([
+        ['primary', makeColor('#1A1C1E', 0x1A, 0x1C, 0x1E)],
+      ]),
+    });
+
+    const result = handler.execute(state);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(serializeCssVars(result.data.declarations, { prefix: 'ds' })).toBe(
+      ':root {\n'
+      + '  --ds-color-primary: #1a1c1e;\n'
+      + '}\n',
+    );
+  });
+});

--- a/packages/cli/src/linter/css-vars/handler.test.ts
+++ b/packages/cli/src/linter/css-vars/handler.test.ts
@@ -1,0 +1,142 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, test, expect } from 'bun:test';
+import { CssVarsEmitterHandler } from './handler.js';
+import { serializeCssVars } from './serialize.js';
+import type { DesignSystemState, ResolvedColor, ResolvedDimension } from '../model/spec.js';
+
+function emptyState(overrides?: Partial<DesignSystemState>): DesignSystemState {
+  return {
+    colors: new Map(),
+    typography: new Map(),
+    rounded: new Map(),
+    spacing: new Map(),
+    elevation: new Map(),
+    motion: { duration: new Map(), easing: new Map() },
+    components: new Map(),
+    colorRamps: new Map(),
+    colorPairs: new Map(),
+    themes: new Map(),
+    activeTheme: 'light',
+    symbolTable: new Map(),
+    colorIndex: new Map(),
+    ...overrides,
+  };
+}
+
+function makeColor(hex: string, r: number, g: number, b: number): ResolvedColor {
+  return { type: 'color', hex, r, g, b, luminance: 0, format: 'hex', raw: hex };
+}
+
+function makeDim(value: number, unit: string): ResolvedDimension {
+  return { type: 'dimension', value, unit };
+}
+
+describe('CssVarsEmitterHandler', () => {
+  const handler = new CssVarsEmitterHandler();
+
+  test('empty state produces valid empty :root block', () => {
+    const result = handler.execute(emptyState());
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data.declarations).toEqual([]);
+    expect(serializeCssVars(result.data.declarations)).toBe(':root {\n}\n');
+  });
+
+  test('colors emit --color-* declarations with lowercase hex values', () => {
+    const state = emptyState({
+      colors: new Map([
+        ['primary', makeColor('#1A1C1E', 0x1A, 0x1C, 0x1E)],
+        ['white', makeColor('#FFFFFF', 255, 255, 255)],
+      ]),
+    });
+
+    const result = handler.execute(state);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(serializeCssVars(result.data.declarations)).toBe(
+      ':root {\n'
+      + '  --color-primary: #1a1c1e;\n'
+      + '  --color-white: #ffffff;\n'
+      + '}\n',
+    );
+  });
+
+  test('spacing and rounded dimensions preserve numeric values and units', () => {
+    const state = emptyState({
+      spacing: new Map([
+        ['sm', makeDim(8, 'px')],
+        ['md', makeDim(1, 'rem')],
+      ]),
+      rounded: new Map([
+        ['card', makeDim(12, 'px')],
+      ]),
+    });
+
+    const result = handler.execute(state);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(serializeCssVars(result.data.declarations)).toBe(
+      ':root {\n'
+      + '  --spacing-sm: 8px;\n'
+      + '  --spacing-md: 1rem;\n'
+      + '  --rounded-card: 12px;\n'
+      + '}\n',
+    );
+  });
+
+  test('nested token names collapse dots to hyphens for valid CSS property names', () => {
+    const state = emptyState({
+      colors: new Map([
+        ['background.light', makeColor('#FFFFFF', 255, 255, 255)],
+      ]),
+      spacing: new Map([
+        ['gap.lg', makeDim(24, 'px')],
+      ]),
+    });
+
+    const result = handler.execute(state);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(serializeCssVars(result.data.declarations)).toBe(
+      ':root {\n'
+      + '  --color-background-light: #ffffff;\n'
+      + '  --spacing-gap-lg: 24px;\n'
+      + '}\n',
+    );
+  });
+
+  test('prefix option adds a custom prefix to emitted property names', () => {
+    const state = emptyState({
+      colors: new Map([
+        ['primary', makeColor('#1A1C1E', 0x1A, 0x1C, 0x1E)],
+      ]),
+    });
+
+    const result = handler.execute(state);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(serializeCssVars(result.data.declarations, { prefix: 'ds' })).toBe(
+      ':root {\n'
+      + '  --ds-color-primary: #1a1c1e;\n'
+      + '}\n',
+    );
+  });
+});

--- a/packages/cli/src/linter/css-vars/handler.ts
+++ b/packages/cli/src/linter/css-vars/handler.ts
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { CssVarDeclaration, CssVarsEmitterSpec, CssVarsEmitterResult } from './spec.js';
+import type { DesignSystemState, ResolvedDimension } from '../model/spec.js';
+
+/**
+ * Pure function mapping DesignSystemState → CSS custom property declarations.
+ * No side effects.
+ */
+export class CssVarsEmitterHandler implements CssVarsEmitterSpec {
+  execute(state: DesignSystemState): CssVarsEmitterResult {
+    const declarations: CssVarDeclaration[] = [];
+
+    for (const [name, color] of state.colors) {
+      declarations.push({
+        name: `color-${this.cssSafe(name)}`,
+        value: color.hex.toLowerCase(),
+      });
+    }
+
+    this.mapDimensionGroup(declarations, 'spacing', state.spacing);
+    this.mapDimensionGroup(declarations, 'rounded', state.rounded);
+
+    return { success: true, data: { declarations } };
+  }
+
+  private mapDimensionGroup(
+    declarations: CssVarDeclaration[],
+    group: 'spacing' | 'rounded',
+    dims: Map<string, ResolvedDimension>,
+  ): void {
+    for (const [name, dim] of dims) {
+      declarations.push({
+        name: `${group}-${this.cssSafe(name)}`,
+        value: this.dimToString(dim),
+      });
+    }
+  }
+
+  private dimToString(dim: ResolvedDimension): string {
+    return `${dim.value}${dim.unit}`;
+  }
+
+  /**
+   * Make a token name safe for a CSS custom property. Nested tokens flatten to
+   * dotted keys (e.g. `background.light`); a literal dot makes a browser drop
+   * the declaration, so collapse dots to hyphens.
+   */
+  private cssSafe(name: string): string {
+    return name.replace(/\./g, '-');
+  }
+}

--- a/packages/cli/src/linter/css-vars/serialize.ts
+++ b/packages/cli/src/linter/css-vars/serialize.ts
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { CssVarDeclaration } from './spec.js';
+
+export interface SerializeCssVarsOptions {
+  prefix?: string | undefined;
+}
+
+/**
+ * Serialize declarations to a CSS `:root { ... }` block string.
+ * Pure function — no I/O. Values are emitted verbatim.
+ */
+export function serializeCssVars(
+  declarations: CssVarDeclaration[],
+  options: SerializeCssVarsOptions = {},
+): string {
+  const variablePrefix = options.prefix ? `${options.prefix}-` : '';
+  const lines = declarations.map(
+    declaration => `  --${variablePrefix}${declaration.name}: ${declaration.value};`,
+  );
+
+  if (lines.length === 0) return ':root {\n}\n';
+  return `:root {\n${lines.join('\n')}\n}\n`;
+}

--- a/packages/cli/src/linter/css-vars/spec.ts
+++ b/packages/cli/src/linter/css-vars/spec.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { z } from 'zod';
+import type { DesignSystemState } from '../model/spec.js';
+
+export const CssVarDeclarationSchema = z.object({
+  name: z.string(),
+  value: z.string(),
+});
+
+export type CssVarDeclaration = z.infer<typeof CssVarDeclarationSchema>;
+
+// ── Result ─────────────────────────────────────────────────────────
+
+export const CssVarsEmitterResultSchema = z.discriminatedUnion('success', [
+  z.object({
+    success: z.literal(true),
+    data: z.object({
+      declarations: z.array(CssVarDeclarationSchema),
+    }),
+  }),
+  z.object({
+    success: z.literal(false),
+    error: z.object({
+      code: z.string(),
+      message: z.string(),
+    }),
+  }),
+]);
+
+export type CssVarsEmitterResult = z.infer<typeof CssVarsEmitterResultSchema>;
+
+// ── Interface ──────────────────────────────────────────────────────
+
+export interface CssVarsEmitterSpec {
+  execute(state: DesignSystemState): CssVarsEmitterResult;
+}

--- a/packages/cli/src/linter/dtcg/conformance.test.ts
+++ b/packages/cli/src/linter/dtcg/conformance.test.ts
@@ -81,9 +81,10 @@ export default defineConfig({
 
       // Install dependencies in temp dir so they can be imported in config
       // Using bun add should be fast if cached
+      const customPath = `${process.env.PATH || ''}:/Users/dalmaer/.bun/bin`;
       const installProc = spawnSync('bun', ['add', '@terrazzo/cli', '@terrazzo/plugin-css'], {
         cwd: tmpDir,
-        env: { ...process.env, PATH: process.env.PATH },
+        env: { ...process.env, PATH: customPath },
         shell: true
       });
 
@@ -94,7 +95,7 @@ export default defineConfig({
       // 5. Run Terrazzo build
       const proc = spawnSync('npx', ['@terrazzo/cli', 'build'], {
         cwd: tmpDir,
-        env: { ...process.env, PATH: process.env.PATH },
+        env: { ...process.env, PATH: customPath },
         shell: true
       });
 

--- a/packages/cli/src/linter/dtcg/conformance.test.ts
+++ b/packages/cli/src/linter/dtcg/conformance.test.ts
@@ -21,7 +21,10 @@ import { lint } from '../lint.js';
 import { DtcgEmitterHandler } from './handler.js';
 
 describe('DTCG Conformance', () => {
-  test('Terrazzo can parse our DTCG output and generate CSS', () => {
+  // Skipped: @terrazzo/token-types@^2.4.0 was removed from npm (404).
+  // This test depends on installing Terrazzo from the public registry.
+  // Re-enable once Terrazzo publishes a fix. See: https://github.com/google-labs-code/design.md/issues/106
+  test.skip('Terrazzo can parse our DTCG output and generate CSS', () => {
     const fixtureContent = `---
 name: Test Brand
 colors:
@@ -81,9 +84,10 @@ export default defineConfig({
 
       // Install dependencies in temp dir so they can be imported in config
       // Using bun add should be fast if cached
+      const customPath = process.env.PATH || '';
       const installProc = spawnSync('bun', ['add', '@terrazzo/cli', '@terrazzo/plugin-css'], {
         cwd: tmpDir,
-        env: { ...process.env, PATH: process.env.PATH },
+        env: { ...process.env, PATH: customPath },
         shell: true
       });
 
@@ -94,7 +98,7 @@ export default defineConfig({
       // 5. Run Terrazzo build
       const proc = spawnSync('npx', ['@terrazzo/cli', 'build'], {
         cwd: tmpDir,
-        env: { ...process.env, PATH: process.env.PATH },
+        env: { ...process.env, PATH: customPath },
         shell: true
       });
 

--- a/packages/cli/src/linter/dtcg/conformance.test.ts
+++ b/packages/cli/src/linter/dtcg/conformance.test.ts
@@ -21,7 +21,10 @@ import { lint } from '../lint.js';
 import { DtcgEmitterHandler } from './handler.js';
 
 describe('DTCG Conformance', () => {
-  test('Terrazzo can parse our DTCG output and generate CSS', () => {
+  // Skipped: @terrazzo/token-types@^2.4.0 was removed from npm (404).
+  // This test depends on installing Terrazzo from the public registry.
+  // Re-enable once Terrazzo publishes a fix. See: https://github.com/google-labs-code/design.md/issues/106
+  test.skip('Terrazzo can parse our DTCG output and generate CSS', () => {
     const fixtureContent = `---
 name: Test Brand
 colors:
@@ -81,7 +84,7 @@ export default defineConfig({
 
       // Install dependencies in temp dir so they can be imported in config
       // Using bun add should be fast if cached
-      const customPath = `${process.env.PATH || ''}:/Users/dalmaer/.bun/bin`;
+      const customPath = process.env.PATH || '';
       const installProc = spawnSync('bun', ['add', '@terrazzo/cli', '@terrazzo/plugin-css'], {
         cwd: tmpDir,
         env: { ...process.env, PATH: customPath },

--- a/packages/cli/src/linter/index.test.ts
+++ b/packages/cli/src/linter/index.test.ts
@@ -116,7 +116,7 @@ components:
     const content = `---
 colors:
   primary: "#647D66"
-  bad-color: red
+  bad-color: not-a-color
 
 components:
   card:
@@ -128,5 +128,39 @@ components:
 
     // Should have errors: invalid color + broken reference
     expect(result.summary.errors).toBeGreaterThanOrEqual(2);
+  });
+
+  it('warns on a misspelled top-level key via the default rule set', () => {
+    const content = `---
+name: Example
+colours:
+  primary: "#647D66"
+---`;
+
+    const result = lint(content);
+
+    const finding = result.findings.find(
+      f => f.message === 'Unknown key "colours" — did you mean "colors"?'
+    );
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('warning');
+    expect(finding!.path).toBe('colours');
+  });
+
+  it('stays silent for custom extension keys that are not close to any known key', () => {
+    const content = `---
+name: Example
+icons:
+  search: "search-icon.svg"
+motion:
+  fast: "100ms"
+---`;
+
+    const result = lint(content);
+
+    const unknownKeyFindings = result.findings.filter(f =>
+      f.message.startsWith('Unknown key ')
+    );
+    expect(unknownKeyFindings).toEqual([]);
   });
 });

--- a/packages/cli/src/linter/index.test.ts
+++ b/packages/cli/src/linter/index.test.ts
@@ -129,4 +129,38 @@ components:
     // Should have errors: invalid color + broken reference
     expect(result.summary.errors).toBeGreaterThanOrEqual(2);
   });
+
+  it('warns on a misspelled top-level key via the default rule set', () => {
+    const content = `---
+name: Example
+colours:
+  primary: "#647D66"
+---`;
+
+    const result = lint(content);
+
+    const finding = result.findings.find(
+      f => f.message === 'Unknown key "colours" — did you mean "colors"?'
+    );
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('warning');
+    expect(finding!.path).toBe('colours');
+  });
+
+  it('stays silent for custom extension keys that are not close to any known key', () => {
+    const content = `---
+name: Example
+icons:
+  search: "search-icon.svg"
+motion:
+  fast: "100ms"
+---`;
+
+    const result = lint(content);
+
+    const unknownKeyFindings = result.findings.filter(f =>
+      f.message.startsWith('Unknown key ')
+    );
+    expect(unknownKeyFindings).toEqual([]);
+  });
 });

--- a/packages/cli/src/linter/index.test.ts
+++ b/packages/cli/src/linter/index.test.ts
@@ -116,7 +116,7 @@ components:
     const content = `---
 colors:
   primary: "#647D66"
-  bad-color: red
+  bad-color: not-a-color
 
 components:
   card:

--- a/packages/cli/src/linter/index.ts
+++ b/packages/cli/src/linter/index.ts
@@ -28,6 +28,7 @@ export type {
 } from './model/spec.js';
 export type { Finding, Severity } from './linter/spec.js';
 export type { TailwindEmitterResult, TailwindThemeExtend } from './tailwind/spec.js';
+export type { TailwindV4EmitterResult, TailwindV4ThemeData } from './tailwind/v4/spec.js';
 export type { DtcgEmitterResult, DtcgTokenFile } from './dtcg/spec.js';
 
 // ── Advanced linting ───────────────────────────────────────────────
@@ -46,6 +47,8 @@ export {
 } from './linter/rules/index.js';
 export { contrastRatio } from './model/handler.js';
 export { TailwindEmitterHandler } from './tailwind/handler.js';
+export { TailwindV4EmitterHandler } from './tailwind/v4/handler.js';
+export { serializeToCss as serializeTailwindV4 } from './tailwind/v4/serialize.js';
 export { DtcgEmitterHandler } from './dtcg/handler.js';
 export { fixSectionOrder } from './fixer/handler.js';
 export type { FixerInput, FixerResult } from './fixer/spec.js';

--- a/packages/cli/src/linter/index.ts
+++ b/packages/cli/src/linter/index.ts
@@ -30,7 +30,9 @@ export type {
 export type { DocumentSection, LineRange, SuppressionDirective } from './parser/spec.js';
 export type { Finding, Severity } from './linter/spec.js';
 export type { TailwindEmitterResult, TailwindThemeExtend } from './tailwind/spec.js';
+export type { TailwindV4EmitterResult, TailwindV4ThemeData } from './tailwind/v4/spec.js';
 export type { DtcgEmitterResult, DtcgTokenFile } from './dtcg/spec.js';
+export type { CssVarsEmitterResult, CssVarDeclaration } from './css-vars/spec.js';
 
 // ── Advanced linting ───────────────────────────────────────────────
 export { runLinter, preEvaluate } from './linter/runner.js';
@@ -70,11 +72,17 @@ export {
   casingMismatchRule,
   reservedNameForm,
   reservedNameFormRule,
+  unknownKey,
+  tokenLikeIgnored,
 } from './linter/rules/index.js';
 export type { RuleDescriptor, RuleFinding } from './linter/rules/types.js';
 export { contrastRatio } from './model/handler.js';
 export { TailwindEmitterHandler } from './tailwind/handler.js';
 export { renderTailwindThemeCss } from './tailwind/css.js';
+export { TailwindV4EmitterHandler } from './tailwind/v4/handler.js';
+export { serializeToCss as serializeTailwindV4 } from './tailwind/v4/serialize.js';
 export { DtcgEmitterHandler } from './dtcg/handler.js';
+export { CssVarsEmitterHandler } from './css-vars/handler.js';
+export { serializeCssVars } from './css-vars/serialize.js';
 export { fixSectionOrder } from './fixer/handler.js';
 export type { FixerInput, FixerResult } from './fixer/spec.js';

--- a/packages/cli/src/linter/index.ts
+++ b/packages/cli/src/linter/index.ts
@@ -30,6 +30,7 @@ export type { Finding, Severity } from './linter/spec.js';
 export type { TailwindEmitterResult, TailwindThemeExtend } from './tailwind/spec.js';
 export type { TailwindV4EmitterResult, TailwindV4ThemeData } from './tailwind/v4/spec.js';
 export type { DtcgEmitterResult, DtcgTokenFile } from './dtcg/spec.js';
+export type { CssVarsEmitterResult, CssVarDeclaration } from './css-vars/spec.js';
 
 // ── Advanced linting ───────────────────────────────────────────────
 export { runLinter, preEvaluate } from './linter/runner.js';
@@ -52,5 +53,7 @@ export { TailwindEmitterHandler } from './tailwind/handler.js';
 export { TailwindV4EmitterHandler } from './tailwind/v4/handler.js';
 export { serializeToCss as serializeTailwindV4 } from './tailwind/v4/serialize.js';
 export { DtcgEmitterHandler } from './dtcg/handler.js';
+export { CssVarsEmitterHandler } from './css-vars/handler.js';
+export { serializeCssVars } from './css-vars/serialize.js';
 export { fixSectionOrder } from './fixer/handler.js';
 export type { FixerInput, FixerResult } from './fixer/spec.js';

--- a/packages/cli/src/linter/index.ts
+++ b/packages/cli/src/linter/index.ts
@@ -45,6 +45,7 @@ export {
   missingSections,
   missingTypography,
   unknownKey,
+  tokenLikeIgnored,
 } from './linter/rules/index.js';
 export { contrastRatio } from './model/handler.js';
 export { TailwindEmitterHandler } from './tailwind/handler.js';

--- a/packages/cli/src/linter/index.ts
+++ b/packages/cli/src/linter/index.ts
@@ -44,6 +44,7 @@ export {
   tokenSummary,
   missingSections,
   missingTypography,
+  unknownKey,
 } from './linter/rules/index.js';
 export { contrastRatio } from './model/handler.js';
 export { TailwindEmitterHandler } from './tailwind/handler.js';

--- a/packages/cli/src/linter/linter/rules/index.ts
+++ b/packages/cli/src/linter/linter/rules/index.ts
@@ -24,6 +24,7 @@ import { missingSectionsRule } from './missing-sections.js';
 import { sectionOrderRule } from './section-order.js';
 import { missingTypographyRule } from './missing-typography.js';
 import { unknownKeyRule } from './unknown-key.js';
+import { tokenLikeIgnoredRule } from './token-like-ignored.js';
 
 /** The default set of lint rule descriptors, in order. */
 export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
@@ -36,6 +37,7 @@ export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
   missingTypographyRule,
   sectionOrderRule,
   unknownKeyRule,
+  tokenLikeIgnoredRule,
 ];
 
 /** Converts a RuleDescriptor into a LintRule by injecting severity into findings. */
@@ -61,4 +63,5 @@ export { missingSections } from './missing-sections.js';
 export { missingTypography } from './missing-typography.js';
 export { unknownKey } from './unknown-key.js';
 export { sectionOrder } from './section-order.js';
+export { tokenLikeIgnored } from './token-like-ignored.js';
 export type { LintRule } from './types.js';

--- a/packages/cli/src/linter/linter/rules/index.ts
+++ b/packages/cli/src/linter/linter/rules/index.ts
@@ -23,6 +23,7 @@ import { tokenSummaryRule } from './token-summary.js';
 import { missingSectionsRule } from './missing-sections.js';
 import { sectionOrderRule } from './section-order.js';
 import { missingTypographyRule } from './missing-typography.js';
+import { unknownKeyRule } from './unknown-key.js';
 
 /** The default set of lint rule descriptors, in order. */
 export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
@@ -34,6 +35,7 @@ export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
   missingSectionsRule,
   missingTypographyRule,
   sectionOrderRule,
+  unknownKeyRule,
 ];
 
 /** Converts a RuleDescriptor into a LintRule by injecting severity into findings. */
@@ -57,5 +59,6 @@ export { orphanedTokens } from './orphaned-tokens.js';
 export { tokenSummary } from './token-summary.js';
 export { missingSections } from './missing-sections.js';
 export { missingTypography } from './missing-typography.js';
+export { unknownKey } from './unknown-key.js';
 export { sectionOrder } from './section-order.js';
 export type { LintRule } from './types.js';

--- a/packages/cli/src/linter/linter/rules/index.ts
+++ b/packages/cli/src/linter/linter/rules/index.ts
@@ -58,6 +58,8 @@ import { unknownTemplateRule } from './unknown-template.js';
 import { missingRegionRule } from './missing-region.js';
 import { offGridDimensionRule } from './off-grid-dimension.js';
 import { templateRegionPurityRule } from './template-region-purity.js';
+import { unknownKeyRule } from './unknown-key.js';
+import { tokenLikeIgnoredRule } from './token-like-ignored.js';
 
 /** The default set of lint rule descriptors, in order. */
 export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
@@ -104,6 +106,8 @@ export const DEFAULT_RULE_DESCRIPTORS: RuleDescriptor[] = [
   missingRegionRule,
   offGridDimensionRule,
   templateRegionPurityRule,
+  unknownKeyRule,
+  tokenLikeIgnoredRule,
 ];
 
 /** Converts a RuleDescriptor into a LintRule by injecting severity into findings. */
@@ -127,6 +131,7 @@ export { orphanedTokens } from './orphaned-tokens.js';
 export { tokenSummary } from './token-summary.js';
 export { missingSections } from './missing-sections.js';
 export { missingTypography } from './missing-typography.js';
+export { unknownKey } from './unknown-key.js';
 export { sectionOrder } from './section-order.js';
 export { unchangedState } from './unchanged-state.js';
 export { missingFocusVisible } from './missing-focus-visible.js';
@@ -163,4 +168,5 @@ export { unknownTemplate } from './unknown-template.js';
 export { missingRegion } from './missing-region.js';
 export { offGridDimension } from './off-grid-dimension.js';
 export { templateRegionPurity } from './template-region-purity.js';
+export { tokenLikeIgnored } from './token-like-ignored.js';
 export type { LintRule } from './types.js';

--- a/packages/cli/src/linter/linter/rules/levenshtein.test.ts
+++ b/packages/cli/src/linter/linter/rules/levenshtein.test.ts
@@ -1,0 +1,60 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { levenshtein } from './levenshtein.js';
+
+describe('levenshtein', () => {
+  it('returns 0 for identical strings', () => {
+    expect(levenshtein('colors', 'colors')).toBe(0);
+  });
+
+  it('returns 0 when both strings are empty', () => {
+    expect(levenshtein('', '')).toBe(0);
+  });
+
+  it('returns the length of the other string when one is empty', () => {
+    expect(levenshtein('', 'colors')).toBe(6);
+    expect(levenshtein('colors', '')).toBe(6);
+  });
+
+  it('counts a single substitution as distance 1', () => {
+    expect(levenshtein('cat', 'bat')).toBe(1);
+  });
+
+  it('counts a single insertion as distance 1', () => {
+    expect(levenshtein('cat', 'cats')).toBe(1);
+  });
+
+  it('counts a single deletion as distance 1', () => {
+    expect(levenshtein('cats', 'cat')).toBe(1);
+  });
+
+  it('is symmetric: levenshtein(a, b) === levenshtein(b, a)', () => {
+    expect(levenshtein('typografy', 'typography')).toBe(levenshtein('typography', 'typografy'));
+    expect(levenshtein('kitten', 'sitting')).toBe(levenshtein('sitting', 'kitten'));
+  });
+
+  it('matches the classic kitten/sitting example (distance 3)', () => {
+    expect(levenshtein('kitten', 'sitting')).toBe(3);
+  });
+
+  it('computes distance for the schema-key typo cases used by unknown-key', () => {
+    expect(levenshtein('colours', 'colors')).toBe(1);
+    expect(levenshtein('typografy', 'typography')).toBe(2);
+    expect(levenshtein('nam', 'name')).toBe(1);
+    expect(levenshtein('rounding', 'rounded')).toBe(3);
+    expect(levenshtein('icons', 'colors')).toBe(4);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/levenshtein.ts
+++ b/packages/cli/src/linter/linter/rules/levenshtein.ts
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** Levenshtein edit distance between two strings. */
+export function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, (_, i) =>
+    Array.from({ length: n + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0))
+  );
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i]![j] = a[i - 1] === b[j - 1]
+        ? dp[i - 1]![j - 1]!
+        : 1 + Math.min(dp[i - 1]![j]!, dp[i]![j - 1]!, dp[i - 1]![j - 1]!);
+    }
+  }
+  return dp[m]![n]!;
+}

--- a/packages/cli/src/linter/linter/rules/orphaned-tokens.test.ts
+++ b/packages/cli/src/linter/linter/rules/orphaned-tokens.test.ts
@@ -33,4 +33,103 @@ describe('orphanedTokens', () => {
     const state = buildState({ colors: { primary: '#ff0000' } });
     expect(orphanedTokens(state)).toEqual([]);
   });
+
+  it('does not flag MD3 paired tokens when the family is referenced (issue #46)', () => {
+    // When a component references `primary`, the rest of the MD3 primary
+    // family (`on-primary`, `primary-container`, `on-primary-container`,
+    // `primary-fixed`, `primary-fixed-dim`, `on-primary-fixed`,
+    // `on-primary-fixed-variant`, `inverse-primary`) is part of the same
+    // semantic group and should not be flagged as orphaned.
+    const state = buildState({
+      colors: {
+        primary: '#1A1C1E',
+        'on-primary': '#ffffff',
+        'primary-container': '#e2e2e2',
+        'on-primary-container': '#636565',
+        'primary-fixed': '#e2e2e2',
+        'primary-fixed-dim': '#c6c6c7',
+        'on-primary-fixed': '#1a1c1c',
+        'on-primary-fixed-variant': '#454747',
+        'inverse-primary': '#5d5f5f',
+      },
+      components: {
+        button: { backgroundColor: '{colors.primary}' },
+      },
+    });
+    const findings = orphanedTokens(state);
+    expect(findings).toEqual([]);
+  });
+
+  it('does not flag MD3 surface family when one surface token is referenced', () => {
+    const state = buildState({
+      colors: {
+        surface: '#0b1326',
+        'surface-dim': '#0b1326',
+        'surface-bright': '#31394d',
+        'surface-container': '#171f33',
+        'surface-container-lowest': '#060e20',
+        'surface-container-low': '#131b2e',
+        'surface-container-high': '#222a3d',
+        'surface-container-highest': '#2d3449',
+        'on-surface': '#dae2fd',
+        'on-surface-variant': '#c4c7c8',
+        'inverse-surface': '#dae2fd',
+        'inverse-on-surface': '#283044',
+        'surface-tint': '#c6c6c7',
+        'surface-variant': '#2d3449',
+      },
+      components: {
+        card: { backgroundColor: '{colors.surface-container}' },
+      },
+    });
+    const findings = orphanedTokens(state);
+    expect(findings).toEqual([]);
+  });
+
+  it('still flags genuinely-orphaned custom tokens outside any referenced family', () => {
+    // `brand-blue` is not part of the MD3 primary family, so referencing
+    // `primary` does not save it.
+    const state = buildState({
+      colors: {
+        primary: '#1A1C1E',
+        'on-primary': '#ffffff',
+        'brand-blue': '#0000ff',
+      },
+      components: {
+        button: { backgroundColor: '{colors.primary}' },
+      },
+    });
+    const findings = orphanedTokens(state);
+    const orphan = findings.find(d => d.path === 'colors.brand-blue');
+    expect(orphan).toBeDefined();
+    // And confirms `on-primary` does not get flagged just because it's not
+    // directly referenced.
+    expect(findings.find(d => d.path === 'colors.on-primary')).toBeUndefined();
+  });
+
+  it('does not flag MD3 baseline families even when no component references them', () => {
+    // The MD3 baseline colors (primary, secondary, tertiary, error, surface,
+    // background, outline) are part of the standard contract. A design system
+    // that ships them should not get warned for components that happen to
+    // not exercise the full palette in their canonical examples.
+    const state = buildState({
+      colors: {
+        primary: '#1A1C1E',
+        secondary: '#6C7278',
+        tertiary: '#B8422E',
+        error: '#B3261E',
+        'on-error': '#ffffff',
+        'error-container': '#F9DEDC',
+        background: '#fffbfe',
+        'on-background': '#1c1b1f',
+        outline: '#79747e',
+        'outline-variant': '#cac4d0',
+      },
+      components: {
+        button: { backgroundColor: '{colors.primary}' },
+      },
+    });
+    const findings = orphanedTokens(state);
+    expect(findings).toEqual([]);
+  });
 });

--- a/packages/cli/src/linter/linter/rules/orphaned-tokens.test.ts
+++ b/packages/cli/src/linter/linter/rules/orphaned-tokens.test.ts
@@ -63,4 +63,103 @@ describe('orphanedTokens', () => {
     const findings = orphanedTokens(state);
     expect(findings.some(f => f.path?.startsWith('colors.surface-info'))).toBe(false);
   });
+
+  it('does not flag MD3 paired tokens when the family is referenced (issue #46)', () => {
+    // When a component references `primary`, the rest of the MD3 primary
+    // family (`on-primary`, `primary-container`, `on-primary-container`,
+    // `primary-fixed`, `primary-fixed-dim`, `on-primary-fixed`,
+    // `on-primary-fixed-variant`, `inverse-primary`) is part of the same
+    // semantic group and should not be flagged as orphaned.
+    const state = buildState({
+      colors: {
+        primary: '#1A1C1E',
+        'on-primary': '#ffffff',
+        'primary-container': '#e2e2e2',
+        'on-primary-container': '#636565',
+        'primary-fixed': '#e2e2e2',
+        'primary-fixed-dim': '#c6c6c7',
+        'on-primary-fixed': '#1a1c1c',
+        'on-primary-fixed-variant': '#454747',
+        'inverse-primary': '#5d5f5f',
+      },
+      components: {
+        button: { backgroundColor: '{colors.primary}' },
+      },
+    });
+    const findings = orphanedTokens(state);
+    expect(findings).toEqual([]);
+  });
+
+  it('does not flag MD3 surface family when one surface token is referenced', () => {
+    const state = buildState({
+      colors: {
+        surface: '#0b1326',
+        'surface-dim': '#0b1326',
+        'surface-bright': '#31394d',
+        'surface-container': '#171f33',
+        'surface-container-lowest': '#060e20',
+        'surface-container-low': '#131b2e',
+        'surface-container-high': '#222a3d',
+        'surface-container-highest': '#2d3449',
+        'on-surface': '#dae2fd',
+        'on-surface-variant': '#c4c7c8',
+        'inverse-surface': '#dae2fd',
+        'inverse-on-surface': '#283044',
+        'surface-tint': '#c6c6c7',
+        'surface-variant': '#2d3449',
+      },
+      components: {
+        card: { backgroundColor: '{colors.surface-container}' },
+      },
+    });
+    const findings = orphanedTokens(state);
+    expect(findings).toEqual([]);
+  });
+
+  it('still flags genuinely-orphaned custom tokens outside any referenced family', () => {
+    // `brand-blue` is not part of the MD3 primary family, so referencing
+    // `primary` does not save it.
+    const state = buildState({
+      colors: {
+        primary: '#1A1C1E',
+        'on-primary': '#ffffff',
+        'brand-blue': '#0000ff',
+      },
+      components: {
+        button: { backgroundColor: '{colors.primary}' },
+      },
+    });
+    const findings = orphanedTokens(state);
+    const orphan = findings.find(d => d.path === 'colors.brand-blue');
+    expect(orphan).toBeDefined();
+    // And confirms `on-primary` does not get flagged just because it's not
+    // directly referenced.
+    expect(findings.find(d => d.path === 'colors.on-primary')).toBeUndefined();
+  });
+
+  it('does not flag MD3 baseline families even when no component references them', () => {
+    // The MD3 baseline colors (primary, secondary, tertiary, error, surface,
+    // background, outline) are part of the standard contract. A design system
+    // that ships them should not get warned for components that happen to
+    // not exercise the full palette in their canonical examples.
+    const state = buildState({
+      colors: {
+        primary: '#1A1C1E',
+        secondary: '#6C7278',
+        tertiary: '#B8422E',
+        error: '#B3261E',
+        'on-error': '#ffffff',
+        'error-container': '#F9DEDC',
+        background: '#fffbfe',
+        'on-background': '#1c1b1f',
+        outline: '#79747e',
+        'outline-variant': '#cac4d0',
+      },
+      components: {
+        button: { backgroundColor: '{colors.primary}' },
+      },
+    });
+    const findings = orphanedTokens(state);
+    expect(findings).toEqual([]);
+  });
 });

--- a/packages/cli/src/linter/linter/rules/orphaned-tokens.ts
+++ b/packages/cli/src/linter/linter/rules/orphaned-tokens.ts
@@ -16,7 +16,46 @@ import type { DesignSystemState } from '../../model/spec.js';
 import type { RuleDescriptor, RuleFinding } from './types.js';
 
 /**
- * Orphaned tokens — tokens defined but never referenced by any component.
+ * Reduce a Material Design 3 color token name to its family root.
+ *
+ * Strips MD3 prefixes (`on-`, `inverse-`) and suffixes (`-container*`,
+ * `-fixed*`, `-dim`, `-bright`, `-tint`, `-variant`). Tokens that don't match
+ * any MD3 pattern collapse to their own name, which means custom tokens like
+ * `brand-blue` keep getting flagged when truly unused.
+ */
+function colorFamily(name: string): string {
+  let n = name;
+  // Prefixes. `inverse-on-surface` needs both passes of `on-` removal.
+  n = n.replace(/^on-/, '');
+  n = n.replace(/^inverse-/, '');
+  n = n.replace(/^on-/, '');
+  // Suffixes. Order matters: `-container-low` must collapse before `-low`
+  // becomes a candidate suffix.
+  n = n.replace(/-container.*$/, '');
+  n = n.replace(/-fixed.*$/, '');
+  n = n.replace(/-(dim|bright|tint|variant)$/, '');
+  return n;
+}
+
+/**
+ * Material Design 3 baseline color families. Tokens belonging to these
+ * families are part of the MD3 standard contract and are never flagged as
+ * orphaned, even if a given component set doesn't reference them. Custom
+ * tokens (e.g. `brand-blue`, `accent-magenta`) still get flagged when unused.
+ */
+const MD3_STANDARD_FAMILIES = new Set([
+  'primary',
+  'secondary',
+  'tertiary',
+  'error',
+  'surface',
+  'background',
+  'outline',
+]);
+
+/**
+ * Orphaned tokens — tokens defined but never referenced by any component or
+ * any sibling token in the same MD3 family.
  */
 export function orphanedTokens(state: DesignSystemState): RuleFinding[] {
   if (state.components.size === 0) return [];
@@ -34,15 +73,28 @@ export function orphanedTokens(state: DesignSystemState): RuleFinding[] {
     }
   }
 
+  // A component referencing one MD3 token implies its semantic siblings are
+  // part of the same in-use group (e.g. `primary` brings `on-primary`,
+  // `primary-container`, `inverse-primary`, etc.). Compute the set of
+  // referenced families so siblings don't get flagged as orphaned.
+  const referencedFamilies = new Set<string>();
+  for (const path of referencedPaths) {
+    if (path.startsWith('colors.')) {
+      referencedFamilies.add(colorFamily(path.slice('colors.'.length)));
+    }
+  }
+
   const findings: RuleFinding[] = [];
   for (const [name] of state.colors) {
     const path = `colors.${name}`;
-    if (!referencedPaths.has(path)) {
-      findings.push({
-        path,
-        message: `'${name}' is defined but never referenced by any component.`,
-      });
-    }
+    if (referencedPaths.has(path)) continue;
+    const family = colorFamily(name);
+    if (referencedFamilies.has(family)) continue;
+    if (MD3_STANDARD_FAMILIES.has(family)) continue;
+    findings.push({
+      path,
+      message: `'${name}' is defined but never referenced by any component.`,
+    });
   }
   return findings;
 }

--- a/packages/cli/src/linter/linter/rules/orphaned-tokens.ts
+++ b/packages/cli/src/linter/linter/rules/orphaned-tokens.ts
@@ -16,13 +16,54 @@ import type { DesignSystemState } from '../../model/spec.js';
 import type { RuleDescriptor, RuleFinding } from './types.js';
 
 /**
- * Orphaned tokens — tokens defined but never referenced by any component.
- * References inside per-state overrides (`states.hover`, etc.) count.
+ * Reduce a Material Design 3 color token name to its family root.
+ *
+ * Strips MD3 prefixes (`on-`, `inverse-`) and suffixes (`-container*`,
+ * `-fixed*`, `-dim`, `-bright`, `-tint`, `-variant`). Tokens that don't match
+ * any MD3 pattern collapse to their own name, which means custom tokens like
+ * `brand-blue` keep getting flagged when truly unused.
+ */
+function colorFamily(name: string): string {
+  let n = name;
+  // Prefixes. `inverse-on-surface` needs both passes of `on-` removal.
+  n = n.replace(/^on-/, '');
+  n = n.replace(/^inverse-/, '');
+  n = n.replace(/^on-/, '');
+  // Suffixes. Order matters: `-container-low` must collapse before `-low`
+  // becomes a candidate suffix.
+  n = n.replace(/-container.*$/, '');
+  n = n.replace(/-fixed.*$/, '');
+  n = n.replace(/-(dim|bright|tint|variant)$/, '');
+  return n;
+}
+
+/**
+ * Material Design 3 baseline color families. Tokens belonging to these
+ * families are part of the MD3 standard contract and are never flagged as
+ * orphaned, even if a given component set doesn't reference them. Custom
+ * tokens (e.g. `brand-blue`, `accent-magenta`) still get flagged when unused.
+ */
+const MD3_STANDARD_FAMILIES = new Set([
+  'primary',
+  'secondary',
+  'tertiary',
+  'error',
+  'surface',
+  'background',
+  'outline',
+]);
+
+/**
+ * Orphaned tokens — tokens defined but never referenced by any component or
+ * any sibling token in the same MD3 family. References inside per-state
+ * overrides (`states.hover`, etc.) count.
  *
  * Ramp-derived steps and pair-derived members are exempt: they are synthesized
  * from a single declaration, so flagging each individually would flood the
  * report. Only the ramp anchor (or the pair name itself) triggers the warning
- * when nothing in the system references the group.
+ * when nothing in the system references the group. Flat MD3-named tokens are
+ * likewise exempt when their family root is referenced or is part of the MD3
+ * baseline contract.
  */
 export function orphanedTokens(state: DesignSystemState): RuleFinding[] {
   if (state.components.size === 0) return [];
@@ -57,6 +98,17 @@ export function orphanedTokens(state: DesignSystemState): RuleFinding[] {
     if (resolved?.pairRole) referencedPairs.add(resolved.pairRole.pair);
   }
 
+  // A component referencing one MD3 token implies its semantic siblings are
+  // part of the same in-use group (e.g. `primary` brings `on-primary`,
+  // `primary-container`, `inverse-primary`, etc.). Compute the set of
+  // referenced families so siblings don't get flagged as orphaned.
+  const referencedFamilies = new Set<string>();
+  for (const path of referencedPaths) {
+    if (path.startsWith('colors.')) {
+      referencedFamilies.add(colorFamily(path.slice('colors.'.length)));
+    }
+  }
+
   const findings: RuleFinding[] = [];
   for (const [name, color] of state.colors) {
     // Skip ramp steps and pair members; they're reported via their group, not individually.
@@ -73,6 +125,12 @@ export function orphanedTokens(state: DesignSystemState): RuleFinding[] {
       const derivedPairUsed = [...ramp.pairs.keys()].some(k => referencedPairs.has(`${name}-${k}`));
       if (derivedPairUsed) continue;
     }
+
+    // Flat MD3-style tokens: exempt paired siblings of a referenced family
+    // and the MD3 baseline families themselves.
+    const family = colorFamily(name);
+    if (referencedFamilies.has(family)) continue;
+    if (MD3_STANDARD_FAMILIES.has(family)) continue;
 
     findings.push({
       path,

--- a/packages/cli/src/linter/linter/rules/token-like-ignored.test.ts
+++ b/packages/cli/src/linter/linter/rules/token-like-ignored.test.ts
@@ -1,0 +1,133 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { tokenLikeIgnored } from './token-like-ignored.js';
+import { buildState } from './test-helpers.js';
+import type { SourceLocation } from '../../parser/spec.js';
+
+const loc: SourceLocation = { line: 1, column: 0, block: 'frontmatter' };
+
+describe('tokenLikeIgnored', () => {
+  it('warns when an unknown key has hex color leaf values', () => {
+    const state = buildState({
+      sourceMap: new Map([['base_colors', loc]]),
+      rawValues: { base_colors: { ink: '#0B0F14', mist: '#F5F7FA' } },
+    });
+    const findings = tokenLikeIgnored(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('base_colors');
+    expect(findings[0]!.message).toContain('"base_colors"');
+    expect(findings[0]!.message).toContain('silently ignored by export');
+  });
+
+  it('warns when an unknown key has a fontFamily property', () => {
+    const state = buildState({
+      sourceMap: new Map([['brand_type', loc]]),
+      rawValues: {
+        brand_type: { heading: { fontFamily: 'Inter', fontSize: '32px' } },
+      },
+    });
+    const findings = tokenLikeIgnored(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('brand_type');
+  });
+
+  it('warns when an unknown key has CSS dimension leaf values', () => {
+    const state = buildState({
+      sourceMap: new Map([['semantic_spacing', loc]]),
+      rawValues: { semantic_spacing: { sm: '4px', md: '8px', lg: '16px' } },
+    });
+    const findings = tokenLikeIgnored(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('semantic_spacing');
+  });
+
+  it('stays silent when an unknown key has a flat string value (not a map)', () => {
+    const state = buildState({
+      sourceMap: new Map([['theme', loc]]),
+      rawValues: { theme: 'dark' },
+    });
+    expect(tokenLikeIgnored(state)).toEqual([]);
+  });
+
+  it('stays silent when an unknown key has a number value', () => {
+    const state = buildState({
+      sourceMap: new Map([['version_major', loc]]),
+      rawValues: { version_major: 2 },
+    });
+    expect(tokenLikeIgnored(state)).toEqual([]);
+  });
+
+  it('stays silent when an unknown key has a non-token-like object (no hex, no dimension, no typo prop)', () => {
+    const state = buildState({
+      sourceMap: new Map([['meta', loc]]),
+      rawValues: { meta: { author: 'Jane', created: '2026-01-01' } },
+    });
+    expect(tokenLikeIgnored(state)).toEqual([]);
+  });
+
+  it('stays silent for all recognized schema keys', () => {
+    const state = buildState({
+      sourceMap: new Map([
+        ['version', loc],
+        ['name', loc],
+        ['colors', loc],
+        ['typography', loc],
+        ['spacing', loc],
+        ['rounded', loc],
+        ['components', loc],
+      ]),
+    });
+    expect(tokenLikeIgnored(state)).toEqual([]);
+  });
+
+  it('emits one finding per token-like unknown key', () => {
+    const state = buildState({
+      sourceMap: new Map([
+        ['base_colors', loc],
+        ['semantic_colors', loc],
+        ['meta', loc],
+      ]),
+      rawValues: {
+        base_colors: { primary: '#1A73E8' },
+        semantic_colors: { success: '#34A853' },
+        meta: { owner: 'design-team' },
+      },
+    });
+    const findings = tokenLikeIgnored(state);
+    expect(findings.length).toBe(2);
+    expect(findings.map(f => f.path).sort()).toEqual(['base_colors', 'semantic_colors']);
+  });
+
+  it('warns on nested token maps', () => {
+    const state = buildState({
+      sourceMap: new Map([['palette', loc]]),
+      rawValues: {
+        palette: {
+          light: { brand: '#4A90E2', surface: '#FFFFFF' },
+          dark: { brand: '#82B1FF', surface: '#121212' },
+        },
+      },
+    });
+    const findings = tokenLikeIgnored(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('palette');
+  });
+
+  it('returns empty when there are no unknown keys', () => {
+    const state = buildState({});
+    expect(tokenLikeIgnored(state)).toEqual([]);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/token-like-ignored.ts
+++ b/packages/cli/src/linter/linter/rules/token-like-ignored.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * CSS hex color pattern: #RGB, #RGBA, #RRGGBB, or #RRGGBBAA.
+ */
+const HEX_COLOR_RE = /^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+/**
+ * CSS dimension pattern: an optional sign, digits, and a CSS unit suffix.
+ */
+const CSS_DIMENSION_RE = /^-?\d*\.?\d+[a-zA-Z%]+$/;
+
+/**
+ * Typography-flavored property names that strongly suggest this map holds
+ * design tokens rather than arbitrary metadata.
+ */
+const TYPOGRAPHY_PROPS = new Set(['fontFamily', 'fontSize', 'fontWeight', 'lineHeight', 'letterSpacing']);
+
+/**
+ * Determine whether a plain object looks like a design-token map.
+ *
+ * A map is "token-like" when at least one leaf value is a hex color string or
+ * a CSS dimension string, OR at least one key is a well-known typography
+ * property name. Flat scalars (strings, numbers) and non-object values are
+ * never token-like on their own — the value must be an object.
+ */
+function isTokenLikeMap(value: unknown): boolean {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const obj = value as Record<string, unknown>;
+  return hasTokenLikeContent(obj);
+}
+
+function hasTokenLikeContent(obj: Record<string, unknown>): boolean {
+  for (const [key, val] of Object.entries(obj)) {
+    // Typography property key is itself a signal.
+    if (TYPOGRAPHY_PROPS.has(key)) return true;
+
+    if (typeof val === 'string') {
+      if (HEX_COLOR_RE.test(val) || CSS_DIMENSION_RE.test(val)) return true;
+    } else if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
+      // Recurse one level for nested token maps (e.g. base_colors: { light: { ink: "#0B0F14" } })
+      if (hasTokenLikeContent(val as Record<string, unknown>)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Token-like ignored keys — warns when a top-level YAML key is not part of
+ * the recognized export schema and its value looks like a design-token map.
+ * These values will be silently dropped by `design.md export`.
+ */
+export function tokenLikeIgnored(state: DesignSystemState): RuleFinding[] {
+  const unknownKeys = state.unknownKeys ?? [];
+  const unknownKeyValues = state.unknownKeyValues ?? {};
+  const findings: RuleFinding[] = [];
+
+  for (const key of unknownKeys) {
+    const value = unknownKeyValues[key];
+    if (isTokenLikeMap(value)) {
+      findings.push({
+        path: key,
+        message:
+          `"${key}" looks like a design-token map but is not a recognized schema key ` +
+          `(colors, typography, spacing, rounded, components). ` +
+          `It will be silently ignored by export commands. ` +
+          `Rename it to a supported key or move its values under a recognized section.`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+export const tokenLikeIgnoredRule: RuleDescriptor = {
+  name: 'token-like-ignored',
+  severity: 'warning',
+  description:
+    'Warns when a top-level YAML key looks like a design-token map but is not ' +
+    'part of the recognized export schema and will be silently ignored.',
+  run: tokenLikeIgnored,
+};

--- a/packages/cli/src/linter/linter/rules/token-like-ignored.ts
+++ b/packages/cli/src/linter/linter/rules/token-like-ignored.ts
@@ -26,6 +26,14 @@ const HEX_COLOR_RE = /^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
 const CSS_DIMENSION_RE = /^-?\d*\.?\d+[a-zA-Z%]+$/;
 
 /**
+ * Upper bound on a token-like leaf value's length before pattern matching.
+ * A hex color or CSS dimension is short; longer strings cannot match either,
+ * so capping the length avoids pathological regex backtracking on oversized
+ * attacker-supplied values.
+ */
+const MAX_TOKEN_VALUE_LENGTH = 64;
+
+/**
  * Typography-flavored property names that strongly suggest this map holds
  * design tokens rather than arbitrary metadata.
  */
@@ -54,7 +62,7 @@ function hasTokenLikeContent(obj: Record<string, unknown>): boolean {
     if (TYPOGRAPHY_PROPS.has(key)) return true;
 
     if (typeof val === 'string') {
-      if (HEX_COLOR_RE.test(val) || CSS_DIMENSION_RE.test(val)) return true;
+      if (val.length <= MAX_TOKEN_VALUE_LENGTH && (HEX_COLOR_RE.test(val) || CSS_DIMENSION_RE.test(val))) return true;
     } else if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
       // Recurse one level for nested token maps (e.g. base_colors: { light: { ink: "#0B0F14" } })
       if (hasTokenLikeContent(val as Record<string, unknown>)) return true;

--- a/packages/cli/src/linter/linter/rules/token-like-ignored.ts
+++ b/packages/cli/src/linter/linter/rules/token-like-ignored.ts
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+
+/**
+ * CSS hex color pattern: #RGB, #RGBA, #RRGGBB, or #RRGGBBAA.
+ */
+const HEX_COLOR_RE = /^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+/**
+ * CSS dimension pattern: an optional sign, digits, and a CSS unit suffix.
+ */
+const CSS_DIMENSION_RE = /^-?\d*\.?\d+[a-zA-Z%]+$/;
+
+/**
+ * Upper bound on a token-like leaf value's length before pattern matching.
+ * A hex color or CSS dimension is short; longer strings cannot match either,
+ * so capping the length avoids pathological regex backtracking on oversized
+ * attacker-supplied values.
+ */
+const MAX_TOKEN_VALUE_LENGTH = 64;
+
+/**
+ * Typography-flavored property names that strongly suggest this map holds
+ * design tokens rather than arbitrary metadata.
+ */
+const TYPOGRAPHY_PROPS = new Set(['fontFamily', 'fontSize', 'fontWeight', 'lineHeight', 'letterSpacing']);
+
+/**
+ * Determine whether a plain object looks like a design-token map.
+ *
+ * A map is "token-like" when at least one leaf value is a hex color string or
+ * a CSS dimension string, OR at least one key is a well-known typography
+ * property name. Flat scalars (strings, numbers) and non-object values are
+ * never token-like on their own — the value must be an object.
+ */
+function isTokenLikeMap(value: unknown): boolean {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const obj = value as Record<string, unknown>;
+  return hasTokenLikeContent(obj);
+}
+
+function hasTokenLikeContent(obj: Record<string, unknown>): boolean {
+  for (const [key, val] of Object.entries(obj)) {
+    // Typography property key is itself a signal.
+    if (TYPOGRAPHY_PROPS.has(key)) return true;
+
+    if (typeof val === 'string') {
+      if (val.length <= MAX_TOKEN_VALUE_LENGTH && (HEX_COLOR_RE.test(val) || CSS_DIMENSION_RE.test(val))) return true;
+    } else if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
+      // Recurse one level for nested token maps (e.g. base_colors: { light: { ink: "#0B0F14" } })
+      if (hasTokenLikeContent(val as Record<string, unknown>)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Token-like ignored keys — warns when a top-level YAML key is not part of
+ * the recognized export schema and its value looks like a design-token map.
+ * These values will be silently dropped by `design.md export`.
+ */
+export function tokenLikeIgnored(state: DesignSystemState): RuleFinding[] {
+  const unknownKeys = state.unknownKeys ?? [];
+  const unknownKeyValues = state.unknownKeyValues ?? {};
+  const findings: RuleFinding[] = [];
+
+  for (const key of unknownKeys) {
+    const value = unknownKeyValues[key];
+    if (isTokenLikeMap(value)) {
+      findings.push({
+        path: key,
+        message:
+          `"${key}" looks like a design-token map but is not a recognized schema key ` +
+          `(colors, typography, spacing, rounded, components). ` +
+          `It will be silently ignored by export commands. ` +
+          `Rename it to a supported key or move its values under a recognized section.`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+export const tokenLikeIgnoredRule: RuleDescriptor = {
+  name: 'token-like-ignored',
+  severity: 'warning',
+  description:
+    'Warns when a top-level YAML key looks like a design-token map but is not ' +
+    'part of the recognized export schema and will be silently ignored.',
+  run: tokenLikeIgnored,
+};

--- a/packages/cli/src/linter/linter/rules/types.test.ts
+++ b/packages/cli/src/linter/linter/rules/types.test.ts
@@ -40,7 +40,7 @@ describe('LintRule type', () => {
   });
 
   it('has all rules in DEFAULT_RULE_DESCRIPTORS', () => {
-    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(9);
+    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(10);
     DEFAULT_RULE_DESCRIPTORS.forEach((rule: RuleDescriptor) => {
       expect(rule.name).toBeTruthy();
       expect(rule.severity).toBeTruthy();

--- a/packages/cli/src/linter/linter/rules/types.test.ts
+++ b/packages/cli/src/linter/linter/rules/types.test.ts
@@ -47,7 +47,7 @@ describe('LintRule type', () => {
   });
 
   it('has all rules in DEFAULT_RULE_DESCRIPTORS', () => {
-    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(43);
+    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(45);
     DEFAULT_RULE_DESCRIPTORS.forEach((rule: RuleDescriptor) => {
       expect(rule.name).toBeTruthy();
       expect(rule.severity).toBeTruthy();

--- a/packages/cli/src/linter/linter/rules/types.test.ts
+++ b/packages/cli/src/linter/linter/rules/types.test.ts
@@ -40,7 +40,7 @@ describe('LintRule type', () => {
   });
 
   it('has all rules in DEFAULT_RULE_DESCRIPTORS', () => {
-    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(8);
+    expect(DEFAULT_RULE_DESCRIPTORS.length).toBe(9);
     DEFAULT_RULE_DESCRIPTORS.forEach((rule: RuleDescriptor) => {
       expect(rule.name).toBeTruthy();
       expect(rule.severity).toBeTruthy();

--- a/packages/cli/src/linter/linter/rules/unknown-key.test.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-key.test.ts
@@ -111,4 +111,12 @@ describe('unknownKey', () => {
     const findings = unknownKey(state);
     expect(findings.map(f => f.path).sort()).toEqual(['colours', 'typografy']);
   });
+
+  it('stays silent (and cheap) for very long keys via the length short-circuit', () => {
+    const state = buildState({
+      sourceMap: new Map([['a'.repeat(50000), loc]]),
+    });
+    const findings = unknownKey(state);
+    expect(findings.length).toBe(0);
+  });
 });

--- a/packages/cli/src/linter/linter/rules/unknown-key.test.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-key.test.ts
@@ -1,0 +1,114 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { unknownKey } from './unknown-key.js';
+import { buildState } from './test-helpers.js';
+import type { SourceLocation } from '../../parser/spec.js';
+
+const loc: SourceLocation = { line: 1, column: 0, block: 'frontmatter' };
+
+describe('unknownKey', () => {
+  it('warns and suggests "colors" for "colours" (distance 1)', () => {
+    const state = buildState({
+      sourceMap: new Map([
+        ['name', loc],
+        ['colours', loc],
+      ]),
+    });
+    const findings = unknownKey(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('colours');
+    expect(findings[0]!.message).toBe('Unknown key "colours" — did you mean "colors"?');
+  });
+
+  it('warns and suggests "typography" for "typografy" (distance 2)', () => {
+    const state = buildState({
+      sourceMap: new Map([['typografy', loc]]),
+    });
+    const findings = unknownKey(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toBe('Unknown key "typografy" — did you mean "typography"?');
+  });
+
+  it('warns and suggests "name" for "nam" (distance 1)', () => {
+    const state = buildState({
+      sourceMap: new Map([['nam', loc]]),
+    });
+    const findings = unknownKey(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toBe('Unknown key "nam" — did you mean "name"?');
+  });
+
+  it('matches case-insensitively (e.g. "Colors" is treated as known)', () => {
+    const state = buildState({
+      sourceMap: new Map([['Colors', loc]]),
+    });
+    const findings = unknownKey(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toBe('Unknown key "Colors" — did you mean "colors"?');
+  });
+
+  it('stays silent for far-from-any-key extension keys', () => {
+    const state = buildState({
+      sourceMap: new Map([
+        ['icons', loc],
+        ['motion', loc],
+        ['brand', loc],
+      ]),
+    });
+    expect(unknownKey(state)).toEqual([]);
+  });
+
+  it('stays silent for "rounding" (distance 3 from "rounded")', () => {
+    const state = buildState({
+      sourceMap: new Map([['rounding', loc]]),
+    });
+    expect(unknownKey(state)).toEqual([]);
+  });
+
+  it('returns empty when all top-level keys are known', () => {
+    const state = buildState({
+      sourceMap: new Map([
+        ['version', loc],
+        ['name', loc],
+        ['description', loc],
+        ['colors', loc],
+        ['typography', loc],
+        ['rounded', loc],
+        ['spacing', loc],
+        ['components', loc],
+      ]),
+    });
+    expect(unknownKey(state)).toEqual([]);
+  });
+
+  it('returns empty when there are no top-level keys', () => {
+    const state = buildState({});
+    expect(unknownKey(state)).toEqual([]);
+  });
+
+  it('emits one finding per misspelled key and ignores unrelated extension keys', () => {
+    const state = buildState({
+      sourceMap: new Map([
+        ['colors', loc],
+        ['colours', loc],
+        ['typografy', loc],
+        ['icons', loc],
+      ]),
+    });
+    const findings = unknownKey(state);
+    expect(findings.map(f => f.path).sort()).toEqual(['colours', 'typografy']);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/unknown-key.test.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-key.test.ts
@@ -1,0 +1,122 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { unknownKey } from './unknown-key.js';
+import { buildState } from './test-helpers.js';
+import type { SourceLocation } from '../../parser/spec.js';
+
+const loc: SourceLocation = { line: 1, column: 0, block: 'frontmatter' };
+
+describe('unknownKey', () => {
+  it('warns and suggests "colors" for "colours" (distance 1)', () => {
+    const state = buildState({
+      sourceMap: new Map([
+        ['name', loc],
+        ['colours', loc],
+      ]),
+    });
+    const findings = unknownKey(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.path).toBe('colours');
+    expect(findings[0]!.message).toBe('Unknown key "colours" — did you mean "colors"?');
+  });
+
+  it('warns and suggests "typography" for "typografy" (distance 2)', () => {
+    const state = buildState({
+      sourceMap: new Map([['typografy', loc]]),
+    });
+    const findings = unknownKey(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toBe('Unknown key "typografy" — did you mean "typography"?');
+  });
+
+  it('warns and suggests "name" for "nam" (distance 1)', () => {
+    const state = buildState({
+      sourceMap: new Map([['nam', loc]]),
+    });
+    const findings = unknownKey(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toBe('Unknown key "nam" — did you mean "name"?');
+  });
+
+  it('matches case-insensitively (e.g. "Colors" is treated as known)', () => {
+    const state = buildState({
+      sourceMap: new Map([['Colors', loc]]),
+    });
+    const findings = unknownKey(state);
+    expect(findings.length).toBe(1);
+    expect(findings[0]!.message).toBe('Unknown key "Colors" — did you mean "colors"?');
+  });
+
+  it('stays silent for far-from-any-key extension keys', () => {
+    const state = buildState({
+      sourceMap: new Map([
+        ['icons', loc],
+        ['motion', loc],
+        ['brand', loc],
+      ]),
+    });
+    expect(unknownKey(state)).toEqual([]);
+  });
+
+  it('stays silent for "rounding" (distance 3 from "rounded")', () => {
+    const state = buildState({
+      sourceMap: new Map([['rounding', loc]]),
+    });
+    expect(unknownKey(state)).toEqual([]);
+  });
+
+  it('returns empty when all top-level keys are known', () => {
+    const state = buildState({
+      sourceMap: new Map([
+        ['version', loc],
+        ['name', loc],
+        ['description', loc],
+        ['colors', loc],
+        ['typography', loc],
+        ['rounded', loc],
+        ['spacing', loc],
+        ['components', loc],
+      ]),
+    });
+    expect(unknownKey(state)).toEqual([]);
+  });
+
+  it('returns empty when there are no top-level keys', () => {
+    const state = buildState({});
+    expect(unknownKey(state)).toEqual([]);
+  });
+
+  it('emits one finding per misspelled key and ignores unrelated extension keys', () => {
+    const state = buildState({
+      sourceMap: new Map([
+        ['colors', loc],
+        ['colours', loc],
+        ['typografy', loc],
+        ['icons', loc],
+      ]),
+    });
+    const findings = unknownKey(state);
+    expect(findings.map(f => f.path).sort()).toEqual(['colours', 'typografy']);
+  });
+
+  it('stays silent (and cheap) for very long keys via the length short-circuit', () => {
+    const state = buildState({
+      sourceMap: new Map([['a'.repeat(50000), loc]]),
+    });
+    const findings = unknownKey(state);
+    expect(findings.length).toBe(0);
+  });
+});

--- a/packages/cli/src/linter/linter/rules/unknown-key.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-key.ts
@@ -34,6 +34,11 @@ export function unknownKey(state: DesignSystemState): RuleFinding[] {
     let bestMatch: string | undefined;
     let bestDist = Infinity;
     for (const known of SCHEMA_KEYS) {
+      // Edit distance is at least the length difference, so a key whose length
+      // differs from a known key by more than the typo threshold can never be a
+      // typo — skip the O(n*m) distance computation for it. This keeps the rule
+      // cheap on long, attacker-supplied keys without changing any result.
+      if (Math.abs(key.length - known.length) > MAX_TYPO_DISTANCE) continue;
       const dist = levenshtein(key.toLowerCase(), known.toLowerCase());
       if (dist < bestDist) {
         bestDist = dist;

--- a/packages/cli/src/linter/linter/rules/unknown-key.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-key.ts
@@ -1,0 +1,60 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { SCHEMA_KEYS } from '../../parser/spec.js';
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+import { levenshtein } from './levenshtein.js';
+
+/** Max edit distance to consider a typo (not a custom key). */
+const MAX_TYPO_DISTANCE = 2;
+
+/**
+ * Unknown key — warns when a top-level YAML key looks like a typo of a known
+ * schema key. The DESIGN.md schema is intentionally extensible (custom keys
+ * are allowed), so only close matches to known keys are reported; unrelated
+ * extension keys stay silent.
+ */
+export function unknownKey(state: DesignSystemState): RuleFinding[] {
+  const knownSet = new Set<string>(SCHEMA_KEYS);
+  return (state.unknownKeys ?? []).flatMap(key => {
+    if (knownSet.has(key)) return [];
+
+    let bestMatch: string | undefined;
+    let bestDist = Infinity;
+    for (const known of SCHEMA_KEYS) {
+      const dist = levenshtein(key.toLowerCase(), known.toLowerCase());
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestMatch = known;
+      }
+    }
+
+    if (bestDist <= MAX_TYPO_DISTANCE && bestMatch) {
+      return [{
+        path: key,
+        message: `Unknown key "${key}" — did you mean "${bestMatch}"?`,
+      }];
+    }
+
+    return [];
+  });
+}
+
+export const unknownKeyRule: RuleDescriptor = {
+  name: 'unknown-key',
+  severity: 'warning',
+  description: 'Unknown key — warns when a top-level YAML key looks like a typo of a known schema key.',
+  run: unknownKey,
+};

--- a/packages/cli/src/linter/linter/rules/unknown-key.ts
+++ b/packages/cli/src/linter/linter/rules/unknown-key.ts
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { SCHEMA_KEYS } from '../../parser/spec.js';
+import type { DesignSystemState } from '../../model/spec.js';
+import type { RuleDescriptor, RuleFinding } from './types.js';
+import { levenshtein } from './levenshtein.js';
+
+/** Max edit distance to consider a typo (not a custom key). */
+const MAX_TYPO_DISTANCE = 2;
+
+/**
+ * Unknown key — warns when a top-level YAML key looks like a typo of a known
+ * schema key. The DESIGN.md schema is intentionally extensible (custom keys
+ * are allowed), so only close matches to known keys are reported; unrelated
+ * extension keys stay silent.
+ */
+export function unknownKey(state: DesignSystemState): RuleFinding[] {
+  const knownSet = new Set<string>(SCHEMA_KEYS);
+  return (state.unknownKeys ?? []).flatMap(key => {
+    if (knownSet.has(key)) return [];
+
+    let bestMatch: string | undefined;
+    let bestDist = Infinity;
+    for (const known of SCHEMA_KEYS) {
+      // Edit distance is at least the length difference, so a key whose length
+      // differs from a known key by more than the typo threshold can never be a
+      // typo — skip the O(n*m) distance computation for it. This keeps the rule
+      // cheap on long, attacker-supplied keys without changing any result.
+      if (Math.abs(key.length - known.length) > MAX_TYPO_DISTANCE) continue;
+      const dist = levenshtein(key.toLowerCase(), known.toLowerCase());
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestMatch = known;
+      }
+    }
+
+    if (bestDist <= MAX_TYPO_DISTANCE && bestMatch) {
+      return [{
+        path: key,
+        message: `Unknown key "${key}" — did you mean "${bestMatch}"?`,
+      }];
+    }
+
+    return [];
+  });
+}
+
+export const unknownKeyRule: RuleDescriptor = {
+  name: 'unknown-key',
+  severity: 'warning',
+  description: 'Unknown key — warns when a top-level YAML key looks like a typo of a known schema key.',
+  run: unknownKey,
+};

--- a/packages/cli/src/linter/model/color-parser.ts
+++ b/packages/cli/src/linter/model/color-parser.ts
@@ -1,0 +1,589 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export interface ParsedColorResult {
+  hex: string;
+  r: number;
+  g: number;
+  b: number;
+  a?: number;
+  luminance: number;
+}
+
+const CSS_NAMED_COLORS: Record<string, string> = {
+  aliceblue: '#f0f8ff', antiquewhite: '#faebd7', aqua: '#00ffff', aquamarine: '#7fffd4', azure: '#f0ffff',
+  beige: '#f5f5dc', bisque: '#ffe4c4', black: '#000000', blanchedalmond: '#ffebcd', blue: '#0000ff',
+  blueviolet: '#8a2be2', brown: '#a52a2a', burlywood: '#deb887', cadetblue: '#5f9ea0', chartreuse: '#7fff00',
+  chocolate: '#d2691e', coral: '#ff7f50', cornflowerblue: '#6495ed', cornsilk: '#fff8dc', crimson: '#dc143c',
+  cyan: '#00ffff', darkblue: '#00008b', darkcyan: '#008b8b', darkgoldenrod: '#b8860b', darkgray: '#a9a9a9',
+  darkgrey: '#a9a9a9', darkgreen: '#006400', darkkhaki: '#bdb76b', darkmagenta: '#8b008b', darkolivegreen: '#556b2f',
+  darkorange: '#ff8c00', darkorchid: '#9932cc', darkred: '#8b0000', darksalmon: '#e9967a', darkseagreen: '#8fbc8f',
+  darkslateblue: '#483d8b', darkslategrey: '#2f4f4f', darkslategray: '#2f4f4f', darkturquoise: '#00ced1',
+  darkviolet: '#9400d3', deeppink: '#ff1493', deepskyblue: '#00bfff', dimgray: '#696969', dimgrey: '#696969',
+  dodgerblue: '#1e90ff', firebrick: '#b22222', floralwhite: '#fffaf0', forestgreen: '#228b22', fuchsia: '#ff00ff',
+  gainsboro: '#dcdcdc', ghostwhite: '#f8f8ff', gold: '#ffd700', goldenrod: '#daa520', gray: '#808080',
+  grey: '#808080', green: '#008000', greenyellow: '#adff2f', honeydew: '#f0fff0', hotpink: '#ff69b4',
+  indianred: '#cd5c5c', indigo: '#4b0082', ivory: '#fffff0', khaki: '#f0e68c', lavender: '#e6e6fa',
+  lavenderblush: '#fff0f5', lawngreen: '#7cfc00', lemonchiffon: '#fffacd', lightblue: '#add8e6', lightcoral: '#f08080',
+  lightcyan: '#e0ffff', lightgoldenrodyellow: '#fafad2', lightgray: '#d3d3d3', lightgrey: '#d3d3d3', lightgreen: '#90ee90',
+  lightpink: '#ffb6c1', lightsalmon: '#ffa07a', lightseagreen: '#20b2aa', lightskyblue: '#87cefa', lightslate: '#778899',
+  lightslategray: '#778899', lightslategrey: '#778899', lightsteelblue: '#b0c4de', lightyellow: '#ffffe0', lime: '#00ff00',
+  limegreen: '#32cd32', linen: '#faf0e6', magenta: '#ff00ff', maroon: '#800000',
+  mediumaquamarine: '#66cdaa', mediumblue: '#0000cd', mediumorchid: '#ba55d3', mediumpurple: '#9370db', mediumseagreen: '#3cb371',
+  mediumslateblue: '#7b68ee', mediumspringgreen: '#00fa9a', mediumturquoise: '#48d1cc', mediumvioletred: '#c71585', midnightblue: '#191970',
+  mintcream: '#f5fffa', mistyrose: '#ffe4e1', moccasin: '#ffe4b5', navajowhite: '#ffdead', navy: '#000080',
+  oldlace: '#fdf5e6', olive: '#808000', olivedrab: '#6b8e23', orange: '#ffa500', orangered: '#ff4500',
+  orchid: '#da70d6', palegoldenrod: '#eee8aa', palegreen: '#98fb98', paleturquoise: '#afeeee', palevioletred: '#db7093',
+  papayawhip: '#ffefd5', peachpuff: '#ffdab9', peru: '#cd853f', pink: '#ffc0cb', plum: '#dda0dd',
+  powderblue: '#b0e0e6', purple: '#800080', rebeccapurple: '#663399', red: '#ff0000', rosybrown: '#bc8f8f',
+  royalblue: '#4169e1', saddlebrown: '#8b4513', salmon: '#fa8072', sandybrown: '#f4a460', seagreen: '#2e8b57',
+  seashell: '#fff5ee', sienna: '#a0522d', silver: '#c0c0c0', skyblue: '#87ceeb', slateblue: '#6a5acd',
+  slategray: '#708090', slategrey: '#708090', snow: '#fffafa', springgreen: '#00ff7f', steelblue: '#4682b4',
+  tan: '#d2b48c', teal: '#008080', thistle: '#d8bfd8', tomato: '#ff6347', turquoise: '#40e0d0',
+  violet: '#ee82ee', wheat: '#f5deb3', white: '#ffffff', whitesmoke: '#f5f5f5', yellow: '#ffff00',
+  yellowgreen: '#9acd32', transparent: '#00000000',
+};
+
+/**
+ * Parse a CSS color string into its sRGB representation + WCAG relative luminance.
+ * Returns null if the color is invalid.
+ */
+export function parseCssColor(colorStr: string): ParsedColorResult | null {
+  const clean = colorStr.trim().toLowerCase();
+  if (!clean) return null;
+
+  // 1. Hex Color Pattern
+  if (clean.startsWith('#')) {
+    if (!/^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/.test(clean)) {
+      return null;
+    }
+    return parseHex(clean);
+  }
+
+  // 2. Named Colors lookup
+  if (Object.prototype.hasOwnProperty.call(CSS_NAMED_COLORS, clean)) {
+    return parseHex(CSS_NAMED_COLORS[clean]!);
+  }
+
+  // 3. Functional notations parse
+  const parsedFunc = tokenizeFunc(clean);
+  if (!parsedFunc) {
+    return null;
+  }
+
+  const { name, args } = parsedFunc;
+
+  switch (name) {
+    case 'rgb':
+    case 'rgba': {
+      // Supports rgb(255, 0, 0) and rgb(255 0 0 / 0.5)
+      // args could be: [r, g, b] or [r, g, b, a]
+      if (args.length !== 3 && args.length !== 4) return null;
+      const rRaw = parsePercentOrNumber(args[0]!, 255);
+      const gRaw = parsePercentOrNumber(args[1]!, 255);
+      const bRaw = parsePercentOrNumber(args[2]!, 255);
+      const aVal = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(rRaw) || isNaN(gRaw) || isNaN(bRaw) || isNaN(aVal)) return null;
+
+      const r = Math.max(0, Math.min(255, Math.round(rRaw)));
+      const g = Math.max(0, Math.min(255, Math.round(gRaw)));
+      const b = Math.max(0, Math.min(255, Math.round(bRaw)));
+      const a = Math.max(0, Math.min(1, aVal));
+
+      return makeResult(r, g, b, a);
+    }
+    case 'hsl':
+    case 'hsla': {
+      // Supports hsl(120, 100%, 50%) and hsl(120deg 100% 50% / 0.5)
+      if (args.length !== 3 && args.length !== 4) return null;
+      const h = parseHue(args[0]!);
+      const s = parsePercentOrNumber(args[1]!, 1);
+      const l = parsePercentOrNumber(args[2]!, 1);
+      const a = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(h) || isNaN(s) || isNaN(l) || isNaN(a)) return null;
+
+      const rgb = hslToRgb(h, s, l);
+      return makeResult(rgb.r, rgb.g, rgb.b, a);
+    }
+    case 'hwb': {
+      // Supports hwb(120 0% 0% / 0.5)
+      if (args.length !== 3 && args.length !== 4) return null;
+      const h = parseHue(args[0]!);
+      const w = parsePercentOrNumber(args[1]!, 1);
+      const b = parsePercentOrNumber(args[2]!, 1);
+      const a = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(h) || isNaN(w) || isNaN(b) || isNaN(a)) return null;
+
+      const rgb = hwbToRgb(h, w, b);
+      return makeResult(rgb.r, rgb.g, rgb.b, a);
+    }
+    case 'lab': {
+      // lab(l a b / alpha)
+      if (args.length !== 3 && args.length !== 4) return null;
+      const l = parsePercentOrNumber(args[0]!, 100); // L is typically 0-100
+      const aVal = parseFloat(args[1]!);
+      const bVal = parseFloat(args[2]!);
+      const a = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(l) || isNaN(aVal) || isNaN(bVal) || isNaN(a)) return null;
+
+      const rgb = labToRgb(l, aVal, bVal);
+      return makeResult(rgb.r, rgb.g, rgb.b, a);
+    }
+    case 'lch': {
+      // lch(l c h / alpha)
+      if (args.length !== 3 && args.length !== 4) return null;
+      const l = parsePercentOrNumber(args[0]!, 100);
+      const c = parseFloat(args[1]!);
+      const h = parseHue(args[2]!);
+      const a = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(l) || isNaN(c) || isNaN(h) || isNaN(a)) return null;
+
+      const rgb = lchToRgb(l, c, h);
+      return makeResult(rgb.r, rgb.g, rgb.b, a);
+    }
+    case 'oklab': {
+      // oklab(l a b / alpha) - L is 0-1 or 0%-100%
+      if (args.length !== 3 && args.length !== 4) return null;
+      const l = parsePercentOrNumber(args[0]!, 1);
+      const aVal = parseFloat(args[1]!);
+      const bVal = parseFloat(args[2]!);
+      const a = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(l) || isNaN(aVal) || isNaN(bVal) || isNaN(a)) return null;
+
+      const rgb = oklabToRgb(l, aVal, bVal);
+      return makeResult(rgb.r, rgb.g, rgb.b, a);
+    }
+    case 'oklch': {
+      // oklch(l c h / alpha)
+      if (args.length !== 3 && args.length !== 4) return null;
+      const l = parsePercentOrNumber(args[0]!, 1);
+      const c = parseFloat(args[1]!);
+      const h = parseHue(args[2]!);
+      const a = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(l) || isNaN(c) || isNaN(h) || isNaN(a)) return null;
+
+      const rgb = oklchToRgb(l, c, h);
+      return makeResult(rgb.r, rgb.g, rgb.b, a);
+    }
+    case 'color-mix': {
+      // color-mix(in srgb, color1 percentage, color2 percentage)
+      // Let's split the inner tokens by comma at depth 0
+      const subArgs = splitByComma(clean.slice(10, -1));
+      if (subArgs.length !== 3) return null;
+
+      // SubArg 0: color space (e.g. "in srgb")
+      const spaceTokens = subArgs[0]!.trim().split(/\s+/);
+      if (spaceTokens.length !== 2 || spaceTokens[0] !== 'in' || spaceTokens[1] !== 'srgb') {
+        return null; // We only support "in srgb" blending standard
+      }
+
+      // SubArg 1: "<color1> [weight1]"
+      // SubArg 2: "<color2> [weight2]"
+      const parsed1 = parseColorWithWeight(subArgs[1]!);
+      const parsed2 = parseColorWithWeight(subArgs[2]!);
+      if (!parsed1 || !parsed2) return null;
+
+      const c1 = parseCssColor(parsed1.colorStr);
+      const c2 = parseCssColor(parsed2.colorStr);
+      if (!c1 || !c2) return null;
+
+      // Normalize weights
+      let w1 = parsed1.weight;
+      let w2 = parsed2.weight;
+
+      if (w1 === null && w2 === null) {
+        w1 = 50;
+        w2 = 50;
+      } else if (w1 !== null && w2 === null) {
+        w2 = 100 - w1;
+      } else if (w2 !== null && w1 === null) {
+        w1 = 100 - w2;
+      } else if (w1 !== null && w2 !== null) {
+        const sum = w1 + w2;
+        if (sum === 0) return null;
+        // Scale to sum to 100
+        w1 = (w1 / sum) * 100;
+        w2 = (w2 / sum) * 100;
+      }
+
+      // Convert weight to 0-1 range
+      const f1 = w1! / 100;
+      const f2 = w2! / 100;
+
+      // Blend components with premultiplied alpha
+      const a1 = c1.a !== undefined ? c1.a : 1;
+      const a2 = c2.a !== undefined ? c2.a : 1;
+
+      const aMix = a1 * f1 + a2 * f2;
+      let r = 0, g = 0, b = 0;
+
+      if (aMix > 0) {
+        r = Math.round((c1.r * a1 * f1 + c2.r * a2 * f2) / aMix);
+        g = Math.round((c1.g * a1 * f1 + c2.g * a2 * f2) / aMix);
+        b = Math.round((c1.b * a1 * f1 + c2.b * a2 * f2) / aMix);
+      }
+
+      return makeResult(
+        Math.max(0, Math.min(255, r)),
+        Math.max(0, Math.min(255, g)),
+        Math.max(0, Math.min(255, b)),
+        Math.max(0, Math.min(1, aMix))
+      );
+    }
+    default:
+      return null;
+  }
+}
+
+// ── Parsing internal utilities ─────────────────────────────────────
+
+function parseHex(hexStr: string): ParsedColorResult {
+  let hex = hexStr;
+  if (hex.length === 4) {
+    hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  } else if (hex.length === 5) {
+    hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}${hex[4]}${hex[4]}`;
+  }
+
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+
+  let a: number | undefined;
+  if (hex.length === 9) {
+    a = parseInt(hex.slice(7, 9), 16) / 255;
+  }
+
+  return makeResult(r, g, b, a);
+}
+
+function makeResult(r: number, g: number, b: number, a?: number): ParsedColorResult {
+  // Compute hex string
+  const hexR = r.toString(16).padStart(2, '0');
+  const hexG = g.toString(16).padStart(2, '0');
+  const hexB = b.toString(16).padStart(2, '0');
+  
+  let hex = `#${hexR}${hexG}${hexB}`;
+  if (a !== undefined && a < 1) {
+    const hexA = Math.round(a * 255).toString(16).padStart(2, '0');
+    hex += hexA;
+  }
+
+  const luminance = computeLuminance(r, g, b);
+
+  return { hex, r, g, b, a, luminance };
+}
+
+function computeLuminance(r: number, g: number, b: number): number {
+  const linearize = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+function parseHue(s: string): number {
+  const lower = s.trim().toLowerCase();
+  let val = 0;
+  if (lower.endsWith('deg')) {
+    val = parseFloat(lower.slice(0, -3));
+  } else if (lower.endsWith('rad')) {
+    val = (parseFloat(lower.slice(0, -3)) * 180) / Math.PI;
+  } else if (lower.endsWith('grad')) {
+    val = (parseFloat(lower.slice(0, -4)) * 360) / 400;
+  } else if (lower.endsWith('turn')) {
+    val = parseFloat(lower.slice(0, -4)) * 360;
+  } else {
+    val = parseFloat(lower);
+  }
+  val = val % 360;
+  if (val < 0) val += 360;
+  return val;
+}
+
+function parsePercentOrNumber(s: string, refMax: number): number {
+  const trim = s.trim();
+  if (trim.endsWith('%')) {
+    return (parseFloat(trim.slice(0, -1)) / 100) * refMax;
+  }
+  return parseFloat(trim);
+}
+
+function parseAlpha(s: string | undefined): number {
+  if (s === undefined) return 1;
+  const trim = s.trim();
+  if (trim.endsWith('%')) {
+    return parseFloat(trim.slice(0, -1)) / 100;
+  }
+  return parseFloat(trim);
+}
+
+function tokenizeFunc(str: string): { name: string; args: string[] } | null {
+  const match = str.trim().match(/^([a-z-]{3,15})\((.*)\)$/i);
+  if (!match) return null;
+  const name = match[1]!.toLowerCase();
+  const inner = match[2]!.trim();
+
+  let coordStr = inner;
+  let alphaStr: string | undefined = undefined;
+
+  // Parenthesis-aware search for the first depth-0 '/' division
+  let slantIndex = -1;
+  let depth = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const char = inner[i];
+    if (char === '(') depth++;
+    else if (char === ')') depth--;
+    else if (depth === 0 && char === '/') {
+      slantIndex = i;
+      break;
+    }
+  }
+
+  if (slantIndex !== -1) {
+    coordStr = inner.slice(0, slantIndex).trim();
+    alphaStr = inner.slice(slantIndex + 1).trim();
+  }
+
+  // Split coordinate parameters
+  const args = splitList(coordStr);
+  if (alphaStr !== undefined) {
+    args.push(alphaStr);
+  }
+
+  return { name, args };
+}
+
+/**
+ * Split a space/comma separated parameter coordinates list, ignoring nested parens
+ */
+function splitList(str: string): string[] {
+  const results: string[] = [];
+  let current = '';
+  let depth = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+    if (char === '(') {
+      depth++;
+      current += char;
+    } else if (char === ')') {
+      depth--;
+      current += char;
+    } else if (depth === 0 && (char === ',' || /\s/.test(char))) {
+      if (current.trim()) {
+        results.push(current.trim());
+        current = '';
+      }
+    } else {
+      current += char;
+    }
+  }
+  if (current.trim()) {
+    results.push(current.trim());
+  }
+  return results;
+}
+
+function splitByComma(str: string): string[] {
+  const results: string[] = [];
+  let current = '';
+  let depth = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+    if (char === '(') {
+      depth++;
+      current += char;
+    } else if (char === ')') {
+      depth--;
+      current += char;
+    } else if (depth === 0 && char === ',') {
+      results.push(current.trim());
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  if (current.trim()) {
+    results.push(current.trim());
+  }
+  return results;
+}
+
+function parseColorWithWeight(subArg: string): { colorStr: string; weight: number | null } | null {
+  // This parses strings like "red 20%" or "20% red" or "rgb(255, 0, 0)"
+  const parts = splitList(subArg.trim());
+  if (parts.length === 0 || parts.length > 2) return null;
+
+  if (parts.length === 1) {
+    return { colorStr: parts[0]!, weight: null };
+  }
+
+  // Identify which item is the percentage
+  const p0 = parts[0]!;
+  const p1 = parts[1]!;
+
+  const isP0Weight = p0.endsWith('%') || (!isNaN(Number(p0)) && p0 !== '');
+  const isP1Weight = p1.endsWith('%') || (!isNaN(Number(p1)) && p1 !== '');
+
+  if (isP0Weight && !isP1Weight) {
+    const w = p0.endsWith('%') ? parseFloat(p0.slice(0, -1)) : parseFloat(p0) * 100;
+    return { colorStr: p1, weight: w };
+  } else if (isP1Weight && !isP0Weight) {
+    const w = p1.endsWith('%') ? parseFloat(p1.slice(0, -1)) : parseFloat(p1) * 100;
+    return { colorStr: p0, weight: w };
+  }
+
+  return null;
+}
+
+// ── Chromatic conversions logic module ────────────────────────────
+
+function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: number } {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+
+  let r_ = 0, g_ = 0, b_ = 0;
+  if (h < 60) {
+    r_ = c; g_ = x; b_ = 0;
+  } else if (h < 120) {
+    r_ = x; g_ = c; b_ = 0;
+  } else if (h < 180) {
+    r_ = 0; g_ = c; b_ = x;
+  } else if (h < 240) {
+    r_ = 0; g_ = x; b_ = c;
+  } else if (h < 300) {
+    r_ = x; g_ = 0; b_ = c;
+  } else {
+    r_ = c; g_ = 0; b_ = x;
+  }
+
+  return {
+    r: Math.max(0, Math.min(255, Math.round((r_ + m) * 255))),
+    g: Math.max(0, Math.min(255, Math.round((g_ + m) * 255))),
+    b: Math.max(0, Math.min(255, Math.round((b_ + m) * 255))),
+  };
+}
+
+function hwbToRgb(h: number, w: number, b: number): { r: number; g: number; b: number } {
+  if (w + b >= 1) {
+    const sum = w + b;
+    const val = Math.max(0, Math.min(255, Math.round((w / sum) * 255)));
+    return { r: val, g: val, b: val };
+  }
+
+  const pure = hslToRgb(h, 1, 0.5);
+  
+  const r = Math.round((pure.r / 255) * (1 - w - b) * 255 + w * 255);
+  const g = Math.round((pure.g / 255) * (1 - w - b) * 255 + w * 255);
+  const bVal = Math.round((pure.b / 255) * (1 - w - b) * 255 + w * 255);
+  
+  return {
+    r: Math.max(0, Math.min(255, r)),
+    g: Math.max(0, Math.min(255, g)),
+    b: Math.max(0, Math.min(255, bVal)),
+  };
+}
+
+function labToRgb(l: number, a: number, b: number): { r: number; g: number; b: number } {
+  // Convert Lab to D50 XYZ
+  const fy = (l + 16) / 116;
+  const fx = a / 500 + fy;
+  const fz = fy - b / 200;
+
+  const e = 216 / 24389;
+  const k = 24389 / 27;
+
+  const fx3 = fx * fx * fx;
+  const fz3 = fz * fz * fz;
+
+  const xr = fx3 > e ? fx3 : (116 * fx - 16) / k;
+  const yr = l > k * e ? fy * fy * fy : l / k;
+  const zr = fz3 > e ? fz3 : (116 * fz - 16) / k;
+
+  // D50 White point
+  const Xn = 0.96422;
+  const Yn = 1.0;
+  const Zn = 0.82521;
+
+  const x = xr * Xn;
+  const y = yr * Yn;
+  const z = zr * Zn;
+
+  // Convert D50 XYZ to D65 XYZ via Bradford chromatic adaptation
+  const x65 = 0.9555726312052288 * x - 0.02303316850884054 * y + 0.06316100215997244 * z;
+  const y65 = -0.02828971739420664 * x + 1.0099416310812543 * y + 0.021007716449297163 * z;
+  const z65 = 0.012298224741016325 * x - 0.02048298287477757 * y + 1.3299098463422234 * z;
+
+  // Convert D65 XYZ to Linear sRGB
+  const r_lin = 3.2404542 * x65 - 1.5371385 * y65 - 0.4985314 * z65;
+  const g_lin = -0.9692660 * x65 + 1.8760108 * y65 + 0.0415560 * z65;
+  const b_lin = 0.0556434 * x65 - 0.2040259 * y65 + 1.0572252 * z65;
+
+  // Convert Linear sRGB to sRGB via standard gamma correction
+  const gamma = (val: number) => {
+    return val <= 0.0031308 ? 12.92 * val : 1.055 * Math.pow(val, 1 / 2.4) - 0.055;
+  };
+
+  return {
+    r: Math.max(0, Math.min(255, Math.round(gamma(r_lin) * 255))),
+    g: Math.max(0, Math.min(255, Math.round(gamma(g_lin) * 255))),
+    b: Math.max(0, Math.min(255, Math.round(gamma(b_lin) * 255))),
+  };
+}
+
+function lchToRgb(l: number, c: number, h: number): { r: number; g: number; b: number } {
+  const hRad = (h * Math.PI) / 180;
+  const a = c * Math.cos(hRad);
+  const b = c * Math.sin(hRad);
+  return labToRgb(l, a, b);
+}
+
+function oklabToRgb(l: number, a: number, b: number): { r: number; g: number; b: number } {
+  const l_ = l + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = l - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = l - 0.0894841775 * a - 1.2914855480 * b;
+
+  const l3 = l_ * l_ * l_;
+  const m3 = m_ * m_ * m_;
+  const s3 = s_ * s_ * s_;
+
+  const r_lin = +4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3;
+  const g_lin = -1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3;
+  const b_lin = -0.0041960863 * l3 - 0.7034186147 * m3 + 1.7076147010 * s3;
+
+  const gamma = (val: number) => {
+    return val <= 0.0031308 ? 12.92 * val : 1.055 * Math.pow(val, 1 / 2.4) - 0.055;
+  };
+
+  return {
+    r: Math.max(0, Math.min(255, Math.round(gamma(r_lin) * 255))),
+    g: Math.max(0, Math.min(255, Math.round(gamma(g_lin) * 255))),
+    b: Math.max(0, Math.min(255, Math.round(gamma(b_lin) * 255))),
+  };
+}
+
+function oklchToRgb(l: number, c: number, h: number): { r: number; g: number; b: number } {
+  const hRad = (h * Math.PI) / 180;
+  const a = c * Math.cos(hRad);
+  const b = c * Math.sin(hRad);
+  return oklabToRgb(l, a, b);
+}

--- a/packages/cli/src/linter/model/color-parser.ts
+++ b/packages/cli/src/linter/model/color-parser.ts
@@ -60,6 +60,7 @@ const CSS_NAMED_COLORS: Record<string, string> = {
  * Returns null if the color is invalid.
  */
 export function parseCssColor(colorStr: string): ParsedColorResult | null {
+  if (typeof colorStr !== 'string') return null;
   const clean = colorStr.trim().toLowerCase();
   if (!clean) return null;
 

--- a/packages/cli/src/linter/model/color-parser.ts
+++ b/packages/cli/src/linter/model/color-parser.ts
@@ -306,10 +306,10 @@ function parseHue(s: string): number {
   let val = 0;
   if (lower.endsWith('deg')) {
     val = parseFloat(lower.slice(0, -3));
-  } else if (lower.endsWith('rad')) {
-    val = (parseFloat(lower.slice(0, -3)) * 180) / Math.PI;
   } else if (lower.endsWith('grad')) {
     val = (parseFloat(lower.slice(0, -4)) * 360) / 400;
+  } else if (lower.endsWith('rad')) {
+    val = (parseFloat(lower.slice(0, -3)) * 180) / Math.PI;
   } else if (lower.endsWith('turn')) {
     val = parseFloat(lower.slice(0, -4)) * 360;
   } else {
@@ -437,19 +437,17 @@ function parseColorWithWeight(subArg: string): { colorStr: string; weight: numbe
     return { colorStr: parts[0]!, weight: null };
   }
 
-  // Identify which item is the percentage
+  // CSS color-mix weights are percentages only; a bare number is not a valid weight.
   const p0 = parts[0]!;
   const p1 = parts[1]!;
 
-  const isP0Weight = p0.endsWith('%') || (!isNaN(Number(p0)) && p0 !== '');
-  const isP1Weight = p1.endsWith('%') || (!isNaN(Number(p1)) && p1 !== '');
+  const isP0Weight = p0.endsWith('%');
+  const isP1Weight = p1.endsWith('%');
 
   if (isP0Weight && !isP1Weight) {
-    const w = p0.endsWith('%') ? parseFloat(p0.slice(0, -1)) : parseFloat(p0) * 100;
-    return { colorStr: p1, weight: w };
+    return { colorStr: p1, weight: parseFloat(p0.slice(0, -1)) };
   } else if (isP1Weight && !isP0Weight) {
-    const w = p1.endsWith('%') ? parseFloat(p1.slice(0, -1)) : parseFloat(p1) * 100;
-    return { colorStr: p0, weight: w };
+    return { colorStr: p0, weight: parseFloat(p1.slice(0, -1)) };
   }
 
   return null;

--- a/packages/cli/src/linter/model/color-parser.ts
+++ b/packages/cli/src/linter/model/color-parser.ts
@@ -56,11 +56,18 @@ const CSS_NAMED_COLORS: Record<string, string> = {
 };
 
 /**
+ * Maximum nesting depth for recursive color-mix() resolution. Guards against
+ * stack exhaustion from pathologically nested, attacker-supplied color values.
+ */
+const MAX_COLOR_MIX_DEPTH = 32;
+
+/**
  * Parse a CSS color string into its sRGB representation + WCAG relative luminance.
  * Returns null if the color is invalid.
  */
-export function parseCssColor(colorStr: string): ParsedColorResult | null {
+export function parseCssColor(colorStr: string, depth = 0): ParsedColorResult | null {
   if (typeof colorStr !== 'string') return null;
+  if (depth > MAX_COLOR_MIX_DEPTH) return null;
   const clean = colorStr.trim().toLowerCase();
   if (!clean) return null;
 
@@ -202,8 +209,8 @@ export function parseCssColor(colorStr: string): ParsedColorResult | null {
       const parsed2 = parseColorWithWeight(subArgs[2]!);
       if (!parsed1 || !parsed2) return null;
 
-      const c1 = parseCssColor(parsed1.colorStr);
-      const c2 = parseCssColor(parsed2.colorStr);
+      const c1 = parseCssColor(parsed1.colorStr, depth + 1);
+      const c2 = parseCssColor(parsed2.colorStr, depth + 1);
       if (!c1 || !c2) return null;
 
       // Normalize weights

--- a/packages/cli/src/linter/model/color-parser.ts
+++ b/packages/cli/src/linter/model/color-parser.ts
@@ -1,0 +1,595 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export interface ParsedColorResult {
+  hex: string;
+  r: number;
+  g: number;
+  b: number;
+  a?: number;
+  luminance: number;
+}
+
+const CSS_NAMED_COLORS: Record<string, string> = {
+  aliceblue: '#f0f8ff', antiquewhite: '#faebd7', aqua: '#00ffff', aquamarine: '#7fffd4', azure: '#f0ffff',
+  beige: '#f5f5dc', bisque: '#ffe4c4', black: '#000000', blanchedalmond: '#ffebcd', blue: '#0000ff',
+  blueviolet: '#8a2be2', brown: '#a52a2a', burlywood: '#deb887', cadetblue: '#5f9ea0', chartreuse: '#7fff00',
+  chocolate: '#d2691e', coral: '#ff7f50', cornflowerblue: '#6495ed', cornsilk: '#fff8dc', crimson: '#dc143c',
+  cyan: '#00ffff', darkblue: '#00008b', darkcyan: '#008b8b', darkgoldenrod: '#b8860b', darkgray: '#a9a9a9',
+  darkgrey: '#a9a9a9', darkgreen: '#006400', darkkhaki: '#bdb76b', darkmagenta: '#8b008b', darkolivegreen: '#556b2f',
+  darkorange: '#ff8c00', darkorchid: '#9932cc', darkred: '#8b0000', darksalmon: '#e9967a', darkseagreen: '#8fbc8f',
+  darkslateblue: '#483d8b', darkslategrey: '#2f4f4f', darkslategray: '#2f4f4f', darkturquoise: '#00ced1',
+  darkviolet: '#9400d3', deeppink: '#ff1493', deepskyblue: '#00bfff', dimgray: '#696969', dimgrey: '#696969',
+  dodgerblue: '#1e90ff', firebrick: '#b22222', floralwhite: '#fffaf0', forestgreen: '#228b22', fuchsia: '#ff00ff',
+  gainsboro: '#dcdcdc', ghostwhite: '#f8f8ff', gold: '#ffd700', goldenrod: '#daa520', gray: '#808080',
+  grey: '#808080', green: '#008000', greenyellow: '#adff2f', honeydew: '#f0fff0', hotpink: '#ff69b4',
+  indianred: '#cd5c5c', indigo: '#4b0082', ivory: '#fffff0', khaki: '#f0e68c', lavender: '#e6e6fa',
+  lavenderblush: '#fff0f5', lawngreen: '#7cfc00', lemonchiffon: '#fffacd', lightblue: '#add8e6', lightcoral: '#f08080',
+  lightcyan: '#e0ffff', lightgoldenrodyellow: '#fafad2', lightgray: '#d3d3d3', lightgrey: '#d3d3d3', lightgreen: '#90ee90',
+  lightpink: '#ffb6c1', lightsalmon: '#ffa07a', lightseagreen: '#20b2aa', lightskyblue: '#87cefa', lightslate: '#778899',
+  lightslategray: '#778899', lightslategrey: '#778899', lightsteelblue: '#b0c4de', lightyellow: '#ffffe0', lime: '#00ff00',
+  limegreen: '#32cd32', linen: '#faf0e6', magenta: '#ff00ff', maroon: '#800000',
+  mediumaquamarine: '#66cdaa', mediumblue: '#0000cd', mediumorchid: '#ba55d3', mediumpurple: '#9370db', mediumseagreen: '#3cb371',
+  mediumslateblue: '#7b68ee', mediumspringgreen: '#00fa9a', mediumturquoise: '#48d1cc', mediumvioletred: '#c71585', midnightblue: '#191970',
+  mintcream: '#f5fffa', mistyrose: '#ffe4e1', moccasin: '#ffe4b5', navajowhite: '#ffdead', navy: '#000080',
+  oldlace: '#fdf5e6', olive: '#808000', olivedrab: '#6b8e23', orange: '#ffa500', orangered: '#ff4500',
+  orchid: '#da70d6', palegoldenrod: '#eee8aa', palegreen: '#98fb98', paleturquoise: '#afeeee', palevioletred: '#db7093',
+  papayawhip: '#ffefd5', peachpuff: '#ffdab9', peru: '#cd853f', pink: '#ffc0cb', plum: '#dda0dd',
+  powderblue: '#b0e0e6', purple: '#800080', rebeccapurple: '#663399', red: '#ff0000', rosybrown: '#bc8f8f',
+  royalblue: '#4169e1', saddlebrown: '#8b4513', salmon: '#fa8072', sandybrown: '#f4a460', seagreen: '#2e8b57',
+  seashell: '#fff5ee', sienna: '#a0522d', silver: '#c0c0c0', skyblue: '#87ceeb', slateblue: '#6a5acd',
+  slategray: '#708090', slategrey: '#708090', snow: '#fffafa', springgreen: '#00ff7f', steelblue: '#4682b4',
+  tan: '#d2b48c', teal: '#008080', thistle: '#d8bfd8', tomato: '#ff6347', turquoise: '#40e0d0',
+  violet: '#ee82ee', wheat: '#f5deb3', white: '#ffffff', whitesmoke: '#f5f5f5', yellow: '#ffff00',
+  yellowgreen: '#9acd32', transparent: '#00000000',
+};
+
+/**
+ * Maximum nesting depth for recursive color-mix() resolution. Guards against
+ * stack exhaustion from pathologically nested, attacker-supplied color values.
+ */
+const MAX_COLOR_MIX_DEPTH = 32;
+
+/**
+ * Parse a CSS color string into its sRGB representation + WCAG relative luminance.
+ * Returns null if the color is invalid.
+ */
+export function parseCssColor(colorStr: string, depth = 0): ParsedColorResult | null {
+  if (typeof colorStr !== 'string') return null;
+  if (depth > MAX_COLOR_MIX_DEPTH) return null;
+  const clean = colorStr.trim().toLowerCase();
+  if (!clean) return null;
+
+  // 1. Hex Color Pattern
+  if (clean.startsWith('#')) {
+    if (!/^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/.test(clean)) {
+      return null;
+    }
+    return parseHex(clean);
+  }
+
+  // 2. Named Colors lookup
+  if (Object.prototype.hasOwnProperty.call(CSS_NAMED_COLORS, clean)) {
+    return parseHex(CSS_NAMED_COLORS[clean]!);
+  }
+
+  // 3. Functional notations parse
+  const parsedFunc = tokenizeFunc(clean);
+  if (!parsedFunc) {
+    return null;
+  }
+
+  const { name, args } = parsedFunc;
+
+  switch (name) {
+    case 'rgb':
+    case 'rgba': {
+      // Supports rgb(255, 0, 0) and rgb(255 0 0 / 0.5)
+      // args could be: [r, g, b] or [r, g, b, a]
+      if (args.length !== 3 && args.length !== 4) return null;
+      const rRaw = parsePercentOrNumber(args[0]!, 255);
+      const gRaw = parsePercentOrNumber(args[1]!, 255);
+      const bRaw = parsePercentOrNumber(args[2]!, 255);
+      const aVal = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(rRaw) || isNaN(gRaw) || isNaN(bRaw) || isNaN(aVal)) return null;
+
+      const r = Math.max(0, Math.min(255, Math.round(rRaw)));
+      const g = Math.max(0, Math.min(255, Math.round(gRaw)));
+      const b = Math.max(0, Math.min(255, Math.round(bRaw)));
+      const a = Math.max(0, Math.min(1, aVal));
+
+      return makeResult(r, g, b, a);
+    }
+    case 'hsl':
+    case 'hsla': {
+      // Supports hsl(120, 100%, 50%) and hsl(120deg 100% 50% / 0.5)
+      if (args.length !== 3 && args.length !== 4) return null;
+      const h = parseHue(args[0]!);
+      const s = parsePercentOrNumber(args[1]!, 1);
+      const l = parsePercentOrNumber(args[2]!, 1);
+      const a = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(h) || isNaN(s) || isNaN(l) || isNaN(a)) return null;
+
+      const rgb = hslToRgb(h, s, l);
+      return makeResult(rgb.r, rgb.g, rgb.b, a);
+    }
+    case 'hwb': {
+      // Supports hwb(120 0% 0% / 0.5)
+      if (args.length !== 3 && args.length !== 4) return null;
+      const h = parseHue(args[0]!);
+      const w = parsePercentOrNumber(args[1]!, 1);
+      const b = parsePercentOrNumber(args[2]!, 1);
+      const a = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(h) || isNaN(w) || isNaN(b) || isNaN(a)) return null;
+
+      const rgb = hwbToRgb(h, w, b);
+      return makeResult(rgb.r, rgb.g, rgb.b, a);
+    }
+    case 'lab': {
+      // lab(l a b / alpha)
+      if (args.length !== 3 && args.length !== 4) return null;
+      const l = parsePercentOrNumber(args[0]!, 100); // L is typically 0-100
+      const aVal = parseFloat(args[1]!);
+      const bVal = parseFloat(args[2]!);
+      const a = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(l) || isNaN(aVal) || isNaN(bVal) || isNaN(a)) return null;
+
+      const rgb = labToRgb(l, aVal, bVal);
+      return makeResult(rgb.r, rgb.g, rgb.b, a);
+    }
+    case 'lch': {
+      // lch(l c h / alpha)
+      if (args.length !== 3 && args.length !== 4) return null;
+      const l = parsePercentOrNumber(args[0]!, 100);
+      const c = parseFloat(args[1]!);
+      const h = parseHue(args[2]!);
+      const a = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(l) || isNaN(c) || isNaN(h) || isNaN(a)) return null;
+
+      const rgb = lchToRgb(l, c, h);
+      return makeResult(rgb.r, rgb.g, rgb.b, a);
+    }
+    case 'oklab': {
+      // oklab(l a b / alpha) - L is 0-1 or 0%-100%
+      if (args.length !== 3 && args.length !== 4) return null;
+      const l = parsePercentOrNumber(args[0]!, 1);
+      const aVal = parseFloat(args[1]!);
+      const bVal = parseFloat(args[2]!);
+      const a = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(l) || isNaN(aVal) || isNaN(bVal) || isNaN(a)) return null;
+
+      const rgb = oklabToRgb(l, aVal, bVal);
+      return makeResult(rgb.r, rgb.g, rgb.b, a);
+    }
+    case 'oklch': {
+      // oklch(l c h / alpha)
+      if (args.length !== 3 && args.length !== 4) return null;
+      const l = parsePercentOrNumber(args[0]!, 1);
+      const c = parseFloat(args[1]!);
+      const h = parseHue(args[2]!);
+      const a = args.length === 4 ? parseAlpha(args[3]) : 1;
+
+      if (isNaN(l) || isNaN(c) || isNaN(h) || isNaN(a)) return null;
+
+      const rgb = oklchToRgb(l, c, h);
+      return makeResult(rgb.r, rgb.g, rgb.b, a);
+    }
+    case 'color-mix': {
+      // color-mix(in srgb, color1 percentage, color2 percentage)
+      // Let's split the inner tokens by comma at depth 0
+      const subArgs = splitByComma(clean.slice(10, -1));
+      if (subArgs.length !== 3) return null;
+
+      // SubArg 0: color space (e.g. "in srgb")
+      const spaceTokens = subArgs[0]!.trim().split(/\s+/);
+      if (spaceTokens.length !== 2 || spaceTokens[0] !== 'in' || spaceTokens[1] !== 'srgb') {
+        return null; // We only support "in srgb" blending standard
+      }
+
+      // SubArg 1: "<color1> [weight1]"
+      // SubArg 2: "<color2> [weight2]"
+      const parsed1 = parseColorWithWeight(subArgs[1]!);
+      const parsed2 = parseColorWithWeight(subArgs[2]!);
+      if (!parsed1 || !parsed2) return null;
+
+      const c1 = parseCssColor(parsed1.colorStr, depth + 1);
+      const c2 = parseCssColor(parsed2.colorStr, depth + 1);
+      if (!c1 || !c2) return null;
+
+      // Normalize weights
+      let w1 = parsed1.weight;
+      let w2 = parsed2.weight;
+
+      if (w1 === null && w2 === null) {
+        w1 = 50;
+        w2 = 50;
+      } else if (w1 !== null && w2 === null) {
+        w2 = 100 - w1;
+      } else if (w2 !== null && w1 === null) {
+        w1 = 100 - w2;
+      } else if (w1 !== null && w2 !== null) {
+        const sum = w1 + w2;
+        if (sum === 0) return null;
+        // Scale to sum to 100
+        w1 = (w1 / sum) * 100;
+        w2 = (w2 / sum) * 100;
+      }
+
+      // Convert weight to 0-1 range
+      const f1 = w1! / 100;
+      const f2 = w2! / 100;
+
+      // Blend components with premultiplied alpha
+      const a1 = c1.a !== undefined ? c1.a : 1;
+      const a2 = c2.a !== undefined ? c2.a : 1;
+
+      const aMix = a1 * f1 + a2 * f2;
+      let r = 0, g = 0, b = 0;
+
+      if (aMix > 0) {
+        r = Math.round((c1.r * a1 * f1 + c2.r * a2 * f2) / aMix);
+        g = Math.round((c1.g * a1 * f1 + c2.g * a2 * f2) / aMix);
+        b = Math.round((c1.b * a1 * f1 + c2.b * a2 * f2) / aMix);
+      }
+
+      return makeResult(
+        Math.max(0, Math.min(255, r)),
+        Math.max(0, Math.min(255, g)),
+        Math.max(0, Math.min(255, b)),
+        Math.max(0, Math.min(1, aMix))
+      );
+    }
+    default:
+      return null;
+  }
+}
+
+// ── Parsing internal utilities ─────────────────────────────────────
+
+function parseHex(hexStr: string): ParsedColorResult {
+  let hex = hexStr;
+  if (hex.length === 4) {
+    hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  } else if (hex.length === 5) {
+    hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}${hex[4]}${hex[4]}`;
+  }
+
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+
+  let a: number | undefined;
+  if (hex.length === 9) {
+    a = parseInt(hex.slice(7, 9), 16) / 255;
+  }
+
+  return makeResult(r, g, b, a);
+}
+
+function makeResult(r: number, g: number, b: number, a?: number): ParsedColorResult {
+  // Compute hex string
+  const hexR = r.toString(16).padStart(2, '0');
+  const hexG = g.toString(16).padStart(2, '0');
+  const hexB = b.toString(16).padStart(2, '0');
+  
+  let hex = `#${hexR}${hexG}${hexB}`;
+  if (a !== undefined && a < 1) {
+    const hexA = Math.round(a * 255).toString(16).padStart(2, '0');
+    hex += hexA;
+  }
+
+  const luminance = computeLuminance(r, g, b);
+
+  return { hex, r, g, b, a, luminance };
+}
+
+function computeLuminance(r: number, g: number, b: number): number {
+  const linearize = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+function parseHue(s: string): number {
+  const lower = s.trim().toLowerCase();
+  let val = 0;
+  if (lower.endsWith('deg')) {
+    val = parseFloat(lower.slice(0, -3));
+  } else if (lower.endsWith('grad')) {
+    val = (parseFloat(lower.slice(0, -4)) * 360) / 400;
+  } else if (lower.endsWith('rad')) {
+    val = (parseFloat(lower.slice(0, -3)) * 180) / Math.PI;
+  } else if (lower.endsWith('turn')) {
+    val = parseFloat(lower.slice(0, -4)) * 360;
+  } else {
+    val = parseFloat(lower);
+  }
+  val = val % 360;
+  if (val < 0) val += 360;
+  return val;
+}
+
+function parsePercentOrNumber(s: string, refMax: number): number {
+  const trim = s.trim();
+  if (trim.endsWith('%')) {
+    return (parseFloat(trim.slice(0, -1)) / 100) * refMax;
+  }
+  return parseFloat(trim);
+}
+
+function parseAlpha(s: string | undefined): number {
+  if (s === undefined) return 1;
+  const trim = s.trim();
+  if (trim.endsWith('%')) {
+    return parseFloat(trim.slice(0, -1)) / 100;
+  }
+  return parseFloat(trim);
+}
+
+function tokenizeFunc(str: string): { name: string; args: string[] } | null {
+  const match = str.trim().match(/^([a-z-]{3,15})\((.*)\)$/i);
+  if (!match) return null;
+  const name = match[1]!.toLowerCase();
+  const inner = match[2]!.trim();
+
+  let coordStr = inner;
+  let alphaStr: string | undefined = undefined;
+
+  // Parenthesis-aware search for the first depth-0 '/' division
+  let slantIndex = -1;
+  let depth = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const char = inner[i];
+    if (char === '(') depth++;
+    else if (char === ')') depth--;
+    else if (depth === 0 && char === '/') {
+      slantIndex = i;
+      break;
+    }
+  }
+
+  if (slantIndex !== -1) {
+    coordStr = inner.slice(0, slantIndex).trim();
+    alphaStr = inner.slice(slantIndex + 1).trim();
+  }
+
+  // Split coordinate parameters
+  const args = splitList(coordStr);
+  if (alphaStr !== undefined) {
+    args.push(alphaStr);
+  }
+
+  return { name, args };
+}
+
+/**
+ * Split a space/comma separated parameter coordinates list, ignoring nested parens
+ */
+function splitList(str: string): string[] {
+  const results: string[] = [];
+  let current = '';
+  let depth = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+    if (char === '(') {
+      depth++;
+      current += char;
+    } else if (char === ')') {
+      depth--;
+      current += char;
+    } else if (depth === 0 && (char === ',' || /\s/.test(char))) {
+      if (current.trim()) {
+        results.push(current.trim());
+        current = '';
+      }
+    } else {
+      current += char;
+    }
+  }
+  if (current.trim()) {
+    results.push(current.trim());
+  }
+  return results;
+}
+
+function splitByComma(str: string): string[] {
+  const results: string[] = [];
+  let current = '';
+  let depth = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+    if (char === '(') {
+      depth++;
+      current += char;
+    } else if (char === ')') {
+      depth--;
+      current += char;
+    } else if (depth === 0 && char === ',') {
+      results.push(current.trim());
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  if (current.trim()) {
+    results.push(current.trim());
+  }
+  return results;
+}
+
+function parseColorWithWeight(subArg: string): { colorStr: string; weight: number | null } | null {
+  // This parses strings like "red 20%" or "20% red" or "rgb(255, 0, 0)"
+  const parts = splitList(subArg.trim());
+  if (parts.length === 0 || parts.length > 2) return null;
+
+  if (parts.length === 1) {
+    return { colorStr: parts[0]!, weight: null };
+  }
+
+  // CSS color-mix weights are percentages only; a bare number is not a valid weight.
+  const p0 = parts[0]!;
+  const p1 = parts[1]!;
+
+  const isP0Weight = p0.endsWith('%');
+  const isP1Weight = p1.endsWith('%');
+
+  if (isP0Weight && !isP1Weight) {
+    return { colorStr: p1, weight: parseFloat(p0.slice(0, -1)) };
+  } else if (isP1Weight && !isP0Weight) {
+    return { colorStr: p0, weight: parseFloat(p1.slice(0, -1)) };
+  }
+
+  return null;
+}
+
+// ── Chromatic conversions logic module ────────────────────────────
+
+function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: number } {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+
+  let r_ = 0, g_ = 0, b_ = 0;
+  if (h < 60) {
+    r_ = c; g_ = x; b_ = 0;
+  } else if (h < 120) {
+    r_ = x; g_ = c; b_ = 0;
+  } else if (h < 180) {
+    r_ = 0; g_ = c; b_ = x;
+  } else if (h < 240) {
+    r_ = 0; g_ = x; b_ = c;
+  } else if (h < 300) {
+    r_ = x; g_ = 0; b_ = c;
+  } else {
+    r_ = c; g_ = 0; b_ = x;
+  }
+
+  return {
+    r: Math.max(0, Math.min(255, Math.round((r_ + m) * 255))),
+    g: Math.max(0, Math.min(255, Math.round((g_ + m) * 255))),
+    b: Math.max(0, Math.min(255, Math.round((b_ + m) * 255))),
+  };
+}
+
+function hwbToRgb(h: number, w: number, b: number): { r: number; g: number; b: number } {
+  if (w + b >= 1) {
+    const sum = w + b;
+    const val = Math.max(0, Math.min(255, Math.round((w / sum) * 255)));
+    return { r: val, g: val, b: val };
+  }
+
+  const pure = hslToRgb(h, 1, 0.5);
+  
+  const r = Math.round((pure.r / 255) * (1 - w - b) * 255 + w * 255);
+  const g = Math.round((pure.g / 255) * (1 - w - b) * 255 + w * 255);
+  const bVal = Math.round((pure.b / 255) * (1 - w - b) * 255 + w * 255);
+  
+  return {
+    r: Math.max(0, Math.min(255, r)),
+    g: Math.max(0, Math.min(255, g)),
+    b: Math.max(0, Math.min(255, bVal)),
+  };
+}
+
+function labToRgb(l: number, a: number, b: number): { r: number; g: number; b: number } {
+  // Convert Lab to D50 XYZ
+  const fy = (l + 16) / 116;
+  const fx = a / 500 + fy;
+  const fz = fy - b / 200;
+
+  const e = 216 / 24389;
+  const k = 24389 / 27;
+
+  const fx3 = fx * fx * fx;
+  const fz3 = fz * fz * fz;
+
+  const xr = fx3 > e ? fx3 : (116 * fx - 16) / k;
+  const yr = l > k * e ? fy * fy * fy : l / k;
+  const zr = fz3 > e ? fz3 : (116 * fz - 16) / k;
+
+  // D50 White point
+  const Xn = 0.96422;
+  const Yn = 1.0;
+  const Zn = 0.82521;
+
+  const x = xr * Xn;
+  const y = yr * Yn;
+  const z = zr * Zn;
+
+  // Convert D50 XYZ to D65 XYZ via Bradford chromatic adaptation
+  const x65 = 0.9555726312052288 * x - 0.02303316850884054 * y + 0.06316100215997244 * z;
+  const y65 = -0.02828971739420664 * x + 1.0099416310812543 * y + 0.021007716449297163 * z;
+  const z65 = 0.012298224741016325 * x - 0.02048298287477757 * y + 1.3299098463422234 * z;
+
+  // Convert D65 XYZ to Linear sRGB
+  const r_lin = 3.2404542 * x65 - 1.5371385 * y65 - 0.4985314 * z65;
+  const g_lin = -0.9692660 * x65 + 1.8760108 * y65 + 0.0415560 * z65;
+  const b_lin = 0.0556434 * x65 - 0.2040259 * y65 + 1.0572252 * z65;
+
+  // Convert Linear sRGB to sRGB via standard gamma correction
+  const gamma = (val: number) => {
+    return val <= 0.0031308 ? 12.92 * val : 1.055 * Math.pow(val, 1 / 2.4) - 0.055;
+  };
+
+  return {
+    r: Math.max(0, Math.min(255, Math.round(gamma(r_lin) * 255))),
+    g: Math.max(0, Math.min(255, Math.round(gamma(g_lin) * 255))),
+    b: Math.max(0, Math.min(255, Math.round(gamma(b_lin) * 255))),
+  };
+}
+
+function lchToRgb(l: number, c: number, h: number): { r: number; g: number; b: number } {
+  const hRad = (h * Math.PI) / 180;
+  const a = c * Math.cos(hRad);
+  const b = c * Math.sin(hRad);
+  return labToRgb(l, a, b);
+}
+
+function oklabToRgb(l: number, a: number, b: number): { r: number; g: number; b: number } {
+  const l_ = l + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = l - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = l - 0.0894841775 * a - 1.2914855480 * b;
+
+  const l3 = l_ * l_ * l_;
+  const m3 = m_ * m_ * m_;
+  const s3 = s_ * s_ * s_;
+
+  const r_lin = +4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3;
+  const g_lin = -1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3;
+  const b_lin = -0.0041960863 * l3 - 0.7034186147 * m3 + 1.7076147010 * s3;
+
+  const gamma = (val: number) => {
+    return val <= 0.0031308 ? 12.92 * val : 1.055 * Math.pow(val, 1 / 2.4) - 0.055;
+  };
+
+  return {
+    r: Math.max(0, Math.min(255, Math.round(gamma(r_lin) * 255))),
+    g: Math.max(0, Math.min(255, Math.round(gamma(g_lin) * 255))),
+    b: Math.max(0, Math.min(255, Math.round(gamma(b_lin) * 255))),
+  };
+}
+
+function oklchToRgb(l: number, c: number, h: number): { r: number; g: number; b: number } {
+  const hRad = (h * Math.PI) / 180;
+  const a = c * Math.cos(hRad);
+  const b = c * Math.sin(hRad);
+  return oklabToRgb(l, a, b);
+}

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -356,4 +356,66 @@ describe('ModelHandler', () => {
       }
     });
   });
+
+  // ── Fix #42: numeric component props crash model builder ──────────
+  describe('numeric component property values', () => {
+    it('does not crash when fontWeight is a bare number', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#000000' },
+        components: {
+          'button-primary': {
+            backgroundColor: '{colors.primary}',
+            fontWeight: 600 as unknown as string,
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const btn = result.designSystem.components.get('button-primary');
+      expect(btn).toBeDefined();
+      expect(btn?.properties.get('fontWeight')).toBe(600);
+    });
+
+    it('stores numeric fontWeight value as-is in component properties', () => {
+      const result = handler.execute(makeParsed({
+        components: {
+          'heading': {
+            fontWeight: 700 as unknown as string,
+          },
+        },
+      }));
+      const heading = result.designSystem.components.get('heading');
+      expect(heading?.properties.get('fontWeight')).toBe(700);
+    });
+
+    it('does not crash when borderWidth is a bare number', () => {
+      const result = handler.execute(makeParsed({
+        components: {
+          'card': {
+            borderWidth: 1 as unknown as string,
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const card = result.designSystem.components.get('card');
+      expect(card?.properties.get('borderWidth')).toBe(1);
+    });
+
+    it('handles mixed numeric and string props in same component without crashing', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#ff0000' },
+        spacing: { md: '16px' },
+        components: {
+          'button': {
+            fontWeight: 600 as unknown as string,
+            backgroundColor: '{colors.primary}',
+            padding: '{spacing.md}',
+            borderRadius: '4px',
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const btn = result.designSystem.components.get('button');
+      expect(btn?.properties.get('fontWeight')).toBe(600);
+    });
+  });
 });

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -218,6 +218,25 @@ describe('ModelHandler', () => {
       expect(mix2?.g).toBe(128);
       expect(mix2?.b).toBe(128);
     });
+
+    it('parses grad hue units correctly (100grad === 90deg)', () => {
+      const result = handler.execute(makeParsed({
+        colors: { grad: 'hsl(100grad 100% 50%)', deg: 'hsl(90deg 100% 50%)' },
+      }));
+      expect(result.findings.length).toBe(0);
+      const grad = result.designSystem.colors.get('grad');
+      expect(grad?.hex).toBe('#80ff00');
+      expect(grad?.hex).toBe(result.designSystem.colors.get('deg')?.hex);
+    });
+
+    it('rejects color-mix with bare-number (non-percentage) weights', () => {
+      const result = handler.execute(makeParsed({
+        colors: { bad: 'color-mix(in srgb, red 20, blue)' },
+      }));
+      // CSS color-mix weights are percentages only; a bare number is invalid.
+      expect(result.designSystem.colors.has('bad')).toBe(false);
+      expect(result.findings.some(f => f.path === 'colors.bad' && f.severity === 'error')).toBe(true);
+    });
   });
 
   // ── Cycle 10: Resolve single-level token reference ────────────────

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -475,6 +475,20 @@ describe('ModelHandler', () => {
       const headline = result.designSystem.typography.get('headline');
       expect(headline?.fontWeight).toBe(700);
     });
+
+    it('warns about unrecognized typography sub-properties that are silently dropped', () => {
+      const result = handler.execute(makeParsed({
+        typography: {
+          'headline': { fontFamily: 'Inter', textTransform: 'uppercase' },
+        },
+      }));
+      const warning = result.findings.find(f => f.path === 'typography.headline.textTransform');
+      expect(warning).toBeDefined();
+      expect(warning?.severity).toBe('warning');
+      // The recognized property is still resolved, and known props never warn.
+      expect(result.designSystem.typography.get('headline')?.fontFamily).toBe('Inter');
+      expect(result.findings.some(f => f.path === 'typography.headline.fontFamily')).toBe(false);
+    });
   });
 
   describe('rounded validation', () => {

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -684,4 +684,20 @@ describe('ModelHandler', () => {
       expect(result.designSystem.colors.has(path)).toBe(true);
     });
   });
+
+  describe('color-mix nesting depth limit', () => {
+    it('rejects pathologically nested color-mix as an invalid color without collapsing the model', () => {
+      let nested = 'red';
+      for (let i = 0; i < 50; i++) nested = `color-mix(in srgb, ${nested}, blue)`;
+      const result = handler.execute(makeParsed({
+        colors: { ok: '#ffffff', deep: nested },
+      }));
+      // The over-deep color resolves to "invalid" (a precise per-token error),
+      // not a thrown RangeError that collapses the whole model build.
+      expect(result.designSystem.colors.has('deep')).toBe(false);
+      expect(result.findings.some(f => f.path === 'colors.deep' && f.severity === 'error')).toBe(true);
+      // Other valid tokens are unaffected.
+      expect(result.designSystem.colors.get('ok')?.hex).toBe('#ffffff');
+    });
+  });
 });

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -506,4 +506,58 @@ describe('ModelHandler', () => {
       expect(btn?.properties.get('fontWeight')).toBe(600);
     });
   });
+
+  // ── Fix #75: non-string YAML scalars crash model builder ────────────
+  describe('non-string component property values (Issue #75)', () => {
+    it('does not crash when a component property is a float (opacity: 0.9)', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#FF0000', 'on-primary': '#FFFFFF' },
+        components: {
+          button: {
+            backgroundColor: '{colors.primary}',
+            textColor: '{colors.on-primary}',
+            opacity: 0.9 as unknown as string,
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const btn = result.designSystem.components.get('button');
+      expect(btn?.properties.get('opacity')).toBe(0.9);
+    });
+
+    it('does not crash when a component property is a boolean (visible: true)', () => {
+      const result = handler.execute(makeParsed({
+        components: {
+          banner: {
+            visible: true as unknown as string,
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const banner = result.designSystem.components.get('banner');
+      expect(banner?.properties.get('visible')).toBe(true);
+    });
+
+    it('handles mixed number, boolean, and string props without crashing', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#ff0000' },
+        components: {
+          card: {
+            backgroundColor: '{colors.primary}',
+            borderRadius: '8px',
+            fontWeight: 500 as unknown as string,
+            opacity: 0.85 as unknown as string,
+            visible: true as unknown as string,
+            disabled: false as unknown as string,
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const card = result.designSystem.components.get('card');
+      expect(card?.properties.get('fontWeight')).toBe(500);
+      expect(card?.properties.get('opacity')).toBe(0.85);
+      expect(card?.properties.get('visible')).toBe(true);
+      expect(card?.properties.get('disabled')).toBe(false);
+    });
+  });
 });

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -131,6 +131,96 @@ describe('ModelHandler', () => {
       expect(result.designSystem.symbolTable.has('colors.theme.surface.background.base')).toBe(true);
     });
 
+    it('emits diagnostic for duplicate token path in colors', () => {
+      const result = handler.execute(makeParsed({
+        colors: {
+          'utility-info': {
+            '50': '#111111',
+          },
+          'utility-info.50': '#222222',
+        },
+      }));
+      const errors = result.findings.filter(f => f.severity === 'error');
+      expect(errors.length).toBe(1);
+      expect(errors[0]!.path).toBe('colors.utility-info.50');
+      expect(errors[0]!.message).toBe("Duplicate token path 'colors.utility-info.50' detected.");
+    });
+
+    it('emits diagnostic when grouped color token flattens to an existing token name', () => {
+      const result = handler.execute(makeParsed({
+        colors: {
+          'utility-info-50': '#111111',
+          'utility-info': {
+            '50': '#222222',
+          }
+        },
+      }));
+      const errors = result.findings.filter(f => f.severity === 'error');
+      expect(errors.length).toBe(1);
+      expect(errors[0]!.path).toBe('colors.utility-info.50');
+      expect(errors[0]!.message).toBe("Grouped colors token flattens to 'utility-info-50', which is already defined.");
+    });
+
+    it('emits diagnostic for duplicate token path in rounded', () => {
+      const result = handler.execute(makeParsed({
+        rounded: {
+          'button': {
+            'lg': '8px',
+          },
+          'button.lg': '12px',
+        },
+      }));
+      const errors = result.findings.filter(f => f.severity === 'error');
+      expect(errors.length).toBe(1);
+      expect(errors[0]!.path).toBe('rounded.button.lg');
+      expect(errors[0]!.message).toBe("Duplicate token path 'rounded.button.lg' detected.");
+    });
+
+    it('emits diagnostic when grouped rounded token flattens to an existing token name', () => {
+      const result = handler.execute(makeParsed({
+        rounded: {
+          'button-lg': '8px',
+          'button': {
+            'lg': '12px',
+          }
+        },
+      }));
+      const errors = result.findings.filter(f => f.severity === 'error');
+      expect(errors.length).toBe(1);
+      expect(errors[0]!.path).toBe('rounded.button.lg');
+      expect(errors[0]!.message).toBe("Grouped rounded token flattens to 'button-lg', which is already defined.");
+    });
+
+    it('emits diagnostic for duplicate token path in spacing', () => {
+      const result = handler.execute(makeParsed({
+        spacing: {
+          'gutter': {
+            's': '8px',
+          },
+          'gutter.s': '12px',
+        },
+      }));
+      const errors = result.findings.filter(f => f.severity === 'error');
+      expect(errors.length).toBe(1);
+      expect(errors[0]!.path).toBe('spacing.gutter.s');
+      expect(errors[0]!.message).toBe("Duplicate token path 'spacing.gutter.s' detected.");
+    });
+
+    it('emits diagnostic when grouped spacing token flattens to an existing token name', () => {
+      const result = handler.execute(makeParsed({
+        spacing: {
+          'gutter-s': '8px',
+          'gutter': {
+            's': '12px',
+          }
+        },
+      }));
+      const errors = result.findings.filter(f => f.severity === 'error');
+      expect(errors.length).toBe(1);
+      expect(errors[0]!.path).toBe('spacing.gutter.s');
+      expect(errors[0]!.message).toBe("Grouped spacing token flattens to 'gutter-s', which is already defined.");
+    });
+
     it('resolves standard CSS named colors and converts them to hex/sRGB', () => {
       const result = handler.execute(makeParsed({
         colors: { c1: 'red', c2: 'transparent', c3: 'aliceblue' },

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -754,4 +754,168 @@ describe('ModelHandler', () => {
       expect(result.designSystem.symbolTable.get('voice.warmth')).toBe('4');
     });
   });
+  describe('numeric component property values', () => {
+    it('does not crash when fontWeight is a bare number', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#000000' },
+        components: {
+          'button-primary': {
+            backgroundColor: '{colors.primary}',
+            fontWeight: 600 as unknown as string,
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const btn = result.designSystem.components.get('button-primary');
+      expect(btn).toBeDefined();
+      expect(btn?.properties.get('fontWeight') as unknown).toBe('600');
+    });
+
+    it('stores numeric fontWeight value as-is in component properties', () => {
+      const result = handler.execute(makeParsed({
+        components: {
+          'heading': {
+            fontWeight: 700 as unknown as string,
+          },
+        },
+      }));
+      const heading = result.designSystem.components.get('heading');
+      expect(heading?.properties.get('fontWeight') as unknown).toBe('700');
+    });
+
+    it('does not crash when borderWidth is a bare number', () => {
+      const result = handler.execute(makeParsed({
+        components: {
+          'card': {
+            borderWidth: 1 as unknown as string,
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const card = result.designSystem.components.get('card');
+      expect(card?.properties.get('borderWidth') as unknown).toBe('1');
+    });
+
+    it('handles mixed numeric and string props in same component without crashing', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#ff0000' },
+        spacing: { md: '16px' },
+        components: {
+          'button': {
+            fontWeight: 600 as unknown as string,
+            backgroundColor: '{colors.primary}',
+            padding: '{spacing.md}',
+            borderRadius: '4px',
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const btn = result.designSystem.components.get('button');
+      expect(btn?.properties.get('fontWeight') as unknown).toBe('600');
+    });
+  });
+
+  describe('non-string component property values (Issue #75)', () => {
+    it('does not crash when a component property is a float (opacity: 0.9)', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#FF0000', 'on-primary': '#FFFFFF' },
+        components: {
+          button: {
+            backgroundColor: '{colors.primary}',
+            textColor: '{colors.on-primary}',
+            opacity: 0.9 as unknown as string,
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const btn = result.designSystem.components.get('button');
+      expect(btn?.properties.get('opacity') as unknown).toBe('0.9');
+    });
+
+    it('does not crash when a component property is a boolean (visible: true)', () => {
+      const result = handler.execute(makeParsed({
+        components: {
+          banner: {
+            visible: true as unknown as string,
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const banner = result.designSystem.components.get('banner');
+      expect(banner?.properties.get('visible') as unknown).toBe('true');
+    });
+
+    it('handles mixed number, boolean, and string props without crashing', () => {
+      const result = handler.execute(makeParsed({
+        colors: { primary: '#ff0000' },
+        components: {
+          card: {
+            backgroundColor: '{colors.primary}',
+            borderRadius: '8px',
+            fontWeight: 500 as unknown as string,
+            opacity: 0.85 as unknown as string,
+            visible: true as unknown as string,
+            disabled: false as unknown as string,
+          },
+        },
+      }));
+      expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
+      const card = result.designSystem.components.get('card');
+      expect(card?.properties.get('fontWeight') as unknown).toBe('500');
+      expect(card?.properties.get('opacity') as unknown).toBe('0.85');
+      expect(card?.properties.get('visible') as unknown).toBe('true');
+      expect(card?.properties.get('disabled') as unknown).toBe('false');
+    });
+  });
+
+  describe('token nesting depth limit', () => {
+    it('emits error when token nesting depth exceeds 20', () => {
+      // 22 levels: Level 1..21 are objects, Level 22 is a leaf.
+      // forEachLeaf will be called for Level 22 with depth 21.
+      let obj: any = '#ffffff';
+      for (let i = 22; i >= 1; i--) {
+        obj = { [`level${i}`]: obj };
+      }
+
+      const result = handler.execute(makeParsed({
+        colors: obj,
+      }));
+      expect(result.findings.some((f) => f.message.includes('nesting depth'))).toBe(true);
+      expect(result.findings.find((f) => f.message.includes('nesting depth'))?.path).toBe('colors');
+    });
+
+    it('allows nesting up to depth 20', () => {
+      // 21 levels: Level 1..20 are objects, Level 21 is a leaf.
+      // forEachLeaf will be called for Level 21 with depth 20.
+      let obj: any = '#ffffff';
+      for (let i = 21; i >= 1; i--) {
+        obj = { [`level${i}`]: obj };
+      }
+
+      const result = handler.execute(makeParsed({
+        colors: obj,
+      }));
+      expect(result.findings.some((f) => f.message.includes('nesting depth'))).toBe(false);
+      // Construct the expected path: level1.level2...level21
+      const path = Array.from({ length: 21 }, (_, i) => `level${i + 1}`).join('.');
+      expect(result.designSystem.colors.has(path)).toBe(true);
+    });
+  });
+
+  describe('color-mix nesting depth limit', () => {
+    it('rejects pathologically nested color-mix as an invalid color without collapsing the model', () => {
+      let nested = 'red';
+      for (let i = 0; i < 50; i++) nested = `color-mix(in srgb, ${nested}, blue)`;
+      const result = handler.execute(makeParsed({
+        colors: { ok: '#ffffff', deep: nested },
+      }));
+      // The over-deep color resolves to "invalid" (a precise per-token error),
+      // not a thrown RangeError that collapses the whole model build.
+      expect(result.designSystem.colors.has('deep')).toBe(false);
+      expect(result.findings.some(f => f.path === 'colors.deep' && f.severity === 'error')).toBe(true);
+      // Other valid tokens are unaffected.
+      expect(result.designSystem.colors.get('ok')?.hex).toBe('#ffffff');
+    });
+  });
+
 });

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -75,6 +75,94 @@ describe('ModelHandler', () => {
       expect(semitransparent?.hex).toBe('#ffffffa6');
       expect(semitransparent?.a).toBeCloseTo(166 / 255, 5);
     });
+
+    it('resolves standard CSS named colors and converts them to hex/sRGB', () => {
+      const result = handler.execute(makeParsed({
+        colors: { c1: 'red', c2: 'transparent', c3: 'aliceblue' },
+      }));
+      expect(result.findings.length).toBe(0);
+      const c1 = result.designSystem.colors.get('c1');
+      expect(c1?.hex).toBe('#ff0000');
+      expect(c1?.r).toBe(255);
+      expect(c1?.g).toBe(0);
+      expect(c1?.b).toBe(0);
+      
+      const c2 = result.designSystem.colors.get('c2');
+      expect(c2?.hex).toBe('#00000000');
+      expect(c2?.a).toBe(0);
+    });
+
+    it('resolves functional rgb/rgba colors', () => {
+      // comma separated
+      const resComma = handler.execute(makeParsed({
+        colors: { rgb1: 'rgb(255, 100, 50)', rgba1: 'rgba(255, 100, 50, 0.5)' },
+      }));
+      expect(resComma.findings.length).toBe(0);
+      expect(resComma.designSystem.colors.get('rgb1')?.hex).toBe('#ff6432');
+      expect(resComma.designSystem.colors.get('rgba1')?.a).toBeCloseTo(0.5);
+
+      // space separated and percentages
+      const resSpace = handler.execute(makeParsed({
+        colors: { rgb2: 'rgb(100% 50% 0%)', rgba2: 'rgb(100% 50% 0% / 40%)' },
+      }));
+      expect(resSpace.findings.length).toBe(0);
+      expect(resSpace.designSystem.colors.get('rgb2')?.r).toBe(255);
+      expect(resSpace.designSystem.colors.get('rgb2')?.g).toBe(128);
+      expect(resSpace.designSystem.colors.get('rgba2')?.a).toBeCloseTo(0.4);
+    });
+
+    it('resolves functional hsl/hsla colors', () => {
+      const result = handler.execute(makeParsed({
+        colors: { hsl1: 'hsl(120, 100%, 50%)', hsla1: 'hsl(120deg 100% 50% / 0.25)' },
+      }));
+      expect(result.findings.length).toBe(0);
+      const hsl1 = result.designSystem.colors.get('hsl1');
+      expect(hsl1?.hex).toBe('#00ff00');
+      const hsla1 = result.designSystem.colors.get('hsla1');
+      expect(hsla1?.hex).toBe('#00ff0040');
+      expect(hsla1?.a).toBeCloseTo(0.25);
+    });
+
+    it('resolves functional hwb colors', () => {
+      const result = handler.execute(makeParsed({
+        colors: { hwb1: 'hwb(120 0% 0%)', hwb2: 'hwb(120 50% 50%)', hwb3: 'hwb(120 20% 40% / 0.5)' },
+      }));
+      expect(result.findings.length).toBe(0);
+      expect(result.designSystem.colors.get('hwb1')?.hex).toBe('#00ff00');
+      expect(result.designSystem.colors.get('hwb2')?.hex).toBe('#808080');
+      expect(result.designSystem.colors.get('hwb3')?.a).toBeCloseTo(0.5);
+    });
+
+    it('resolves lab, lch, oklab, oklch color spaces', () => {
+      const result = handler.execute(makeParsed({
+        colors: {
+          lab1: 'lab(50% 40 -20)',
+          lch1: 'lch(50% 44.72 333.43)',
+          oklab1: 'oklab(0.6 0.1 -0.1)',
+          oklch1: 'oklch(0.6 0.1414 315)'
+        },
+      }));
+      expect(result.findings.length).toBe(0);
+      expect(result.designSystem.colors.get('lab1')).toBeDefined();
+      expect(result.designSystem.colors.get('lch1')).toBeDefined();
+      expect(result.designSystem.colors.get('oklab1')).toBeDefined();
+      expect(result.designSystem.colors.get('oklch1')).toBeDefined();
+    });
+
+    it('resolves color-mix colors', () => {
+      const result = handler.execute(makeParsed({
+        colors: { mix1: 'color-mix(in srgb, red 20%, blue 80%)', mix2: 'color-mix(in srgb, red, white 50%)' },
+      }));
+      expect(result.findings.length).toBe(0);
+      const mix1 = result.designSystem.colors.get('mix1');
+      expect(mix1?.r).toBe(51);
+      expect(mix1?.b).toBe(204);
+      
+      const mix2 = result.designSystem.colors.get('mix2');
+      expect(mix2?.r).toBe(255);
+      expect(mix2?.g).toBe(128);
+      expect(mix2?.b).toBe(128);
+    });
   });
 
   // ── Cycle 10: Resolve single-level token reference ────────────────

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -460,7 +460,7 @@ describe('ModelHandler', () => {
       expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
       const btn = result.designSystem.components.get('button-primary');
       expect(btn).toBeDefined();
-      expect(btn?.properties.get('fontWeight')).toBe(600);
+      expect(btn?.properties.get('fontWeight') as unknown).toBe(600);
     });
 
     it('stores numeric fontWeight value as-is in component properties', () => {
@@ -472,7 +472,7 @@ describe('ModelHandler', () => {
         },
       }));
       const heading = result.designSystem.components.get('heading');
-      expect(heading?.properties.get('fontWeight')).toBe(700);
+      expect(heading?.properties.get('fontWeight') as unknown).toBe(700);
     });
 
     it('does not crash when borderWidth is a bare number', () => {
@@ -485,7 +485,7 @@ describe('ModelHandler', () => {
       }));
       expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
       const card = result.designSystem.components.get('card');
-      expect(card?.properties.get('borderWidth')).toBe(1);
+      expect(card?.properties.get('borderWidth') as unknown).toBe(1);
     });
 
     it('handles mixed numeric and string props in same component without crashing', () => {
@@ -503,7 +503,7 @@ describe('ModelHandler', () => {
       }));
       expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
       const btn = result.designSystem.components.get('button');
-      expect(btn?.properties.get('fontWeight')).toBe(600);
+      expect(btn?.properties.get('fontWeight') as unknown).toBe(600);
     });
   });
 
@@ -522,7 +522,7 @@ describe('ModelHandler', () => {
       }));
       expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
       const btn = result.designSystem.components.get('button');
-      expect(btn?.properties.get('opacity')).toBe(0.9);
+      expect(btn?.properties.get('opacity') as unknown).toBe(0.9);
     });
 
     it('does not crash when a component property is a boolean (visible: true)', () => {
@@ -535,7 +535,7 @@ describe('ModelHandler', () => {
       }));
       expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
       const banner = result.designSystem.components.get('banner');
-      expect(banner?.properties.get('visible')).toBe(true);
+      expect(banner?.properties.get('visible') as unknown).toBe(true);
     });
 
     it('handles mixed number, boolean, and string props without crashing', () => {
@@ -554,10 +554,10 @@ describe('ModelHandler', () => {
       }));
       expect(result.findings.filter(f => f.severity === 'error')).toHaveLength(0);
       const card = result.designSystem.components.get('card');
-      expect(card?.properties.get('fontWeight')).toBe(500);
-      expect(card?.properties.get('opacity')).toBe(0.85);
-      expect(card?.properties.get('visible')).toBe(true);
-      expect(card?.properties.get('disabled')).toBe(false);
+      expect(card?.properties.get('fontWeight') as unknown).toBe(500);
+      expect(card?.properties.get('opacity') as unknown).toBe(0.85);
+      expect(card?.properties.get('visible') as unknown).toBe(true);
+      expect(card?.properties.get('disabled') as unknown).toBe(false);
     });
   });
 });

--- a/packages/cli/src/linter/model/handler.test.ts
+++ b/packages/cli/src/linter/model/handler.test.ts
@@ -76,6 +76,61 @@ describe('ModelHandler', () => {
       expect(semitransparent?.a).toBeCloseTo(166 / 255, 5);
     });
 
+    it('successfully parses nested color declarations (Issue #102)', () => {
+      const result = handler.execute(makeParsed({
+        colors: {
+          background: {
+            light: '#fbfaf1',
+            dark: '#11140e'
+          }
+        }
+      }));
+
+      expect(result.findings.filter(f => f.severity === 'error').length).toBe(0);
+      expect(result.designSystem.colors.has('background.light')).toBe(true);
+      expect(result.designSystem.colors.has('background.dark')).toBe(true);
+      expect(result.designSystem.colors.get('background.light')?.hex).toBe('#fbfaf1');
+      expect(result.designSystem.symbolTable.has('colors.background.light')).toBe(true);
+    });
+
+    it('successfully parses 3-level nested color declarations', () => {
+      const result = handler.execute(makeParsed({
+        colors: {
+          background: {
+            light: {
+              primary: '#fbfaf1',
+              secondary: '#f0f0f0'
+            }
+          }
+        }
+      }));
+
+      expect(result.findings.filter(f => f.severity === 'error').length).toBe(0);
+      expect(result.designSystem.colors.has('background.light.primary')).toBe(true);
+      expect(result.designSystem.colors.has('background.light.secondary')).toBe(true);
+      expect(result.designSystem.colors.get('background.light.primary')?.hex).toBe('#fbfaf1');
+      expect(result.designSystem.symbolTable.has('colors.background.light.primary')).toBe(true);
+    });
+
+    it('successfully parses 4-level nested color declarations', () => {
+      const result = handler.execute(makeParsed({
+        colors: {
+          theme: {
+            surface: {
+              background: {
+                base: '#fbfaf1'
+              }
+            }
+          }
+        }
+      }));
+
+      expect(result.findings.filter(f => f.severity === 'error').length).toBe(0);
+      expect(result.designSystem.colors.has('theme.surface.background.base')).toBe(true);
+      expect(result.designSystem.colors.get('theme.surface.background.base')?.hex).toBe('#fbfaf1');
+      expect(result.designSystem.symbolTable.has('colors.theme.surface.background.base')).toBe(true);
+    });
+
     it('resolves standard CSS named colors and converts them to hex/sRGB', () => {
       const result = handler.execute(makeParsed({
         colors: { c1: 'red', c2: 'transparent', c3: 'aliceblue' },
@@ -203,6 +258,22 @@ describe('ModelHandler', () => {
       if (typeof bg === 'object' && bg !== null && 'hex' in bg) {
         expect(bg.hex).toBe('#647d66');
       }
+    });
+
+    it('resolves references to nested colors', () => {
+      const result = handler.execute(makeParsed({
+        colors: {
+          background: {
+            light: '#fbfaf1',
+            dark: '#11140e'
+          },
+          page: '{colors.background.light}'
+        }
+      }));
+
+      expect(result.findings.filter(f => f.severity === 'error').length).toBe(0);
+      const page = result.designSystem.colors.get('page');
+      expect(page?.hex).toBe('#fbfaf1');
     });
   });
 
@@ -558,6 +629,40 @@ describe('ModelHandler', () => {
       expect(card?.properties.get('opacity') as unknown).toBe(0.85);
       expect(card?.properties.get('visible') as unknown).toBe(true);
       expect(card?.properties.get('disabled') as unknown).toBe(false);
+    });
+  });
+
+  describe('token nesting depth limit', () => {
+    it('emits error when token nesting depth exceeds 20', () => {
+      // 22 levels: Level 1..21 are objects, Level 22 is a leaf.
+      // forEachLeaf will be called for Level 22 with depth 21.
+      let obj: any = '#ffffff';
+      for (let i = 22; i >= 1; i--) {
+        obj = { [`level${i}`]: obj };
+      }
+
+      const result = handler.execute(makeParsed({
+        colors: obj,
+      }));
+      expect(result.findings.some((f) => f.message.includes('nesting depth'))).toBe(true);
+      expect(result.findings.find((f) => f.message.includes('nesting depth'))?.path).toBe('colors');
+    });
+
+    it('allows nesting up to depth 20', () => {
+      // 21 levels: Level 1..20 are objects, Level 21 is a leaf.
+      // forEachLeaf will be called for Level 21 with depth 20.
+      let obj: any = '#ffffff';
+      for (let i = 21; i >= 1; i--) {
+        obj = { [`level${i}`]: obj };
+      }
+
+      const result = handler.execute(makeParsed({
+        colors: obj,
+      }));
+      expect(result.findings.some((f) => f.message.includes('nesting depth'))).toBe(false);
+      // Construct the expected path: level1.level2...level21
+      const path = Array.from({ length: 21 }, (_, i) => `level${i + 1}`).join('.');
+      expect(result.designSystem.colors.has(path)).toBe(true);
     });
   });
 });

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -176,7 +176,13 @@ export class ModelHandler implements ModelSpec {
           const unresolvedRefs: string[] = [];
 
           for (const [propName, rawValue] of Object.entries(props)) {
-            if (isTokenReference(rawValue)) {
+            // Numeric values (e.g. fontWeight: 600, borderWidth: 1) are valid
+            // per spec and must be stored as-is, coercing to string first
+            // would cause isTokenReference / isValidColor to call .match() on
+            // a number and crash with "raw.match is not a function".
+            if (typeof rawValue === 'number') {
+              properties.set(propName, rawValue);
+            } else if (isTokenReference(rawValue)) {
               const refPath = rawValue.slice(1, -1);
               const resolved = resolveReference(symbolTable, refPath, new Set());
               if (resolved !== null) {

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -25,7 +25,7 @@ import type {
   Finding,
 } from './spec.js';
 
-import { isValidColor, isParseableDimension, isTokenReference, parseDimensionParts } from './spec.js';
+import { isValidColor, isParseableDimension, isTokenReference, parseDimensionParts, VALID_TYPOGRAPHY_PROPS } from './spec.js';
 import { parseCssColor } from './color-parser.js';
 
 import {
@@ -34,6 +34,7 @@ import {
 } from '../spec-config.js';
 
 const SCHEMA_KEY_SET: ReadonlySet<string> = new Set(SCHEMA_KEYS);
+const TYPOGRAPHY_PROP_SET: ReadonlySet<string> = new Set(VALID_TYPOGRAPHY_PROPS);
 
 /**
  * Builds a resolved DesignSystemState from parsed YAML tokens.
@@ -399,6 +400,19 @@ function parseTypography(props: Record<string, string | number>, path: string, f
           message: `'${raw}' is not a valid dimension.`,
         });
       }
+    }
+  }
+
+  // Surface typography sub-properties that aren't part of the schema: they are
+  // silently dropped (never resolved or emitted), so warn rather than ignore —
+  // mirroring how unknown component sub-tokens are reported.
+  for (const key of Object.keys(props)) {
+    if (!TYPOGRAPHY_PROP_SET.has(key)) {
+      findings.push({
+        severity: 'warning',
+        path: `${path}.${key}`,
+        message: `'${key}' is not a recognized typography property. Valid properties: ${VALID_TYPOGRAPHY_PROPS.join(', ')}.`,
+      });
     }
   }
 

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -178,9 +178,10 @@ export class ModelHandler implements ModelSpec {
 
           for (const [propName, rawValue] of Object.entries(props)) {
             // Numeric values (e.g. fontWeight: 600, borderWidth: 1) are valid
-            // per spec and must be stored as-is, coercing to string first
-            // would cause isTokenReference / isValidColor to call .match() on
-            // a number and crash with "raw.match is not a function".
+            // per spec and must be stored as-is. We check for 'number' here,
+            // but isTokenReference, isValidColor, and isParseableDimension
+            // are also guarded against other non-string types (like booleans)
+            // to prevent crashes like "raw.match is not a function".
             if (typeof rawValue === 'number') {
               properties.set(propName, rawValue);
             } else if (isTokenReference(rawValue)) {

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import type { ParsedDesignSystem, RawColorValue, RawRampDef, RawPairDef, RawMotionDef, RawIconographyDef, RawRegistryEntry, RawComponentValue, RawThemeDef, RawVoice, RawCopy, RawBreakpointsDef, RawGridDef, RawLayoutRulesDef, RawTemplateDef, RawPageDef } from '../parser/spec.js';
+import { SCHEMA_KEYS } from '../parser/spec.js';
 import type {
   ModelSpec,
   ModelResult,
@@ -52,13 +53,16 @@ import {
   parseDurationParts,
   isValidEasing,
   parseCubicBezier,
+  VALID_TYPOGRAPHY_PROPS,
 } from './spec.js';
 import { parseColorString } from './color.js';
+import { parseCssColor } from './color-parser.js';
 import { COMPONENT_SUB_TOKEN_VALIDATORS } from '../component-validators.js';
 import { generateRampSteps, DEFAULT_RAMP_STEPS } from './color-ramp.js';
-import { ICON_LIBRARIES, KIND_DEFAULTS, BASE_THEME_NAME, VOICE_AXES, VOICE_PERSON, CASING_VALUES, CASING_SURFACES, BREAKPOINT_PHILOSOPHIES } from '../spec-config.js';
+import { ICON_LIBRARIES, KIND_DEFAULTS, BASE_THEME_NAME, VOICE_AXES, VOICE_PERSON, CASING_VALUES, CASING_SURFACES, BREAKPOINT_PHILOSOPHIES, MAX_REFERENCE_DEPTH, MAX_TOKEN_NESTING_DEPTH } from '../spec-config.js';
 
-const MAX_REFERENCE_DEPTH = 10;
+const SCHEMA_KEY_SET: ReadonlySet<string> = new Set(SCHEMA_KEYS);
+const TYPOGRAPHY_PROP_SET: ReadonlySet<string> = new Set(VALID_TYPOGRAPHY_PROPS);
 
 /**
  * Builds a resolved DesignSystemState from parsed YAML tokens.
@@ -87,26 +91,38 @@ export class ModelHandler implements ModelSpec {
       // ── Phase 1: Resolve primitive tokens ──────────────────────────
       // Colors
       if (input.colors) {
+        const isCollision = buildCollisionGuard('colors', findings);
+        const handleColorLeaf = (name: string, raw: unknown): void => {
+          if (isCollision(name)) return;
+          if (typeof raw === 'string' && isTokenReference(raw)) {
+            // Store raw reference for later resolution
+            symbolTable.set(`colors.${name}`, raw);
+          } else if (typeof raw === 'string' && isValidColor(raw)) {
+            const resolved = parseColor(raw);
+            colors.set(name, resolved);
+            symbolTable.set(`colors.${name}`, resolved);
+          } else {
+            findings.push({
+              severity: 'error',
+              path: `colors.${name}`,
+              message: `'${raw}' is not a valid color. Expected hex (e.g., #ffffff) or a CSS color function such as oklch(), oklab(), lab(), color(display-p3 …), hsl(), or rgb().`,
+            });
+            // Store as-is for fallback
+            symbolTable.set(`colors.${name}`, String(raw));
+          }
+        };
         for (const [name, raw] of Object.entries(input.colors)) {
           if (typeof raw === 'string') {
-            if (isTokenReference(raw)) {
-              // Store raw reference for later resolution
-              symbolTable.set(`colors.${name}`, raw);
-            } else if (isValidColor(raw)) {
-              const resolved = parseColor(raw);
-              colors.set(name, resolved);
-              symbolTable.set(`colors.${name}`, resolved);
-            } else {
-              findings.push({
-                severity: 'error',
-                path: `colors.${name}`,
-                message: `'${raw}' is not a valid color. Expected hex (e.g., #ffffff) or a CSS color function such as oklch(), oklab(), lab(), color(display-p3 …), hsl(), or rgb().`,
-              });
-              // Store as-is for fallback
-              symbolTable.set(`colors.${name}`, raw);
-            }
+            handleColorLeaf(name, raw);
           } else if (raw && typeof raw === 'object') {
-            expandObjectColor(name, raw, { colors, colorRamps, colorPairs, symbolTable, findings });
+            if ('type' in raw) {
+              // Ramp / pair (or a typo'd shape) — structured expansion.
+              if (isCollision(name)) continue;
+              expandObjectColor(name, raw, { colors, colorRamps, colorPairs, symbolTable, findings });
+            } else {
+              // Plain nested group — flatten leaves to dot-separated names.
+              forEachLeaf(raw as Record<string, unknown>, handleColorLeaf, name, 1, findings, 'colors');
+            }
           }
         }
       }
@@ -122,7 +138,9 @@ export class ModelHandler implements ModelSpec {
 
       // Rounded
       if (input.rounded) {
-        for (const [name, raw] of Object.entries(input.rounded)) {
+        const isCollision = buildCollisionGuard('rounded', findings);
+        forEachLeaf(input.rounded, (name, raw) => {
+          if (isCollision(name)) return;
           if (typeof raw === 'string') {
             if (isParseableDimension(raw)) {
               const resolved = parseDimension(raw);
@@ -146,20 +164,22 @@ export class ModelHandler implements ModelSpec {
               symbolTable.set(`rounded.${name}`, raw);
             }
           }
-        }
+        }, '', 0, findings, 'rounded');
       }
 
       // Spacing
       if (input.spacing) {
-        for (const [name, raw] of Object.entries(input.spacing)) {
+        const isCollision = buildCollisionGuard('spacing', findings);
+        forEachLeaf(input.spacing, (name, raw) => {
+          if (isCollision(name)) return;
           if (isParseableDimension(raw)) {
             const resolved = parseDimension(raw);
             spacing.set(name, resolved);
             symbolTable.set(`spacing.${name}`, resolved);
-          } else {
+          } else if (typeof raw === 'string') {
             symbolTable.set(`spacing.${name}`, raw);
           }
-        }
+        }, '', 0, findings, 'spacing');
       }
 
       // Elevation — semantic shadow tokens (resting / raised / overlay / modal).
@@ -209,71 +229,27 @@ export class ModelHandler implements ModelSpec {
         ? parsePages(input.pages, findings)
         : undefined;
 
-      // ── Phase 2: Resolve chained color references ──────────────────
-      // Iterate color entries that are still raw references and resolve them
-      if (input.colors) {
-        for (const [name, raw] of Object.entries(input.colors)) {
-          if (typeof raw === 'string' && isTokenReference(raw)) {
-            const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
-            if (resolved !== null && typeof resolved === 'object' && 'type' in resolved && resolved.type === 'color') {
-              colors.set(name, resolved as ResolvedColor);
-              symbolTable.set(`colors.${name}`, resolved);
-            }
-          }
-        }
-      }
+      // ── Phase 2: Resolve chained token references ──────────────────
+      // Iterate the symbol table directly (not re-walking raw input) so that
+      // Phase 1 collision decisions are never overwritten and nested token
+      // names resolve under their flattened dot paths.
+      for (const [key, value] of symbolTable) {
+        if (typeof value !== 'string' || !isTokenReference(value)) continue;
+        const resolved = resolveReference(symbolTable, value.slice(1, -1), new Set());
+        if (resolved === null || typeof resolved !== 'object' || !('type' in resolved)) continue;
 
-      // Resolve chained rounded references
-      if (input.rounded) {
-        for (const [name, raw] of Object.entries(input.rounded)) {
-          if (typeof raw === 'string' && isTokenReference(raw)) {
-            const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
-            if (
-              resolved !== null &&
-              typeof resolved === 'object' &&
-              'type' in resolved &&
-              resolved.type === 'dimension'
-            ) {
-              rounded.set(name, resolved as ResolvedDimension);
-              symbolTable.set(`rounded.${name}`, resolved);
-            }
-          }
-        }
-      }
-
-      // Resolve chained spacing references
-      if (input.spacing) {
-        for (const [name, raw] of Object.entries(input.spacing)) {
-          if (typeof raw === 'string' && isTokenReference(raw)) {
-            const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
-            if (
-              resolved !== null &&
-              typeof resolved === 'object' &&
-              'type' in resolved &&
-              resolved.type === 'dimension'
-            ) {
-              spacing.set(name, resolved as ResolvedDimension);
-              symbolTable.set(`spacing.${name}`, resolved);
-            }
-          }
-        }
-      }
-
-      // Resolve chained elevation references
-      if (input.elevation) {
-        for (const [name, raw] of Object.entries(input.elevation)) {
-          if (typeof raw === 'string' && isTokenReference(raw)) {
-            const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
-            if (
-              resolved !== null &&
-              typeof resolved === 'object' &&
-              'type' in resolved &&
-              resolved.type === 'shadow'
-            ) {
-              elevation.set(name, resolved as ResolvedShadow);
-              symbolTable.set(`elevation.${name}`, resolved);
-            }
-          }
+        if (key.startsWith('colors.') && resolved.type === 'color') {
+          colors.set(key.slice('colors.'.length), resolved as ResolvedColor);
+          symbolTable.set(key, resolved);
+        } else if (key.startsWith('rounded.') && resolved.type === 'dimension') {
+          rounded.set(key.slice('rounded.'.length), resolved as ResolvedDimension);
+          symbolTable.set(key, resolved);
+        } else if (key.startsWith('spacing.') && resolved.type === 'dimension') {
+          spacing.set(key.slice('spacing.'.length), resolved as ResolvedDimension);
+          symbolTable.set(key, resolved);
+        } else if (key.startsWith('elevation.') && resolved.type === 'shadow') {
+          elevation.set(key.slice('elevation.'.length), resolved as ResolvedShadow);
+          symbolTable.set(key, resolved);
         }
       }
 
@@ -446,6 +422,19 @@ export class ModelHandler implements ModelSpec {
         for (const [surface, value] of copy.casing) symbolTable.set(`copy.casing.${surface}`, value);
       }
 
+      const unknownKeys = [...input.sourceMap.keys()].filter(
+        key => !SCHEMA_KEY_SET.has(key)
+      );
+
+      const unknownKeyValues: Record<string, unknown> = {};
+      if (input.rawValues) {
+        for (const key of unknownKeys) {
+          if (Object.prototype.hasOwnProperty.call(input.rawValues, key)) {
+            unknownKeyValues[key] = input.rawValues[key];
+          }
+        }
+      }
+
       return {
         designSystem: {
           name: input.name,
@@ -474,6 +463,8 @@ export class ModelHandler implements ModelSpec {
           layoutRules,
           templates,
           pages,
+          unknownKeys,
+          unknownKeyValues,
         },
         findings,
       };
@@ -816,20 +807,37 @@ function resolveComponentValue(
 /**
  * Parse a CSS color string into a ResolvedColor with sRGB channels and
  * WCAG luminance. Supports hex, rgb/rgba, hsl/hsla, oklch, oklab, lab, and
- * color(display-p3 …). Throws if the input is not a recognized color —
- * call `isValidColor` first when validating user input.
+ * color(display-p3 …) natively, with a generic CSS fallback for named
+ * colors, hwb(), lch(), and color-mix(). Throws if the input is not a
+ * recognized color — call `isValidColor` first when validating user input.
  */
 export function parseColor(raw: string): ResolvedColor {
   const result = parseColorString(raw);
-  if (!result) throw new Error(`Invalid color: ${raw}`);
-  return result;
+  if (result) return result;
+  const viaCss = parseCssColor(raw);
+  if (!viaCss) throw new Error(`Invalid color: ${raw}`);
+  return { type: 'color', format: 'css', raw, ...viaCss };
 }
 
 /**
  * Parse a dimension string like "42px" or "1.5rem".
  */
-function parseDimension(raw: string): ResolvedDimension {
-  const parts = parseDimensionParts(raw);
+function parseDimension(raw: unknown): ResolvedDimension {
+  // Defensive type guard – prevents "raw.match is not a function" crash
+  // and provides a clear error message for unexpected input types.
+  if (typeof raw !== 'string') {
+    throw new Error(
+      `parseDimension expected a string, got ${typeof raw}. ` +
+      `This usually indicates a malformed token in your design file.`,
+    );
+  }
+  const value = raw.trim();
+  if (value === '') {
+    throw new Error(
+      'parseDimension received an empty string. Please provide a valid dimension (e.g., "16px", "1.5rem").',
+    );
+  }
+  const parts = parseDimensionParts(value);
   if (!parts) {
     throw new Error(`Invalid dimension: ${raw}`);
   }
@@ -913,7 +921,94 @@ function parseTypography(props: Record<string, string | number>, path: string, f
     }
   }
 
+  // Surface typography sub-properties that aren't part of the schema: they are
+  // silently dropped (never resolved or emitted), so warn rather than ignore —
+  // mirroring how unknown component sub-tokens are reported.
+  for (const key of Object.keys(props)) {
+    if (!TYPOGRAPHY_PROP_SET.has(key)) {
+      findings.push({
+        severity: 'warning',
+        path: `${path}.${key}`,
+        message: `'${key}' is not a recognized typography property. Valid properties: ${VALID_TYPOGRAPHY_PROPS.join(', ')}.`,
+      });
+    }
+  }
+
   return result;
+}
+
+/**
+ * Returns a predicate that detects token name collisions within a single
+ * token category (colors, rounded, spacing). Call once per category; the
+ * returned function tracks state via closure.
+ *
+ * Returns true (and pushes a finding) when the candidate name collides with
+ * an already-registered key, so callers can skip it with a simple `if
+ * (isCollision(name)) return;`.
+ */
+function buildCollisionGuard(
+  category: string,
+  findings: Finding[],
+): (name: string) => boolean {
+  const seenKeys = new Set<string>();
+  const seenNormalized = new Map<string, string>();
+  return (name: string): boolean => {
+    const normalized = name.replace(/\./g, '-');
+    if (seenKeys.has(name)) {
+      findings.push({
+        severity: 'error',
+        path: `${category}.${name}`,
+        message: `Duplicate token path '${category}.${name}' detected.`,
+      });
+      return true;
+    }
+    if (seenNormalized.has(normalized)) {
+      findings.push({
+        severity: 'error',
+        path: `${category}.${name}`,
+        message: `Grouped ${category} token flattens to '${normalized}', which is already defined.`,
+      });
+      return true;
+    }
+    seenKeys.add(name);
+    seenNormalized.set(normalized, name);
+    return false;
+  };
+}
+
+/**
+ * Recursively iterate over an object and call a function for each leaf node.
+ * Leaf node paths are dot-separated (e.g. "background.light").
+ */
+function forEachLeaf(
+  obj: Record<string, unknown>,
+  fn: (path: string, value: unknown) => void,
+  prefix = '',
+  depth = 0,
+  findings?: Finding[],
+  rootPath?: string,
+): void {
+  if (depth > MAX_TOKEN_NESTING_DEPTH) {
+    if (findings && rootPath) {
+      // Check if we've already reported this rootPath to avoid spamming
+      if (!findings.some((f) => f.path === rootPath && f.message.includes('nesting depth'))) {
+        findings.push({
+          severity: 'error',
+          path: rootPath,
+          message: `Token nesting depth exceeds maximum allowed depth of ${MAX_TOKEN_NESTING_DEPTH}.`,
+        });
+      }
+    }
+    return;
+  }
+  for (const [key, value] of Object.entries(obj)) {
+    const fullPath = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      forEachLeaf(value as Record<string, unknown>, fn, fullPath, depth + 1, findings, rootPath);
+    } else {
+      fn(fullPath, value);
+    }
+  }
 }
 
 /**
@@ -1934,7 +2029,7 @@ function parsePages(
       continue;
     }
     const page: PageDef = { pattern, template: tpl };
-    const regionsRaw = (entry as Record<string, unknown>)['regions'];
+    const regionsRaw = (entry as unknown as Record<string, unknown>)['regions'];
     if (Array.isArray(regionsRaw)) {
       page.regions = regionsRaw.filter((s): s is string => typeof s === 'string');
     }

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import type { ParsedDesignSystem } from '../parser/spec.js';
+import { SCHEMA_KEYS } from '../parser/spec.js';
 import type {
   ModelSpec,
   ModelResult,
@@ -28,6 +29,8 @@ import { isValidColor, isParseableDimension, isTokenReference, parseDimensionPar
 import { parseCssColor } from './color-parser.js';
 
 const MAX_REFERENCE_DEPTH = 10;
+
+const SCHEMA_KEY_SET: ReadonlySet<string> = new Set(SCHEMA_KEYS);
 
 /**
  * Builds a resolved DesignSystemState from parsed YAML tokens.
@@ -206,6 +209,10 @@ export class ModelHandler implements ModelSpec {
         }
       }
 
+      const unknownKeys = [...input.sourceMap.keys()].filter(
+        key => !SCHEMA_KEY_SET.has(key)
+      );
+
       return {
         designSystem: {
           name: input.name,
@@ -217,6 +224,7 @@ export class ModelHandler implements ModelSpec {
           components,
           symbolTable,
           sections: input.sections,
+          unknownKeys,
         },
         findings,
       };

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -54,7 +54,10 @@ export class ModelHandler implements ModelSpec {
       // ── Phase 1: Resolve primitive tokens ──────────────────────────
       // Colors
       if (input.colors) {
+        const isCollision = buildCollisionGuard('colors', findings);
         forEachLeaf(input.colors, (name, raw) => {
+          if (isCollision(name)) return;
+
           if (typeof raw === 'string' && isTokenReference(raw)) {
             // Store raw reference for later resolution
             symbolTable.set(`colors.${name}`, raw);
@@ -85,7 +88,10 @@ export class ModelHandler implements ModelSpec {
 
       // Rounded
       if (input.rounded) {
+        const isCollision = buildCollisionGuard('rounded', findings);
         forEachLeaf(input.rounded, (name, raw) => {
+          if (isCollision(name)) return;
+
           if (typeof raw === 'string') {
             if (isParseableDimension(raw)) {
               const resolved = parseDimension(raw);
@@ -114,7 +120,10 @@ export class ModelHandler implements ModelSpec {
 
       // Spacing
       if (input.spacing) {
+        const isCollision = buildCollisionGuard('spacing', findings);
         forEachLeaf(input.spacing, (name, raw) => {
+          if (isCollision(name)) return;
+
           if (isParseableDimension(raw)) {
             const resolved = parseDimension(raw);
             spacing.set(name, resolved);
@@ -125,54 +134,27 @@ export class ModelHandler implements ModelSpec {
         }, '', 0, findings, 'spacing');
       }
 
-      // ── Phase 2: Resolve chained color references ──────────────────
-      // Iterate color entries that are still raw references and resolve them
-      if (input.colors) {
-        forEachLeaf(input.colors, (name, raw) => {
-          if (typeof raw === 'string' && isTokenReference(raw)) {
-            const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
-            if (resolved !== null && typeof resolved === 'object' && 'type' in resolved && resolved.type === 'color') {
-              colors.set(name, resolved as ResolvedColor);
-              symbolTable.set(`colors.${name}`, resolved);
-            }
-          }
-        });
-      }
+      // ── Phase 2: Resolve chained token references ──────────────────
+      // Iterate the symbol table directly (not re-walking raw input) so that
+      // Phase 1 collision decisions are never overwritten.
+      for (const [key, value] of symbolTable) {
+        if (typeof value !== 'string' || !isTokenReference(value)) continue;
+        const resolved = resolveReference(symbolTable, value.slice(1, -1), new Set());
+        if (resolved === null || typeof resolved !== 'object' || !('type' in resolved)) continue;
 
-      // Resolve chained rounded references
-      if (input.rounded) {
-        forEachLeaf(input.rounded, (name, raw) => {
-          if (typeof raw === 'string' && isTokenReference(raw)) {
-            const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
-            if (
-              resolved !== null &&
-              typeof resolved === 'object' &&
-              'type' in resolved &&
-              resolved.type === 'dimension'
-            ) {
-              rounded.set(name, resolved as ResolvedDimension);
-              symbolTable.set(`rounded.${name}`, resolved);
-            }
-          }
-        });
-      }
-
-      // Resolve chained spacing references
-      if (input.spacing) {
-        forEachLeaf(input.spacing, (name, raw) => {
-          if (typeof raw === 'string' && isTokenReference(raw)) {
-            const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
-            if (
-              resolved !== null &&
-              typeof resolved === 'object' &&
-              'type' in resolved &&
-              resolved.type === 'dimension'
-            ) {
-              spacing.set(name, resolved as ResolvedDimension);
-              symbolTable.set(`spacing.${name}`, resolved);
-            }
-          }
-        });
+        if (key.startsWith('colors.') && resolved.type === 'color') {
+          const name = key.slice('colors.'.length);
+          colors.set(name, resolved as ResolvedColor);
+          symbolTable.set(key, resolved);
+        } else if (key.startsWith('rounded.') && resolved.type === 'dimension') {
+          const name = key.slice('rounded.'.length);
+          rounded.set(name, resolved as ResolvedDimension);
+          symbolTable.set(key, resolved);
+        } else if (key.startsWith('spacing.') && resolved.type === 'dimension') {
+          const name = key.slice('spacing.'.length);
+          spacing.set(name, resolved as ResolvedDimension);
+          symbolTable.set(key, resolved);
+        }
       }
 
       // ── Phase 3: Build components ──────────────────────────────────
@@ -264,6 +246,45 @@ export class ModelHandler implements ModelSpec {
 }
 
 // ── Pure utility functions ─────────────────────────────────────────
+
+/**
+ * Returns a predicate that detects token name collisions within a single
+ * token category (colors, rounded, spacing). Call once per category; the
+ * returned function tracks state via closure.
+ *
+ * Returns true (and pushes a finding) when the candidate name collides with
+ * an already-registered key, so callers can skip it with a simple `if
+ * (isCollision(name)) return;`.
+ */
+function buildCollisionGuard(
+  category: string,
+  findings: Finding[],
+): (name: string) => boolean {
+  const seenKeys = new Set<string>();
+  const seenNormalized = new Map<string, string>();
+  return (name: string): boolean => {
+    const normalized = name.replace(/\./g, '-');
+    if (seenKeys.has(name)) {
+      findings.push({
+        severity: 'error',
+        path: `${category}.${name}`,
+        message: `Duplicate token path '${category}.${name}' detected.`,
+      });
+      return true;
+    }
+    if (seenNormalized.has(normalized)) {
+      findings.push({
+        severity: 'error',
+        path: `${category}.${name}`,
+        message: `Grouped ${category} token flattens to '${normalized}', which is already defined.`,
+      });
+      return true;
+    }
+    seenKeys.add(name);
+    seenNormalized.set(normalized, name);
+    return false;
+  };
+}
 
 /**
  * Parse a CSS color string into a ResolvedColor with RGB + WCAG luminance.

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -216,6 +216,15 @@ export class ModelHandler implements ModelSpec {
         key => !SCHEMA_KEY_SET.has(key)
       );
 
+      const unknownKeyValues: Record<string, unknown> = {};
+      if (input.rawValues) {
+        for (const key of unknownKeys) {
+          if (Object.prototype.hasOwnProperty.call(input.rawValues, key)) {
+            unknownKeyValues[key] = input.rawValues[key];
+          }
+        }
+      }
+
       return {
         designSystem: {
           name: input.name,
@@ -228,6 +237,7 @@ export class ModelHandler implements ModelSpec {
           symbolTable,
           sections: input.sections,
           unknownKeys,
+          unknownKeyValues,
         },
         findings,
       };

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -177,12 +177,12 @@ export class ModelHandler implements ModelSpec {
           const unresolvedRefs: string[] = [];
 
           for (const [propName, rawValue] of Object.entries(props)) {
-            // Numeric values (e.g. fontWeight: 600, borderWidth: 1) are valid
-            // per spec and must be stored as-is. We check for 'number' here,
-            // but isTokenReference, isValidColor, and isParseableDimension
-            // are also guarded against other non-string types (like booleans)
-            // to prevent crashes like "raw.match is not a function".
-            if (typeof rawValue === 'number') {
+            // Non-string scalars (numbers, booleans) are valid YAML values
+            // that can appear in component properties (e.g. fontWeight: 600,
+            // visible: true, opacity: 0.9). Store them as-is rather than
+            // passing them to string-only helpers like isTokenReference or
+            // isValidColor, which would either silently coerce or crash.
+            if (typeof rawValue === 'number' || typeof rawValue === 'boolean') {
               properties.set(propName, rawValue);
             } else if (isTokenReference(rawValue)) {
               const refPath = rawValue.slice(1, -1);

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -25,6 +25,7 @@ import type {
 } from './spec.js';
 
 import { isValidColor, isParseableDimension, isTokenReference, parseDimensionParts } from './spec.js';
+import { parseCssColor } from './color-parser.js';
 
 const MAX_REFERENCE_DEPTH = 10;
 
@@ -243,47 +244,17 @@ export class ModelHandler implements ModelSpec {
 // ── Pure utility functions ─────────────────────────────────────────
 
 /**
- * Parse a hex color string into a ResolvedColor with RGB + WCAG luminance.
+ * Parse a CSS color string into a ResolvedColor with RGB + WCAG luminance.
  */
 export function parseColor(raw: string): ResolvedColor {
-  let hex = raw;
-
-  // Normalize #RGB to #RRGGBB
-  if (hex.length === 4) {
-    hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  const parsed = parseCssColor(raw);
+  if (!parsed) {
+    throw new Error(`Invalid color: ${raw}`);
   }
-  // Normalize #RGBA to #RRGGBBAA
-  if (hex.length === 5) {
-    hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}${hex[4]}${hex[4]}`;
-  }
-
-  hex = hex.toLowerCase();
-
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-
-  let a: number | undefined;
-  if (hex.length === 9) {
-    a = parseInt(hex.slice(7, 9), 16) / 255;
-  }
-
-  const luminance = computeLuminance(r, g, b);
-
-  return { type: 'color', hex, r, g, b, a, luminance };
-}
-
-/**
- * Compute WCAG 2.1 relative luminance.
- * Uses sRGB linearization.
- */
-function computeLuminance(r: number, g: number, b: number): number {
-  const linearize = (c: number) => {
-    const s = c / 255;
-    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  return {
+    type: 'color',
+    ...parsed,
   };
-  
-  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
 }
 
 /**

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -63,7 +63,7 @@ export class ModelHandler implements ModelSpec {
             findings.push({
               severity: 'error',
               path: `colors.${name}`,
-              message: `'${raw}' is not a valid color. Expected a hex color code (e.g., #ffffff).`,
+              message: `'${raw}' is not a valid color. Expected a CSS color value (e.g., #ffffff, rgb(0 0 0), oklch(0.5 0.2 240)).`,
             });
             // Store as-is for fallback
             symbolTable.set(`colors.${name}`, raw);

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -282,8 +282,22 @@ export function parseColor(raw: string): ResolvedColor {
 /**
  * Parse a dimension string like "42px" or "1.5rem".
  */
-function parseDimension(raw: string): ResolvedDimension {
-  const parts = parseDimensionParts(raw);
+function parseDimension(raw: any): ResolvedDimension {
+  // Defensive type guard – prevents "raw.match is not a function" crash
+  // and provides a clear error message for unexpected input types.
+  if (typeof raw !== 'string') {
+    throw new Error(
+      `parseDimension expected a string, got ${typeof raw}. ` +
+      `This usually indicates a malformed token in your design file.`,
+    );
+  }
+  const value = raw.trim();
+  if (value === '') {
+    throw new Error(
+      'parseDimension received an empty string. Please provide a valid dimension (e.g., "16px", "1.5rem").',
+    );
+  }
+  const parts = parseDimensionParts(value);
   if (!parts) {
     throw new Error(`Invalid dimension: ${raw}`);
   }

--- a/packages/cli/src/linter/model/handler.ts
+++ b/packages/cli/src/linter/model/handler.ts
@@ -28,7 +28,10 @@ import type {
 import { isValidColor, isParseableDimension, isTokenReference, parseDimensionParts } from './spec.js';
 import { parseCssColor } from './color-parser.js';
 
-const MAX_REFERENCE_DEPTH = 10;
+import {
+  MAX_REFERENCE_DEPTH,
+  MAX_TOKEN_NESTING_DEPTH,
+} from '../spec-config.js';
 
 const SCHEMA_KEY_SET: ReadonlySet<string> = new Set(SCHEMA_KEYS);
 
@@ -51,8 +54,8 @@ export class ModelHandler implements ModelSpec {
       // ── Phase 1: Resolve primitive tokens ──────────────────────────
       // Colors
       if (input.colors) {
-        for (const [name, raw] of Object.entries(input.colors)) {
-          if (isTokenReference(raw)) {
+        forEachLeaf(input.colors, (name, raw) => {
+          if (typeof raw === 'string' && isTokenReference(raw)) {
             // Store raw reference for later resolution
             symbolTable.set(`colors.${name}`, raw);
           } else if (isValidColor(raw)) {
@@ -68,7 +71,7 @@ export class ModelHandler implements ModelSpec {
             // Store as-is for fallback
             symbolTable.set(`colors.${name}`, raw);
           }
-        }
+        }, '', 0, findings, 'colors');
       }
 
       // Typography
@@ -82,7 +85,7 @@ export class ModelHandler implements ModelSpec {
 
       // Rounded
       if (input.rounded) {
-        for (const [name, raw] of Object.entries(input.rounded)) {
+        forEachLeaf(input.rounded, (name, raw) => {
           if (typeof raw === 'string') {
             if (isParseableDimension(raw)) {
               const resolved = parseDimension(raw);
@@ -106,12 +109,12 @@ export class ModelHandler implements ModelSpec {
               symbolTable.set(`rounded.${name}`, raw);
             }
           }
-        }
+        }, '', 0, findings, 'rounded');
       }
 
       // Spacing
       if (input.spacing) {
-        for (const [name, raw] of Object.entries(input.spacing)) {
+        forEachLeaf(input.spacing, (name, raw) => {
           if (isParseableDimension(raw)) {
             const resolved = parseDimension(raw);
             spacing.set(name, resolved);
@@ -119,26 +122,26 @@ export class ModelHandler implements ModelSpec {
           } else {
             symbolTable.set(`spacing.${name}`, raw);
           }
-        }
+        }, '', 0, findings, 'spacing');
       }
 
       // ── Phase 2: Resolve chained color references ──────────────────
       // Iterate color entries that are still raw references and resolve them
       if (input.colors) {
-        for (const [name, raw] of Object.entries(input.colors)) {
-          if (isTokenReference(raw)) {
+        forEachLeaf(input.colors, (name, raw) => {
+          if (typeof raw === 'string' && isTokenReference(raw)) {
             const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
             if (resolved !== null && typeof resolved === 'object' && 'type' in resolved && resolved.type === 'color') {
               colors.set(name, resolved as ResolvedColor);
               symbolTable.set(`colors.${name}`, resolved);
             }
           }
-        }
+        });
       }
 
       // Resolve chained rounded references
       if (input.rounded) {
-        for (const [name, raw] of Object.entries(input.rounded)) {
+        forEachLeaf(input.rounded, (name, raw) => {
           if (typeof raw === 'string' && isTokenReference(raw)) {
             const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
             if (
@@ -151,12 +154,12 @@ export class ModelHandler implements ModelSpec {
               symbolTable.set(`rounded.${name}`, resolved);
             }
           }
-        }
+        });
       }
 
       // Resolve chained spacing references
       if (input.spacing) {
-        for (const [name, raw] of Object.entries(input.spacing)) {
+        forEachLeaf(input.spacing, (name, raw) => {
           if (typeof raw === 'string' && isTokenReference(raw)) {
             const resolved = resolveReference(symbolTable, raw.slice(1, -1), new Set());
             if (
@@ -169,7 +172,7 @@ export class ModelHandler implements ModelSpec {
               symbolTable.set(`spacing.${name}`, resolved);
             }
           }
-        }
+        });
       }
 
       // ── Phase 3: Build components ──────────────────────────────────
@@ -390,4 +393,39 @@ export function contrastRatio(a: ResolvedColor, b: ResolvedColor): number {
   const L1 = Math.max(a.luminance, b.luminance);
   const L2 = Math.min(a.luminance, b.luminance);
   return (L1 + 0.05) / (L2 + 0.05);
+}
+
+/**
+ * Recursively iterate over an object and call a function for each leaf node.
+ * Leaf node paths are dot-separated (e.g. "background.light").
+ */
+function forEachLeaf(
+  obj: Record<string, any>,
+  fn: (path: string, value: any) => void,
+  prefix = '',
+  depth = 0,
+  findings?: Finding[],
+  rootPath?: string
+) {
+  if (depth > MAX_TOKEN_NESTING_DEPTH) {
+    if (findings && rootPath) {
+      // Check if we've already reported this rootPath to avoid spamming
+      if (!findings.some((f) => f.path === rootPath && f.message.includes('nesting depth'))) {
+        findings.push({
+          severity: 'error',
+          path: rootPath,
+          message: `Token nesting depth exceeds maximum allowed depth of ${MAX_TOKEN_NESTING_DEPTH}.`,
+        });
+      }
+    }
+    return;
+  }
+  for (const [key, value] of Object.entries(obj)) {
+    const fullPath = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      forEachLeaf(value, fn, fullPath, depth + 1, findings, rootPath);
+    } else {
+      fn(fullPath, value);
+    }
+  }
 }

--- a/packages/cli/src/linter/model/spec.test.ts
+++ b/packages/cli/src/linter/model/spec.test.ts
@@ -79,6 +79,15 @@ describe('parseDimensionParts', () => {
     expect(parseDimensionParts('auto')).toBeNull();
     expect(parseDimensionParts('inherit')).toBeNull();
   });
+
+  it('returns null for oversized values without pathological backtracking', () => {
+    // Length-capped: an absurdly long value is rejected immediately rather than
+    // triggering quadratic regex backtracking.
+    expect(parseDimensionParts('1'.repeat(100000))).toBeNull();
+    expect(parseDimensionParts('1'.repeat(100000) + 'px')).toBeNull();
+    // Legitimate dimensions well under the cap still parse.
+    expect(parseDimensionParts('999999.999999px')).toEqual({ value: 999999.999999, unit: 'px' });
+  });
 });
 
 describe('isTokenReference', () => {

--- a/packages/cli/src/linter/model/spec.test.ts
+++ b/packages/cli/src/linter/model/spec.test.ts
@@ -24,8 +24,12 @@ describe('isValidColor', () => {
     'oklab(0.5 0 0)',
     'lab(50 0 0)',
     'color(display-p3 1 0.5 0)',
+    'red', 'blue',
+    'hwb(120 0% 0%)',
+    'lch(50% 30 120)',
+    'color-mix(in srgb, red 50%, blue 50%)',
   ];
-  const invalidColors = ['red', 'blue', '#gg0000', '#12345', '647D66', '#1234567', '', '#', 'oklch()', 'lab(50)'];
+  const invalidColors = ['#gg0000', '#12345', '647D66', '#1234567', '', '#', 'oklch()', 'lab(50)'];
 
   it.each(validColors)('accepts valid color: %s', (color: string) => {
     expect(isValidColor(color)).toBe(true);
@@ -86,6 +90,15 @@ describe('parseDimensionParts', () => {
   it('returns null for CSS keywords', () => {
     expect(parseDimensionParts('auto')).toBeNull();
     expect(parseDimensionParts('inherit')).toBeNull();
+  });
+
+  it('returns null for oversized values without pathological backtracking', () => {
+    // Length-capped: an absurdly long value is rejected immediately rather than
+    // triggering quadratic regex backtracking.
+    expect(parseDimensionParts('1'.repeat(100000))).toBeNull();
+    expect(parseDimensionParts('1'.repeat(100000) + 'px')).toBeNull();
+    // Legitimate dimensions well under the cap still parse.
+    expect(parseDimensionParts('999999.999999px')).toEqual({ value: 999999.999999, unit: 'px' });
   });
 });
 

--- a/packages/cli/src/linter/model/spec.test.ts
+++ b/packages/cli/src/linter/model/spec.test.ts
@@ -16,8 +16,8 @@ import { describe, it, expect } from 'bun:test';
 import { isValidColor, isStandardDimension, isParseableDimension, parseDimensionParts, isTokenReference } from './spec.js';
 
 describe('isValidColor', () => {
-  const validColors = ['#ff0000', '#FF0000', '#abc', '#ABC', '#647D66', '#000', '#fff'];
-  const invalidColors = ['red', 'blue', '#gg0000', '#12345', '647D66', '#1234567', '', '#'];
+  const validColors = ['#ff0000', '#FF0000', '#abc', '#ABC', '#647D66', '#000', '#fff', 'red', 'blue'];
+  const invalidColors = ['#gg0000', '#12345', '647D66', '#1234567', '', '#'];
 
   it.each(validColors)('accepts valid hex color: %s', (color: string) => {
     expect(isValidColor(color)).toBe(true);

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -142,6 +142,7 @@ const CSS_UNITS = new Set([
  * Returns null for non-dimension strings (bare numbers, keywords like `auto`).
  */
 export function parseDimensionParts(raw: string): { value: number; unit: string } | null {
+  if (typeof raw !== 'string') return null;
   const match = raw.match(/^(-?\d*\.?\d+)([a-zA-Z%]+)$/);
   if (!match) return null;
   const value = parseFloat(match[1]!);

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -142,12 +142,20 @@ const CSS_UNITS = new Set([
 ]);
 
 /**
+ * Upper bound on a dimension string's length. Real CSS dimensions are a handful
+ * of characters; capping the length keeps validation linear and prevents
+ * pathological regex backtracking on oversized, attacker-supplied values.
+ */
+const MAX_DIMENSION_LENGTH = 64;
+
+/**
  * Parse a dimension string into its numeric value and unit suffix.
  * Accepts an optional leading sign and optional decimal (`.5rem` is valid).
  * Returns null for non-dimension strings (bare numbers, keywords like `auto`).
  */
 export function parseDimensionParts(raw: string): { value: number; unit: string } | null {
   if (typeof raw !== 'string') return null;
+  if (raw.length > MAX_DIMENSION_LENGTH) return null;
   const match = raw.match(/^(-?\d*\.?\d+)([a-zA-Z%]+)$/);
   if (!match) return null;
   const value = parseFloat(match[1]!);

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -19,6 +19,7 @@ import {
   VALID_TYPOGRAPHY_PROPS as _VALID_TYPOGRAPHY_PROPS,
   VALID_COMPONENT_SUB_TOKENS as _VALID_COMPONENT_SUB_TOKENS,
 } from '../spec-config.js';
+import { parseCssColor } from './color-parser.js';
 
 export const SeveritySchema = z.enum(['error', 'warning', 'info']);
 export type Severity = z.infer<typeof SeveritySchema>;
@@ -151,7 +152,7 @@ export function parseDimensionParts(raw: string): { value: number; unit: string 
  * Validate a hex color string. Accepts #RGB, #RGBA, #RRGGBB, and #RRGGBBAA.
  */
 export function isValidColor(raw: string): boolean {
-  return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(raw);
+  return parseCssColor(raw) !== null;
 }
 
 /**

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -82,6 +82,8 @@ export interface DesignSystemState {
   sections?: string[] | undefined;
   /** Top-level YAML keys that are not part of the known schema */
   unknownKeys?: string[] | undefined;
+  /** Raw YAML values for unknown top-level keys, keyed by the unknown key name */
+  unknownKeyValues?: Record<string, unknown> | undefined;
 }
 
 export interface ComponentDef {

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -61,7 +61,7 @@ export interface ResolvedTypography {
   fontVariation?: string | undefined;
 }
 
-export type ResolvedValue = ResolvedColor | ResolvedDimension | ResolvedTypography | string;
+export type ResolvedValue = ResolvedColor | ResolvedDimension | ResolvedTypography | string | number | boolean;
 
 // ── Re-exported from spec-config (single source of truth) ─────────
 export const VALID_TYPOGRAPHY_PROPS = _VALID_TYPOGRAPHY_PROPS;
@@ -98,6 +98,7 @@ export const ModelErrorCode = z.enum([
   'UNRESOLVED_REFERENCE',
   'CIRCULAR_REFERENCE',
   'REFERENCE_TO_NON_PRIMITIVE',
+  'NESTING_DEPTH_EXCEEDED',
   'UNKNOWN_ERROR',
 ]);
 

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -80,6 +80,8 @@ export interface DesignSystemState {
   symbolTable: Map<string, ResolvedValue>;
   /** Markdown heading names found in the document */
   sections?: string[] | undefined;
+  /** Top-level YAML keys that are not part of the known schema */
+  unknownKeys?: string[] | undefined;
 }
 
 export interface ComponentDef {

--- a/packages/cli/src/linter/model/spec.ts
+++ b/packages/cli/src/linter/model/spec.ts
@@ -20,6 +20,7 @@ import {
   VALID_COMPONENT_SUB_TOKENS as _VALID_COMPONENT_SUB_TOKENS,
 } from '../spec-config.js';
 import { isParseableColor } from './color.js';
+import { parseCssColor } from './color-parser.js';
 
 export const SeveritySchema = z.enum(['error', 'warning', 'info']);
 export type Severity = z.infer<typeof SeveritySchema>;
@@ -32,8 +33,12 @@ export interface Finding {
 
 // ── RESOLVED VALUE TYPES ───────────────────────────────────────────
 
-/** The CSS color notation a token was authored in. */
-export type ColorFormat = 'hex' | 'rgb' | 'hsl' | 'oklch' | 'oklab' | 'lab' | 'p3';
+/**
+ * The CSS color notation a token was authored in. `'css'` covers notations
+ * parsed via the generic CSS color fallback (named colors, hwb(), lch(),
+ * color-mix()) where the specific function is not tracked.
+ */
+export type ColorFormat = 'hex' | 'rgb' | 'hsl' | 'oklch' | 'oklab' | 'lab' | 'p3' | 'css';
 
 export interface ResolvedColor {
   type: 'color';
@@ -430,6 +435,10 @@ export interface DesignSystemState {
   templates?: Map<string, TemplateDef> | undefined;
   /** Page → template assignments. Keys are route patterns. */
   pages?: Map<string, PageDef> | undefined;
+  /** Top-level YAML keys that are not part of the known schema */
+  unknownKeys?: string[] | undefined;
+  /** Raw YAML values for unknown top-level keys, keyed by the unknown key name */
+  unknownKeyValues?: Record<string, unknown> | undefined;
 }
 
 export interface ColorIndexEntry {
@@ -512,6 +521,7 @@ export const ModelErrorCode = z.enum([
   'UNRESOLVED_REFERENCE',
   'CIRCULAR_REFERENCE',
   'REFERENCE_TO_NON_PRIMITIVE',
+  'NESTING_DEPTH_EXCEEDED',
   'UNKNOWN_ERROR',
 ]);
 
@@ -553,6 +563,13 @@ const CSS_UNITS = new Set([
 ]);
 
 /**
+ * Upper bound on a dimension string's length. Real CSS dimensions are a handful
+ * of characters; capping the length keeps validation linear and prevents
+ * pathological regex backtracking on oversized, attacker-supplied values.
+ */
+const MAX_DIMENSION_LENGTH = 64;
+
+/**
  * Parse a dimension string into its numeric value and unit suffix.
  * Accepts an optional leading sign and optional decimal (`.5rem` is valid).
  * Returns null for non-dimension strings (bare numbers, keywords like `auto`)
@@ -560,6 +577,7 @@ const CSS_UNITS = new Set([
  */
 export function parseDimensionParts(raw: unknown): { value: number; unit: string } | null {
   if (typeof raw !== 'string') return null;
+  if (raw.length > MAX_DIMENSION_LENGTH) return null;
   const match = raw.match(/^(-?\d*\.?\d+)([a-zA-Z%]+)$/);
   if (!match) return null;
   const value = parseFloat(match[1]!);
@@ -569,10 +587,12 @@ export function parseDimensionParts(raw: unknown): { value: number; unit: string
 /**
  * Validate a CSS color string. Accepts hex (`#RGB`, `#RGBA`, `#RRGGBB`,
  * `#RRGGBBAA`), `rgb()`/`rgba()`, `hsl()`/`hsla()`, `oklch()`, `oklab()`,
- * `lab()`, and `color(display-p3 …)`. Non-strings safely return false.
+ * `lab()`, `lch()`, `hwb()`, `color(display-p3 …)`, `color-mix()`, and CSS
+ * named colors. Non-strings safely return false.
  */
 export function isValidColor(raw: unknown): boolean {
-  return isParseableColor(raw);
+  if (isParseableColor(raw)) return true;
+  return typeof raw === 'string' && parseCssColor(raw) !== null;
 }
 
 /**

--- a/packages/cli/src/linter/parser/handler.ts
+++ b/packages/cli/src/linter/parser/handler.ts
@@ -223,6 +223,7 @@ export class ParserHandler implements ParserSpec {
   private toDesignSystem(raw: Record<string, unknown>, sourceMap: Map<string, SourceLocation>, sections: string[], documentSections: DocumentSection[]): ParsedDesignSystem {
     const { components, componentRegistry } = normalizeComponents(raw['components']);
     return {
+      version: typeof raw['version'] === 'string' ? raw['version'] : undefined,
       name: typeof raw['name'] === 'string' ? raw['name'] : undefined,
       description: typeof raw['description'] === 'string' ? raw['description'] : undefined,
       colors: raw['colors'] as ParsedDesignSystem['colors'],
@@ -249,6 +250,7 @@ export class ParserHandler implements ParserSpec {
       sourceMap,
       sections,
       documentSections,
+      rawValues: raw,
     };
   }
 

--- a/packages/cli/src/linter/parser/handler.ts
+++ b/packages/cli/src/linter/parser/handler.ts
@@ -191,6 +191,7 @@ export class ParserHandler implements ParserSpec {
    */
   private toDesignSystem(raw: Record<string, unknown>, sourceMap: Map<string, SourceLocation>, sections: string[], documentSections: Array<{ heading: string; content: string }>): ParsedDesignSystem {
     return {
+      version: typeof raw['version'] === 'string' ? raw['version'] : undefined,
       name: typeof raw['name'] === 'string' ? raw['name'] : undefined,
       description: typeof raw['description'] === 'string' ? raw['description'] : undefined,
       colors: raw['colors'] as Record<string, string> | undefined,

--- a/packages/cli/src/linter/parser/handler.ts
+++ b/packages/cli/src/linter/parser/handler.ts
@@ -202,6 +202,7 @@ export class ParserHandler implements ParserSpec {
       sourceMap,
       sections,
       documentSections,
+      rawValues: raw,
     };
   }
 

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -227,6 +227,7 @@ export interface RawCopy {
 
 /** Raw, unresolved parsed output — mirrors the YAML schema */
 export interface ParsedDesignSystem {
+  version?: string | undefined;
   name?: string | undefined;
   description?: string | undefined;
   colors?: Record<string, RawColorValue> | undefined;
@@ -286,6 +287,8 @@ export interface ParsedDesignSystem {
   sections?: string[] | undefined;
   /** Full content of each section, including heading and body. */
   documentSections?: DocumentSection[] | undefined;
+  /** Raw YAML values for all top-level keys (known and unknown), used by lint rules. */
+  rawValues?: Record<string, unknown> | undefined;
 }
 
 /**
@@ -327,6 +330,32 @@ export interface DocumentSection {
    */
   codeBlockRanges: LineRange[];
 }
+
+/** Canonical top-level YAML keys per the DESIGN.md schema. */
+export const SCHEMA_KEYS = [
+  'version',
+  'name',
+  'description',
+  'colors',
+  'typography',
+  'rounded',
+  'spacing',
+  'elevation',
+  'motion',
+  'iconography',
+  'components',
+  'componentRegistry',
+  'voice',
+  'copy',
+  'themes',
+  'breakpoints',
+  'grid',
+  'layoutRules',
+  'templates',
+  'pages',
+] as const;
+
+export type SchemaKey = typeof SCHEMA_KEYS[number];
 
 // ── RESULT ─────────────────────────────────────────────────────────
 export type ParserResult =

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -39,6 +39,7 @@ export interface SourceLocation {
 
 /** Raw, unresolved parsed output — mirrors the YAML schema */
 export interface ParsedDesignSystem {
+  version?: string | undefined;
   name?: string | undefined;
   description?: string | undefined;
   colors?: Record<string, string> | undefined;
@@ -52,6 +53,20 @@ export interface ParsedDesignSystem {
   /** Full content of each section, including heading and body. */
   documentSections?: Array<{ heading: string; content: string }> | undefined;
 }
+
+/** Canonical top-level YAML keys per the DESIGN.md schema. */
+export const SCHEMA_KEYS = [
+  'version',
+  'name',
+  'description',
+  'colors',
+  'typography',
+  'rounded',
+  'spacing',
+  'components',
+] as const;
+
+export type SchemaKey = typeof SCHEMA_KEYS[number];
 
 // ── RESULT ─────────────────────────────────────────────────────────
 export type ParserResult =

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -52,6 +52,8 @@ export interface ParsedDesignSystem {
   sections?: string[] | undefined;
   /** Full content of each section, including heading and body. */
   documentSections?: Array<{ heading: string; content: string }> | undefined;
+  /** Raw YAML values for all top-level keys (known and unknown), used by lint rules. */
+  rawValues?: Record<string, unknown> | undefined;
 }
 
 /** Canonical top-level YAML keys per the DESIGN.md schema. */

--- a/packages/cli/src/linter/parser/spec.ts
+++ b/packages/cli/src/linter/parser/spec.ts
@@ -42,11 +42,11 @@ export interface ParsedDesignSystem {
   version?: string | undefined;
   name?: string | undefined;
   description?: string | undefined;
-  colors?: Record<string, string> | undefined;
-  typography?: Record<string, Record<string, string | number>> | undefined;
-  rounded?: Record<string, string> | undefined;
-  spacing?: Record<string, string> | undefined;
-  components?: Record<string, Record<string, string>> | undefined;
+  colors?: Record<string, any> | undefined;
+  typography?: Record<string, Record<string, any>> | undefined;
+  rounded?: Record<string, any> | undefined;
+  spacing?: Record<string, any> | undefined;
+  components?: Record<string, Record<string, any>> | undefined;
   sourceMap: Map<string, SourceLocation>;
   /** Markdown heading names found in the document (e.g., 'Colors', 'Typography') */
   sections?: string[] | undefined;

--- a/packages/cli/src/linter/spec-config.test.ts
+++ b/packages/cli/src/linter/spec-config.test.ts
@@ -18,6 +18,7 @@ import {
   loadSpecConfig,
   getSpecConfig,
   STANDARD_UNITS,
+  SPEC_TYPES,
   SECTIONS,
   TYPOGRAPHY_PROPERTIES,
   COMPONENT_SUB_TOKENS,
@@ -157,6 +158,14 @@ describe('spec-config structural invariants', () => {
   it('units are non-empty and unique', () => {
     expect(STANDARD_UNITS.length).toBeGreaterThan(0);
     expect(new Set(STANDARD_UNITS).size).toBe(STANDARD_UNITS.length);
+  });
+
+  it('primitive type definitions are non-empty', () => {
+    expect(Object.keys(SPEC_TYPES).length).toBeGreaterThan(0);
+    for (const [name, typeDef] of Object.entries(SPEC_TYPES)) {
+      expect(name.length).toBeGreaterThan(0);
+      expect(typeDef.description.length).toBeGreaterThan(0);
+    }
   });
 
   it('recommended token categories are non-empty', () => {

--- a/packages/cli/src/linter/spec-config.ts
+++ b/packages/cli/src/linter/spec-config.ts
@@ -40,6 +40,10 @@ const PropertyDefSchema = z.object({
 
 const ConfigSchema = z.object({
   version: z.string(),
+  limits: z.object({
+    max_token_nesting_depth: z.number().default(20),
+    max_reference_depth: z.number().default(10),
+  }).default({}),
   units: z.array(z.string()).min(1),
   sections: z.array(z.object({
     canonical: z.string(),
@@ -117,6 +121,10 @@ const config = getSpecConfig();
 /** Current spec version. Appears in the schema and the front matter example. */
 export const SPEC_VERSION = config.version;
 
+/** Performance and safety limits for the model handler. */
+export const MAX_TOKEN_NESTING_DEPTH = config.limits.max_token_nesting_depth;
+export const MAX_REFERENCE_DEPTH = config.limits.max_reference_depth;
+
 /** Units the spec formally supports for Dimension values. */
 export const STANDARD_UNITS = config.units;
 export type StandardUnit = (typeof STANDARD_UNITS)[number];
@@ -164,6 +172,8 @@ export const VALID_COMPONENT_SUB_TOKENS = COMPONENT_SUB_TOKENS.map(p => p.name);
 /** All config values bundled as a single object for renderer injection. */
 export interface SpecConfig {
   SPEC_VERSION: typeof SPEC_VERSION;
+  MAX_TOKEN_NESTING_DEPTH: typeof MAX_TOKEN_NESTING_DEPTH;
+  MAX_REFERENCE_DEPTH: typeof MAX_REFERENCE_DEPTH;
   STANDARD_UNITS: typeof STANDARD_UNITS;
   SECTIONS: typeof SECTIONS;
   TYPOGRAPHY_PROPERTIES: typeof TYPOGRAPHY_PROPERTIES;
@@ -176,6 +186,8 @@ export interface SpecConfig {
 /** Build a SpecConfig from the module's exports. */
 export const SPEC_CONFIG: SpecConfig = {
   SPEC_VERSION,
+  MAX_TOKEN_NESTING_DEPTH,
+  MAX_REFERENCE_DEPTH,
   STANDARD_UNITS,
   SECTIONS,
   TYPOGRAPHY_PROPERTIES,

--- a/packages/cli/src/linter/spec-config.ts
+++ b/packages/cli/src/linter/spec-config.ts
@@ -38,6 +38,14 @@ const PropertyDefSchema = z.object({
   description: z.string().optional(),
 });
 
+const TypeDefSchema = z.object({
+  description: z.string(),
+  formats: z.array(z.string()).optional(),
+  units: z.array(z.string()).optional(),
+  note: z.string().optional(),
+  recommendation: z.string().optional(),
+});
+
 const ConfigSchema = z.object({
   version: z.string(),
   limits: z.object({
@@ -45,6 +53,7 @@ const ConfigSchema = z.object({
     max_reference_depth: z.number().default(10),
   }).default({}),
   units: z.array(z.string()).min(1),
+  types: z.record(z.string(), TypeDefSchema),
   sections: z.array(z.object({
     canonical: z.string(),
     aliases: z.array(z.string()).optional(),
@@ -112,6 +121,19 @@ export interface ComponentSubTokenDef {
   description?: string | undefined;
 }
 
+export interface TypeDef {
+  /** One-sentence definition for the type. */
+  description: string;
+  /** Accepted formats rendered as a bullet list in the generated spec. */
+  formats?: readonly string[] | undefined;
+  /** Accepted units for dimensional types. */
+  units?: readonly string[] | undefined;
+  /** Additional normative or implementation note. */
+  note?: string | undefined;
+  /** Non-normative authoring recommendation. */
+  recommendation?: string | undefined;
+}
+
 // ── Constant exports ─────────────────────────────────────────────────
 // These are eagerly initialized from the lazy singleton on first import.
 // The singleton cache ensures the YAML file is read exactly once.
@@ -128,6 +150,9 @@ export const MAX_REFERENCE_DEPTH = config.limits.max_reference_depth;
 /** Units the spec formally supports for Dimension values. */
 export const STANDARD_UNITS = config.units;
 export type StandardUnit = (typeof STANDARD_UNITS)[number];
+
+/** Primitive type definitions rendered into the generated spec. */
+export const SPEC_TYPES: Record<string, TypeDef> = config.types;
 
 export const SECTIONS = config.sections;
 
@@ -175,6 +200,7 @@ export interface SpecConfig {
   MAX_TOKEN_NESTING_DEPTH: typeof MAX_TOKEN_NESTING_DEPTH;
   MAX_REFERENCE_DEPTH: typeof MAX_REFERENCE_DEPTH;
   STANDARD_UNITS: typeof STANDARD_UNITS;
+  SPEC_TYPES: typeof SPEC_TYPES;
   SECTIONS: typeof SECTIONS;
   TYPOGRAPHY_PROPERTIES: typeof TYPOGRAPHY_PROPERTIES;
   COMPONENT_SUB_TOKENS: typeof COMPONENT_SUB_TOKENS;
@@ -189,6 +215,7 @@ export const SPEC_CONFIG: SpecConfig = {
   MAX_TOKEN_NESTING_DEPTH,
   MAX_REFERENCE_DEPTH,
   STANDARD_UNITS,
+  SPEC_TYPES,
   SECTIONS,
   TYPOGRAPHY_PROPERTIES,
   COMPONENT_SUB_TOKENS,

--- a/packages/cli/src/linter/spec-config.ts
+++ b/packages/cli/src/linter/spec-config.ts
@@ -84,9 +84,22 @@ const ComponentExampleValueSchema: z.ZodType<unknown> = z.lazy(() =>
   ])
 );
 
+const TypeDefSchema = z.object({
+  description: z.string(),
+  formats: z.array(z.string()).optional(),
+  units: z.array(z.string()).optional(),
+  note: z.string().optional(),
+  recommendation: z.string().optional(),
+});
+
 const ConfigSchema = z.object({
   version: z.string(),
+  limits: z.object({
+    max_token_nesting_depth: z.number().default(20),
+    max_reference_depth: z.number().default(10),
+  }).default({}),
   units: z.array(z.string()).min(1),
+  types: z.record(z.string(), TypeDefSchema),
   sections: z.array(z.object({
     canonical: z.string(),
     aliases: z.array(z.string()).optional(),
@@ -205,6 +218,19 @@ export interface ComponentStateDef {
   description?: string | undefined;
 }
 
+export interface TypeDef {
+  /** One-sentence definition for the type. */
+  description: string;
+  /** Accepted formats rendered as a bullet list in the generated spec. */
+  formats?: readonly string[] | undefined;
+  /** Accepted units for dimensional types. */
+  units?: readonly string[] | undefined;
+  /** Additional normative or implementation note. */
+  note?: string | undefined;
+  /** Non-normative authoring recommendation. */
+  recommendation?: string | undefined;
+}
+
 // ── Constant exports ─────────────────────────────────────────────────
 // These are eagerly initialized from the lazy singleton on first import.
 // The singleton cache ensures the YAML file is read exactly once.
@@ -214,9 +240,16 @@ const config = getSpecConfig();
 /** Current spec version. Appears in the schema and the front matter example. */
 export const SPEC_VERSION = config.version;
 
+/** Performance and safety limits for the model handler. */
+export const MAX_TOKEN_NESTING_DEPTH = config.limits.max_token_nesting_depth;
+export const MAX_REFERENCE_DEPTH = config.limits.max_reference_depth;
+
 /** Units the spec formally supports for Dimension values. */
 export const STANDARD_UNITS = config.units;
 export type StandardUnit = (typeof STANDARD_UNITS)[number];
+
+/** Primitive type definitions rendered into the generated spec. */
+export const SPEC_TYPES: Record<string, TypeDef> = config.types;
 
 export const SECTIONS = config.sections;
 
@@ -338,7 +371,10 @@ export const VALID_COMPONENT_STATES = COMPONENT_STATES.map(s => s.name);
 /** All config values bundled as a single object for renderer injection. */
 export interface SpecConfig {
   SPEC_VERSION: typeof SPEC_VERSION;
+  MAX_TOKEN_NESTING_DEPTH: typeof MAX_TOKEN_NESTING_DEPTH;
+  MAX_REFERENCE_DEPTH: typeof MAX_REFERENCE_DEPTH;
   STANDARD_UNITS: typeof STANDARD_UNITS;
+  SPEC_TYPES: typeof SPEC_TYPES;
   SECTIONS: typeof SECTIONS;
   TYPOGRAPHY_PROPERTIES: typeof TYPOGRAPHY_PROPERTIES;
   COMPONENT_SUB_TOKENS: typeof COMPONENT_SUB_TOKENS;
@@ -362,7 +398,10 @@ export interface SpecConfig {
 /** Build a SpecConfig from the module's exports. */
 export const SPEC_CONFIG: SpecConfig = {
   SPEC_VERSION,
+  MAX_TOKEN_NESTING_DEPTH,
+  MAX_REFERENCE_DEPTH,
   STANDARD_UNITS,
+  SPEC_TYPES,
   SECTIONS,
   TYPOGRAPHY_PROPERTIES,
   COMPONENT_SUB_TOKENS,

--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -28,6 +28,24 @@ units:
   - em
   - rem
 
+types:
+  Color:
+    description: A color value is any valid CSS color string.
+    formats:
+      - "Hex: `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`"
+      - "Named colors: `red`, `cornflowerblue`, `transparent`"
+      - "Functional: `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()`"
+      - "Wide-gamut: `oklch()`, `oklab()`, `lch()`, `lab()`"
+      - "Mixing: `color-mix(in srgb, ...)`"
+    note: All color values are internally converted to sRGB for WCAG contrast checking. The original format is preserved for display and export.
+    recommendation: Hex notation (`#RRGGBB`) remains the recommended default for simplicity and broad tooling support.
+  Dimension:
+    description: A dimension value is a string with a unit suffix.
+    units:
+      - px
+      - em
+      - rem
+
 sections:
   - canonical: Overview
     aliases:

--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -18,10 +18,33 @@
 
 version: alpha
 
+# Performance and safety limits for the model handler.
+limits:
+  max_token_nesting_depth: 20
+  max_reference_depth: 10
+
 units:
   - px
   - em
   - rem
+
+types:
+  Color:
+    description: A color value is any valid CSS color string.
+    formats:
+      - "Hex: `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`"
+      - "Named colors: `red`, `cornflowerblue`, `transparent`"
+      - "Functional: `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()`"
+      - "Wide-gamut: `oklch()`, `oklab()`, `lch()`, `lab()`, `color(display-p3 ...)`"
+      - "Mixing: `color-mix(in srgb, ...)`"
+    note: All color values are internally converted to sRGB for WCAG contrast checking (wide-gamut inputs are clamped for that purpose). The original notation is preserved for display and export when the target supports it (e.g., Tailwind v4).
+    recommendation: Hex notation (`#RRGGBB`) remains the recommended default for simplicity and broad tooling support.
+  Dimension:
+    description: A dimension value is a string with a unit suffix.
+    units:
+      - px
+      - em
+      - rem
 
 sections:
   - canonical: Overview

--- a/packages/cli/src/linter/spec-config.yaml
+++ b/packages/cli/src/linter/spec-config.yaml
@@ -18,6 +18,11 @@
 
 version: alpha
 
+# Performance and safety limits for the model handler.
+limits:
+  max_token_nesting_depth: 20
+  max_reference_depth: 10
+
 units:
   - px
   - em

--- a/packages/cli/src/linter/spec-gen/compiler.test.ts
+++ b/packages/cli/src/linter/spec-gen/compiler.test.ts
@@ -70,6 +70,7 @@ describe('compileMdx', () => {
       typographyExample: () => renderers.typographyExample(cfg),
       componentsExample: () => renderers.componentsExample(cfg),
       typographyPropertyList: () => renderers.typographyPropertyList(cfg),
+      typeDefinitions: () => renderers.typeDefinitions(cfg),
       sectionOrderList: () => renderers.sectionOrderList(cfg),
       componentSubTokenList: () => renderers.componentSubTokenList(cfg),
       recommendedTokens: () => renderers.recommendedTokens(cfg),

--- a/packages/cli/src/linter/spec-gen/compiler.test.ts
+++ b/packages/cli/src/linter/spec-gen/compiler.test.ts
@@ -72,6 +72,7 @@ describe('compileMdx', () => {
       motionExample: () => renderers.motionExample(cfg),
       iconographyExample: () => renderers.iconographyExample(cfg),
       typographyPropertyList: () => renderers.typographyPropertyList(cfg),
+      typeDefinitions: () => renderers.typeDefinitions(cfg),
       sectionOrderList: () => renderers.sectionOrderList(cfg),
       componentSubTokenList: () => renderers.componentSubTokenList(cfg),
       recommendedTokens: () => renderers.recommendedTokens(cfg),

--- a/packages/cli/src/linter/spec-gen/generate.ts
+++ b/packages/cli/src/linter/spec-gen/generate.ts
@@ -48,6 +48,7 @@ async function main() {
     motionExample: () => renderers.motionExample(cfg),
     iconographyExample: () => renderers.iconographyExample(cfg),
     typographyPropertyList: () => renderers.typographyPropertyList(cfg),
+    typeDefinitions: () => renderers.typeDefinitions(cfg),
     sectionOrderList: () => renderers.sectionOrderList(cfg),
     componentSubTokenList: () => renderers.componentSubTokenList(cfg),
     recommendedTokens: () => renderers.recommendedTokens(cfg),

--- a/packages/cli/src/linter/spec-gen/generate.ts
+++ b/packages/cli/src/linter/spec-gen/generate.ts
@@ -46,6 +46,7 @@ async function main() {
     typographyExample: () => renderers.typographyExample(cfg),
     componentsExample: () => renderers.componentsExample(cfg),
     typographyPropertyList: () => renderers.typographyPropertyList(cfg),
+    typeDefinitions: () => renderers.typeDefinitions(cfg),
     sectionOrderList: () => renderers.sectionOrderList(cfg),
     componentSubTokenList: () => renderers.componentSubTokenList(cfg),
     recommendedTokens: () => renderers.recommendedTokens(cfg),

--- a/packages/cli/src/linter/spec-gen/renderers.ts
+++ b/packages/cli/src/linter/spec-gen/renderers.ts
@@ -19,7 +19,7 @@
  * Each function returns a ready-to-embed markdown string.
  */
 
-import type { SpecConfig, TypographyPropertyDef, SectionDef, ComponentSubTokenDef } from '../spec-config.js';
+import type { SpecConfig, TypographyPropertyDef, SectionDef, ComponentSubTokenDef, TypeDef } from '../spec-config.js';
 
 // ── YAML code block helpers ─────────────────────────────────────
 
@@ -93,6 +93,36 @@ export function typographyPropertyList(config: SpecConfig): string {
       ? `- \`${p.name}\` (${p.type}) - ${p.description}`
       : `- \`${p.name}\` (${p.type})`
   ).join('\n');
+}
+
+/** Primitive type definitions for the schema section. */
+export function typeDefinitions(config: SpecConfig): string {
+  return Object.entries(config.SPEC_TYPES)
+    .map(([name, typeDef]) => typeDefinition(name, typeDef))
+    .join('\n\n');
+}
+
+function typeDefinition(name: string, typeDef: TypeDef): string {
+  const lines = [`**${name}**: ${typeDef.description}`];
+
+  if (typeDef.formats?.length) {
+    lines.push('', 'Supported formats include:', '');
+    lines.push(...typeDef.formats.map(format => `- ${format}`));
+  }
+
+  if (typeDef.units?.length) {
+    lines.push('', `Valid units are: ${typeDef.units.join(', ')}.`);
+  }
+
+  if (typeDef.note) {
+    lines.push('', typeDef.note);
+  }
+
+  if (typeDef.recommendation) {
+    lines.push('', typeDef.recommendation);
+  }
+
+  return lines.join('\n');
 }
 
 /** Numbered section order list with aliases. */

--- a/packages/cli/src/linter/spec-gen/renderers.ts
+++ b/packages/cli/src/linter/spec-gen/renderers.ts
@@ -19,7 +19,7 @@
  * Each function returns a ready-to-embed markdown string.
  */
 
-import type { SpecConfig, TypographyPropertyDef, SectionDef, ComponentSubTokenDef } from '../spec-config.js';
+import type { SpecConfig, TypographyPropertyDef, SectionDef, ComponentSubTokenDef, TypeDef } from '../spec-config.js';
 
 // ── YAML code block helpers ─────────────────────────────────────
 
@@ -138,6 +138,36 @@ export function typographyPropertyList(config: SpecConfig): string {
       ? `- \`${p.name}\` (${p.type}) - ${p.description}`
       : `- \`${p.name}\` (${p.type})`
   ).join('\n');
+}
+
+/** Primitive type definitions for the schema section. */
+export function typeDefinitions(config: SpecConfig): string {
+  return Object.entries(config.SPEC_TYPES)
+    .map(([name, typeDef]) => typeDefinition(name, typeDef))
+    .join('\n\n');
+}
+
+function typeDefinition(name: string, typeDef: TypeDef): string {
+  const lines = [`**${name}**: ${typeDef.description}`];
+
+  if (typeDef.formats?.length) {
+    lines.push('', 'Supported formats include:', '');
+    lines.push(...typeDef.formats.map(format => `- ${format}`));
+  }
+
+  if (typeDef.units?.length) {
+    lines.push('', `Valid units are: ${typeDef.units.join(', ')}.`);
+  }
+
+  if (typeDef.note) {
+    lines.push('', typeDef.note);
+  }
+
+  if (typeDef.recommendation) {
+    lines.push('', typeDef.recommendation);
+  }
+
+  return lines.join('\n');
 }
 
 /** Numbered section order list with aliases. */

--- a/packages/cli/src/linter/spec-gen/spec-helpers.test.ts
+++ b/packages/cli/src/linter/spec-gen/spec-helpers.test.ts
@@ -58,6 +58,12 @@ describe('getSpecContent', () => {
     expect(content.length).toBeGreaterThan(1000);
   });
 
+  it('renders primitive type definitions from spec config', () => {
+    const content = getSpecContent();
+    expect(content).toContain('**Color**: A color value is any valid CSS color string.');
+    expect(content).toContain('**Dimension**: A dimension value is a string with a unit suffix.');
+  });
+
   it('accepts an explicit specPath override', () => {
     // This tests the explicit-path contract. If someone passes a path,
     // it should use that path exactly — no guessing.

--- a/packages/cli/src/linter/spec-gen/spec-helpers.ts
+++ b/packages/cli/src/linter/spec-gen/spec-helpers.ts
@@ -45,7 +45,13 @@ export function getSpecContent(specPath?: string): string {
   try {
     return readFileSync(bundledPath, 'utf-8');
   } catch {
-    // Not a bundle context — fall through to dev path.
+    // Fallback: spec.md may be in ../linter/ instead (one level up).
+    const fallbackPath = resolve(currentDir, '../linter/spec.md');
+    try {
+      return readFileSync(fallbackPath, 'utf-8');
+    } catch {
+      // Not a bundle context — fall through to dev path.
+    }
   }
 
   // Strategy 2: Development — spec.md lives at <repo>/docs/spec.md.

--- a/packages/cli/src/linter/spec-gen/spec.mdx
+++ b/packages/cli/src/linter/spec-gen/spec.mdx
@@ -43,7 +43,17 @@ components:
 
 The `<scale-level>` placeholder represents a named level in a sizing or spacing scale. Common level names include `xs`, `sm`, `md`, `lg`, `xl`, and `full`. Any descriptive string key is valid.
 
-**Color**: A color value must start with "#" followed by a hex color code in the SRGB color space.
+**Color**: A color value is any valid CSS color string. Supported formats include:
+
+- Hex: `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`
+- Named colors: `red`, `cornflowerblue`, `transparent`
+- Functional: `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()`
+- Wide-gamut: `oklch()`, `oklab()`, `lch()`, `lab()`
+- Mixing: `color-mix(in srgb, ...)`
+
+All color values are internally converted to sRGB for WCAG contrast checking. The original format is preserved for display and export.
+
+Hex notation (`#RRGGBB`) remains the recommended default for simplicity and broad tooling support.
 
 {typographyPropertyList()}
 

--- a/packages/cli/src/linter/spec-gen/spec.mdx
+++ b/packages/cli/src/linter/spec-gen/spec.mdx
@@ -1,5 +1,5 @@
 import { SPEC_VERSION, STANDARD_UNITS, SECTIONS, TYPOGRAPHY_PROPERTIES, COMPONENT_SUB_TOKENS, CORE_COLOR_ROLES, ICON_LIBRARIES, EASING_KEYWORDS, RECOMMENDED_TOKENS, EXAMPLES, VOICE_AXES, VOICE_PERSON, CASING_VALUES, CASING_SURFACES, BREAKPOINT_PHILOSOPHIES, BREAKPOINT_KEYS } from '../spec-config.js'
-import { frontmatterExample, colorsExample, typographyExample, componentsExample, motionExample, iconographyExample, typographyPropertyList, sectionOrderList, componentSubTokenList, recommendedTokens, voiceExample, copyExample, voiceAxesTable, casingTable, breakpointsExample, gridExample, layoutRulesExample, templatesExample } from './renderers.js'
+import { frontmatterExample, colorsExample, typographyExample, componentsExample, motionExample, iconographyExample, typographyPropertyList, typeDefinitions, sectionOrderList, componentSubTokenList, recommendedTokens, voiceExample, copyExample, voiceAxesTable, casingTable, breakpointsExample, gridExample, layoutRulesExample, templatesExample } from './renderers.js'
 
 # DESIGN.md Format
 
@@ -43,18 +43,9 @@ components:
 
 The `<scale-level>` placeholder represents a named level in a sizing or spacing scale. Common level names include `xs`, `sm`, `md`, `lg`, `xl`, and `full`. Any descriptive string key is valid.
 
-**Color**: A color value is any CSS color notation. The recommended forms are:
-
-- **Hex** (sRGB): `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`
-- **`rgb()` / `rgba()`** and **`hsl()` / `hsla()`**
-- **`oklch()`**, **`oklab()`**, **`lab()`** for perceptually uniform color
-- **`color(display-p3 …)`** for wide-gamut display colors
-
-The linter computes WCAG contrast in sRGB; wide-gamut inputs are converted and clamped for that purpose, but emitters preserve the original notation when the target supports it (e.g., Tailwind v4).
+{typeDefinitions()}
 
 {typographyPropertyList()}
-
-**Dimension**: A dimension value is a string with a unit suffix. Valid units are: {STANDARD_UNITS.join(', ')}.
 
 **Token References**: A token reference must be wrapped in curly braces, and contain an object path to another value in the YAML tree. For most token groups, the reference must point to a primitive value (e.g., `colors.primary-60`), not a group (e.g., `colors`). Within the `components` section, references to composite values (e.g., `{typography.label-md}`) are permitted.
 

--- a/packages/cli/src/linter/spec-gen/spec.mdx
+++ b/packages/cli/src/linter/spec-gen/spec.mdx
@@ -1,5 +1,5 @@
-import { SPEC_VERSION, STANDARD_UNITS, SECTIONS, TYPOGRAPHY_PROPERTIES, COMPONENT_SUB_TOKENS, CORE_COLOR_ROLES, RECOMMENDED_TOKENS, EXAMPLES } from '../spec-config.js'
-import { frontmatterExample, colorsExample, typographyExample, componentsExample, typographyPropertyList, sectionOrderList, componentSubTokenList, recommendedTokens } from './renderers.js'
+import { SPEC_VERSION, SECTIONS, TYPOGRAPHY_PROPERTIES, COMPONENT_SUB_TOKENS, CORE_COLOR_ROLES, RECOMMENDED_TOKENS, EXAMPLES } from '../spec-config.js'
+import { frontmatterExample, colorsExample, typographyExample, componentsExample, typographyPropertyList, typeDefinitions, sectionOrderList, componentSubTokenList, recommendedTokens } from './renderers.js'
 
 # DESIGN.md Format
 
@@ -43,21 +43,9 @@ components:
 
 The `<scale-level>` placeholder represents a named level in a sizing or spacing scale. Common level names include `xs`, `sm`, `md`, `lg`, `xl`, and `full`. Any descriptive string key is valid.
 
-**Color**: A color value is any valid CSS color string. Supported formats include:
-
-- Hex: `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`
-- Named colors: `red`, `cornflowerblue`, `transparent`
-- Functional: `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()`
-- Wide-gamut: `oklch()`, `oklab()`, `lch()`, `lab()`
-- Mixing: `color-mix(in srgb, ...)`
-
-All color values are internally converted to sRGB for WCAG contrast checking. The original format is preserved for display and export.
-
-Hex notation (`#RRGGBB`) remains the recommended default for simplicity and broad tooling support.
+{typeDefinitions()}
 
 {typographyPropertyList()}
-
-**Dimension**: A dimension value is a string with a unit suffix. Valid units are: {STANDARD_UNITS.join(', ')}.
 
 **Token References**: A token reference must be wrapped in curly braces, and contain an object path to another value in the YAML tree. For most token groups, the reference must point to a primitive value (e.g., `colors.primary-60`), not a group (e.g., `colors`). Within the `components` section, references to composite values (e.g., `{typography.label-md}`) are permitted.
 

--- a/packages/cli/src/linter/tailwind/v4/fixture.test.ts
+++ b/packages/cli/src/linter/tailwind/v4/fixture.test.ts
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { lint } from '../../lint.js';
+import { TailwindV4EmitterHandler } from './handler.js';
+import { serializeToCss } from './serialize.js';
+
+describe('Tailwind v4 export against real fixtures', () => {
+  it('produces a valid @theme block from examples/paws-and-paths/DESIGN.md', () => {
+    const fixturePath = join(import.meta.dir, '../../../../../../examples/paws-and-paths/DESIGN.md');
+    const content = readFileSync(fixturePath, 'utf8');
+    const report = lint(content);
+
+    const handler = new TailwindV4EmitterHandler();
+    const result = handler.execute(report.designSystem);
+    if (!result.success) throw new Error(`Handler failed: ${result.error.message}`);
+
+    const css = serializeToCss(result.data.theme);
+
+    // Wraps in @theme block
+    expect(css.startsWith('@theme {\n')).toBe(true);
+    expect(css.endsWith('}\n')).toBe(true);
+
+    // Contains expected v4 CSS variable prefixes (paws-and-paths has many colors + typography + spacing)
+    expect(css).toContain('--color-');
+    expect(css).toContain('--spacing-');
+    expect(css).toContain('--radius-');
+
+    // Non-empty body
+    const bodyLines = css.split('\n').filter(l => l.trim().startsWith('--'));
+    expect(bodyLines.length).toBeGreaterThan(10);
+  });
+});

--- a/packages/cli/src/linter/tailwind/v4/handler.test.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.test.ts
@@ -1,0 +1,163 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { TailwindV4EmitterHandler } from './handler.js';
+import { ModelHandler } from '../../model/handler.js';
+import type { ParsedDesignSystem } from '../../parser/spec.js';
+
+const emitter = new TailwindV4EmitterHandler();
+const modelHandler = new ModelHandler();
+
+function buildState(overrides: Partial<ParsedDesignSystem> = {}) {
+  const parsed: ParsedDesignSystem = { sourceMap: new Map(), ...overrides };
+  const result = modelHandler.execute(parsed);
+  const hasErrors = result.findings.some(d => d.severity === 'error');
+  if (hasErrors) {
+    throw new Error(`Model build failed: ${result.findings.map(d => d.message).join(', ')}`);
+  }
+  return result.designSystem;
+}
+
+describe('TailwindV4EmitterHandler', () => {
+  describe('colors mapping', () => {
+    it('maps resolved colors to theme.colors keyed by token name', () => {
+      const state = buildState({
+        colors: { primary: '#647D66', secondary: '#ff0000' },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      expect(result.data.theme.colors?.['primary']).toBe('#647d66');
+      expect(result.data.theme.colors?.['secondary']).toBe('#ff0000');
+    });
+  });
+
+  describe('typography mapping', () => {
+    it('splits typography into four separate categories', () => {
+      const state = buildState({
+        typography: {
+          'headline-lg': {
+            fontFamily: 'Google Sans Display',
+            fontSize: '42px',
+            fontWeight: 500,
+            lineHeight: '50px',
+            letterSpacing: '1.2px',
+          },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      const theme = result.data.theme;
+
+      expect(theme.fontFamily?.['headline-lg']).toBe('"Google Sans Display"');
+      expect(theme.fontSize?.['headline-lg']).toBe('42px');
+      expect(theme.lineHeight?.['headline-lg']).toBe('50px');
+      expect(theme.letterSpacing?.['headline-lg']).toBe('1.2px');
+      expect(theme.fontWeight?.['headline-lg']).toBe('500');
+    });
+
+    it('only populates categories for fields present on the token', () => {
+      const state = buildState({
+        typography: {
+          'body-lg': {
+            fontFamily: 'Roboto',
+            fontSize: '14px',
+            fontWeight: 400,
+            lineHeight: '20px',
+          },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      const theme = result.data.theme;
+
+      expect(theme.fontFamily?.['body-lg']).toBe('"Roboto"');
+      expect(theme.fontSize?.['body-lg']).toBe('14px');
+      expect(theme.lineHeight?.['body-lg']).toBe('20px');
+      expect(theme.fontWeight?.['body-lg']).toBe('400');
+      expect(theme.letterSpacing?.['body-lg']).toBeUndefined();
+    });
+
+    it('escapes embedded quotes and backslashes in font-family values', () => {
+      const state = buildState({
+        typography: {
+          fancy: { fontFamily: 'Fancy "Font"', fontSize: '16px' },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      expect(result.data.theme.fontFamily?.['fancy']).toBe('"Fancy \\"Font\\""');
+    });
+  });
+
+  describe('dimensions mapping', () => {
+    it('maps rounded to borderRadius and spacing to spacing', () => {
+      const state = buildState({
+        rounded: { regular: '4px', lg: '8px', full: '9999px' },
+        spacing: { 'gutter-s': '8px', 'gutter-l': '16px' },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      const theme = result.data.theme;
+
+      expect(theme.borderRadius?.['regular']).toBe('4px');
+      expect(theme.borderRadius?.['lg']).toBe('8px');
+      expect(theme.borderRadius?.['full']).toBe('9999px');
+      expect(theme.spacing?.['gutter-s']).toBe('8px');
+      expect(theme.spacing?.['gutter-l']).toBe('16px');
+    });
+  });
+
+  describe('empty state', () => {
+    it('returns success with an empty theme object', () => {
+      const state = buildState({});
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      expect(result.data.theme).toBeDefined();
+    });
+  });
+
+  describe('invalid token names', () => {
+    it('fails when a color token name contains a dot', () => {
+      const state = buildState({
+        colors: { primary: '#000000' },
+      });
+      // Inject an invalid name directly into the Map to simulate an invalid token
+      state.colors.set('primary.surface', {
+        type: 'color', hex: '#ffffff', r: 255, g: 255, b: 255, luminance: 1,
+      });
+      const result = emitter.execute(state);
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.code).toBe('INVALID_TOKEN_NAME');
+      expect(result.error.message).toContain('primary.surface');
+    });
+
+    it('fails when a spacing token name starts with a digit', () => {
+      const state = buildState({});
+      state.spacing.set('1bad', { type: 'dimension', value: 4, unit: 'px' });
+      const result = emitter.execute(state);
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.code).toBe('INVALID_TOKEN_NAME');
+    });
+
+    it('fails when a token name contains a space', () => {
+      const state = buildState({});
+      state.rounded.set('has space', { type: 'dimension', value: 4, unit: 'px' });
+      const result = emitter.execute(state);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/packages/cli/src/linter/tailwind/v4/handler.test.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.test.ts
@@ -99,6 +99,20 @@ describe('TailwindV4EmitterHandler', () => {
       if (!result.success) throw new Error('Expected success');
       expect(result.data.theme.fontFamily?.['fancy']).toBe('"Fancy \\"Font\\""');
     });
+
+    it('escapes line terminators in font-family values', () => {
+      const state = buildState({
+        typography: {
+          multi: { fontFamily: 'Evil\nFamily', fontSize: '16px' },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      const value = result.data.theme.fontFamily?.['multi'];
+      // A raw newline must not survive into the emitted CSS string.
+      expect(value).not.toContain('\n');
+      expect(value).toBe('"Evil\\a Family"');
+    });
   });
 
   describe('dimensions mapping', () => {

--- a/packages/cli/src/linter/tailwind/v4/handler.test.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.test.ts
@@ -1,0 +1,179 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { TailwindV4EmitterHandler } from './handler.js';
+import { ModelHandler } from '../../model/handler.js';
+import type { ParsedDesignSystem } from '../../parser/spec.js';
+
+const emitter = new TailwindV4EmitterHandler();
+const modelHandler = new ModelHandler();
+
+function buildState(overrides: Partial<ParsedDesignSystem> = {}) {
+  const parsed: ParsedDesignSystem = { sourceMap: new Map(), ...overrides };
+  const result = modelHandler.execute(parsed);
+  const hasErrors = result.findings.some(d => d.severity === 'error');
+  if (hasErrors) {
+    throw new Error(`Model build failed: ${result.findings.map(d => d.message).join(', ')}`);
+  }
+  return result.designSystem;
+}
+
+describe('TailwindV4EmitterHandler', () => {
+  describe('colors mapping', () => {
+    it('maps resolved colors to theme.colors keyed by token name', () => {
+      const state = buildState({
+        colors: { primary: '#647D66', secondary: '#ff0000' },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      expect(result.data.theme.colors?.['primary']).toBe('#647d66');
+      expect(result.data.theme.colors?.['secondary']).toBe('#ff0000');
+    });
+  });
+
+  describe('typography mapping', () => {
+    it('splits typography into four separate categories', () => {
+      const state = buildState({
+        typography: {
+          'headline-lg': {
+            fontFamily: 'Google Sans Display',
+            fontSize: '42px',
+            fontWeight: 500,
+            lineHeight: '50px',
+            letterSpacing: '1.2px',
+          },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      const theme = result.data.theme;
+
+      expect(theme.fontFamily?.['headline-lg']).toBe('"Google Sans Display"');
+      expect(theme.fontSize?.['headline-lg']).toBe('42px');
+      expect(theme.lineHeight?.['headline-lg']).toBe('50px');
+      expect(theme.letterSpacing?.['headline-lg']).toBe('1.2px');
+      expect(theme.fontWeight?.['headline-lg']).toBe('500');
+    });
+
+    it('only populates categories for fields present on the token', () => {
+      const state = buildState({
+        typography: {
+          'body-lg': {
+            fontFamily: 'Roboto',
+            fontSize: '14px',
+            fontWeight: 400,
+            lineHeight: '20px',
+          },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      const theme = result.data.theme;
+
+      expect(theme.fontFamily?.['body-lg']).toBe('"Roboto"');
+      expect(theme.fontSize?.['body-lg']).toBe('14px');
+      expect(theme.lineHeight?.['body-lg']).toBe('20px');
+      expect(theme.fontWeight?.['body-lg']).toBe('400');
+      expect(theme.letterSpacing?.['body-lg']).toBeUndefined();
+    });
+
+    it('escapes embedded quotes and backslashes in font-family values', () => {
+      const state = buildState({
+        typography: {
+          fancy: { fontFamily: 'Fancy "Font"', fontSize: '16px' },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      expect(result.data.theme.fontFamily?.['fancy']).toBe('"Fancy \\"Font\\""');
+    });
+
+    it('escapes line terminators in font-family values', () => {
+      const state = buildState({
+        typography: {
+          multi: { fontFamily: 'Evil\nFamily', fontSize: '16px' },
+        },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      const value = result.data.theme.fontFamily?.['multi'];
+      // A raw newline must not survive into the emitted CSS string.
+      expect(value).not.toContain('\n');
+      expect(value).toBe('"Evil\\a Family"');
+    });
+  });
+
+  describe('dimensions mapping', () => {
+    it('maps rounded to borderRadius and spacing to spacing', () => {
+      const state = buildState({
+        rounded: { regular: '4px', lg: '8px', full: '9999px' },
+        spacing: { 'gutter-s': '8px', 'gutter-l': '16px' },
+      });
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      const theme = result.data.theme;
+
+      expect(theme.borderRadius?.['regular']).toBe('4px');
+      expect(theme.borderRadius?.['lg']).toBe('8px');
+      expect(theme.borderRadius?.['full']).toBe('9999px');
+      expect(theme.spacing?.['gutter-s']).toBe('8px');
+      expect(theme.spacing?.['gutter-l']).toBe('16px');
+    });
+  });
+
+  describe('empty state', () => {
+    it('returns success with an empty theme object', () => {
+      const state = buildState({});
+      const result = emitter.execute(state);
+      if (!result.success) throw new Error('Expected success');
+      expect(result.data.theme).toBeDefined();
+    });
+  });
+
+  describe('invalid token names', () => {
+    it('fails when a color token name contains a dot', () => {
+      const state = buildState({
+        colors: { primary: '#000000' },
+      });
+      // Inject an invalid name directly into the Map to simulate an invalid token
+      state.colors.set('primary.surface', {
+        type: 'color', hex: '#ffffff', r: 255, g: 255, b: 255, luminance: 1, format: 'hex', raw: '#ffffff',
+      });
+      const result = emitter.execute(state);
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error.code).toBe('INVALID_TOKEN_NAME');
+      expect(result.error.message).toContain('primary.surface');
+    });
+
+    it('allows Tailwind-style dimension token names that start with a digit', () => {
+      const state = buildState({});
+      state.spacing.set('2xs', { type: 'dimension', value: 2, unit: 'px' });
+      state.rounded.set('4xl', { type: 'dimension', value: 32, unit: 'px' });
+      const result = emitter.execute(state);
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.theme.spacing?.['2xs']).toBe('2px');
+      expect(result.data.theme.borderRadius?.['4xl']).toBe('32px');
+    });
+
+    it('fails when a token name contains a space', () => {
+      const state = buildState({});
+      state.rounded.set('has space', { type: 'dimension', value: 4, unit: 'px' });
+      const result = emitter.execute(state);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/packages/cli/src/linter/tailwind/v4/handler.test.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.test.ts
@@ -144,13 +144,15 @@ describe('TailwindV4EmitterHandler', () => {
       expect(result.error.message).toContain('primary.surface');
     });
 
-    it('fails when a spacing token name starts with a digit', () => {
+    it('allows Tailwind-style dimension token names that start with a digit', () => {
       const state = buildState({});
-      state.spacing.set('1bad', { type: 'dimension', value: 4, unit: 'px' });
+      state.spacing.set('2xs', { type: 'dimension', value: 2, unit: 'px' });
+      state.rounded.set('4xl', { type: 'dimension', value: 32, unit: 'px' });
       const result = emitter.execute(state);
-      expect(result.success).toBe(false);
-      if (result.success) return;
-      expect(result.error.code).toBe('INVALID_TOKEN_NAME');
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.theme.spacing?.['2xs']).toBe('2px');
+      expect(result.data.theme.borderRadius?.['4xl']).toBe('32px');
     });
 
     it('fails when a token name contains a space', () => {

--- a/packages/cli/src/linter/tailwind/v4/handler.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.ts
@@ -1,0 +1,106 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { TailwindV4EmitterSpec, TailwindV4EmitterResult, TailwindV4ThemeData } from './spec.js';
+import type { DesignSystemState, ResolvedDimension } from '../../model/spec.js';
+
+const VALID_TOKEN_NAME = /^[a-zA-Z][a-zA-Z0-9-]*$/;
+
+/**
+ * Pure function mapping DesignSystemState → Tailwind v4 theme data.
+ * Token names are validated against CSS-identifier rules. Font-family values
+ * are wrapped in double quotes, with embedded `"` and `\` escaped.
+ */
+export class TailwindV4EmitterHandler implements TailwindV4EmitterSpec {
+  execute(state: DesignSystemState): TailwindV4EmitterResult {
+    const theme: TailwindV4ThemeData = {};
+
+    // Validate every token name before emitting anything.
+    const allNames: string[] = [
+      ...state.colors.keys(),
+      ...state.typography.keys(),
+      ...state.rounded.keys(),
+      ...state.spacing.keys(),
+    ];
+    for (const name of allNames) {
+      if (!VALID_TOKEN_NAME.test(name)) {
+        return {
+          success: false,
+          error: {
+            code: 'INVALID_TOKEN_NAME',
+            message: `Token name "${name}" is not a valid CSS identifier for Tailwind v4 export (must match /^[a-zA-Z][a-zA-Z0-9-]*$/).`,
+          },
+        };
+      }
+    }
+
+    // Colors
+    if (state.colors.size > 0) {
+      const colors: Record<string, string> = {};
+      for (const [name, color] of state.colors) {
+        colors[name] = color.hex;
+      }
+      theme.colors = colors;
+    }
+
+    // Typography — split into 4 sibling categories
+    const fontFamily: Record<string, string> = {};
+    const fontSize: Record<string, string> = {};
+    const lineHeight: Record<string, string> = {};
+    const letterSpacing: Record<string, string> = {};
+    const fontWeight: Record<string, string> = {};
+    for (const [name, typo] of state.typography) {
+      if (typo.fontFamily) fontFamily[name] = cssStringLiteral(typo.fontFamily);
+      if (typo.fontSize) fontSize[name] = dimToString(typo.fontSize);
+      if (typo.lineHeight) lineHeight[name] = dimToString(typo.lineHeight);
+      if (typo.letterSpacing) letterSpacing[name] = dimToString(typo.letterSpacing);
+      if (typo.fontWeight !== undefined) fontWeight[name] = String(typo.fontWeight);
+    }
+    if (Object.keys(fontFamily).length > 0) theme.fontFamily = fontFamily;
+    if (Object.keys(fontSize).length > 0) theme.fontSize = fontSize;
+    if (Object.keys(lineHeight).length > 0) theme.lineHeight = lineHeight;
+    if (Object.keys(letterSpacing).length > 0) theme.letterSpacing = letterSpacing;
+    if (Object.keys(fontWeight).length > 0) theme.fontWeight = fontWeight;
+
+    // borderRadius + spacing
+    if (state.rounded.size > 0) {
+      theme.borderRadius = mapDimensions(state.rounded);
+    }
+    if (state.spacing.size > 0) {
+      theme.spacing = mapDimensions(state.spacing);
+    }
+
+    return { success: true, data: { theme } };
+  }
+}
+
+function mapDimensions(dims: Map<string, ResolvedDimension>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [name, dim] of dims) {
+    out[name] = dimToString(dim);
+  }
+  return out;
+}
+
+function dimToString(dim: ResolvedDimension): string {
+  return `${dim.value}${dim.unit}`;
+}
+
+/**
+ * Wrap a string value in double quotes, escaping embedded `\` and `"`.
+ * Produces a CSS-safe string literal suitable for font-family values.
+ */
+function cssStringLiteral(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}

--- a/packages/cli/src/linter/tailwind/v4/handler.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.ts
@@ -100,7 +100,13 @@ function dimToString(dim: ResolvedDimension): string {
 /**
  * Wrap a string value in double quotes, escaping embedded `\` and `"`.
  * Produces a CSS-safe string literal suitable for font-family values.
+ * Line terminators (newline, carriage return, form feed) are illegal raw inside
+ * a CSS string and could break the value out of the quoted token, so they are
+ * emitted as CSS hex escapes (e.g. `\a `).
  */
 function cssStringLiteral(value: string): string {
-  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  return `"${value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/[\n\r\f]/g, (c) => `\\${c.charCodeAt(0).toString(16)} `)}"`;
 }

--- a/packages/cli/src/linter/tailwind/v4/handler.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.ts
@@ -1,0 +1,112 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { TailwindV4EmitterSpec, TailwindV4EmitterResult, TailwindV4ThemeData } from './spec.js';
+import type { DesignSystemState, ResolvedDimension } from '../../model/spec.js';
+
+const VALID_TOKEN_NAME = /^[a-zA-Z0-9][a-zA-Z0-9-]*$/;
+
+/**
+ * Pure function mapping DesignSystemState → Tailwind v4 theme data.
+ * Token names are validated against CSS-identifier rules. Font-family values
+ * are wrapped in double quotes, with embedded `"` and `\` escaped.
+ */
+export class TailwindV4EmitterHandler implements TailwindV4EmitterSpec {
+  execute(state: DesignSystemState): TailwindV4EmitterResult {
+    const theme: TailwindV4ThemeData = {};
+
+    // Validate every token name before emitting anything.
+    const allNames: string[] = [
+      ...state.colors.keys(),
+      ...state.typography.keys(),
+      ...state.rounded.keys(),
+      ...state.spacing.keys(),
+    ];
+    for (const name of allNames) {
+      if (!VALID_TOKEN_NAME.test(name)) {
+        return {
+          success: false,
+          error: {
+            code: 'INVALID_TOKEN_NAME',
+            message: `Token name "${name}" is not a valid CSS identifier for Tailwind v4 export (must match /^[a-zA-Z0-9][a-zA-Z0-9-]*$/).`,
+          },
+        };
+      }
+    }
+
+    // Colors
+    if (state.colors.size > 0) {
+      const colors: Record<string, string> = {};
+      for (const [name, color] of state.colors) {
+        colors[name] = color.hex;
+      }
+      theme.colors = colors;
+    }
+
+    // Typography — split into 4 sibling categories
+    const fontFamily: Record<string, string> = {};
+    const fontSize: Record<string, string> = {};
+    const lineHeight: Record<string, string> = {};
+    const letterSpacing: Record<string, string> = {};
+    const fontWeight: Record<string, string> = {};
+    for (const [name, typo] of state.typography) {
+      if (typo.fontFamily) fontFamily[name] = cssStringLiteral(typo.fontFamily);
+      if (typo.fontSize) fontSize[name] = dimToString(typo.fontSize);
+      if (typo.lineHeight) lineHeight[name] = dimToString(typo.lineHeight);
+      if (typo.letterSpacing) letterSpacing[name] = dimToString(typo.letterSpacing);
+      if (typo.fontWeight !== undefined) fontWeight[name] = String(typo.fontWeight);
+    }
+    if (Object.keys(fontFamily).length > 0) theme.fontFamily = fontFamily;
+    if (Object.keys(fontSize).length > 0) theme.fontSize = fontSize;
+    if (Object.keys(lineHeight).length > 0) theme.lineHeight = lineHeight;
+    if (Object.keys(letterSpacing).length > 0) theme.letterSpacing = letterSpacing;
+    if (Object.keys(fontWeight).length > 0) theme.fontWeight = fontWeight;
+
+    // borderRadius + spacing
+    if (state.rounded.size > 0) {
+      theme.borderRadius = mapDimensions(state.rounded);
+    }
+    if (state.spacing.size > 0) {
+      theme.spacing = mapDimensions(state.spacing);
+    }
+
+    return { success: true, data: { theme } };
+  }
+}
+
+function mapDimensions(dims: Map<string, ResolvedDimension>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [name, dim] of dims) {
+    out[name] = dimToString(dim);
+  }
+  return out;
+}
+
+function dimToString(dim: ResolvedDimension): string {
+  return `${dim.value}${dim.unit}`;
+}
+
+/**
+ * Wrap a string value in double quotes, escaping embedded `\` and `"`.
+ * Produces a CSS-safe string literal suitable for font-family values.
+ * Line terminators (newline, carriage return, form feed) are illegal raw inside
+ * a CSS string and could break the value out of the quoted token, so they are
+ * emitted as CSS hex escapes (e.g. `\a `).
+ */
+function cssStringLiteral(value: string): string {
+  return `"${value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/[\n\r\f]/g, (c) => `\\${c.charCodeAt(0).toString(16)} `)}"`;
+}

--- a/packages/cli/src/linter/tailwind/v4/handler.ts
+++ b/packages/cli/src/linter/tailwind/v4/handler.ts
@@ -15,7 +15,7 @@
 import type { TailwindV4EmitterSpec, TailwindV4EmitterResult, TailwindV4ThemeData } from './spec.js';
 import type { DesignSystemState, ResolvedDimension } from '../../model/spec.js';
 
-const VALID_TOKEN_NAME = /^[a-zA-Z][a-zA-Z0-9-]*$/;
+const VALID_TOKEN_NAME = /^[a-zA-Z0-9][a-zA-Z0-9-]*$/;
 
 /**
  * Pure function mapping DesignSystemState → Tailwind v4 theme data.
@@ -39,7 +39,7 @@ export class TailwindV4EmitterHandler implements TailwindV4EmitterSpec {
           success: false,
           error: {
             code: 'INVALID_TOKEN_NAME',
-            message: `Token name "${name}" is not a valid CSS identifier for Tailwind v4 export (must match /^[a-zA-Z][a-zA-Z0-9-]*$/).`,
+            message: `Token name "${name}" is not a valid CSS identifier for Tailwind v4 export (must match /^[a-zA-Z0-9][a-zA-Z0-9-]*$/).`,
           },
         };
       }

--- a/packages/cli/src/linter/tailwind/v4/serialize.test.ts
+++ b/packages/cli/src/linter/tailwind/v4/serialize.test.ts
@@ -1,0 +1,96 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { serializeToCss } from './serialize.js';
+import type { TailwindV4ThemeData } from './spec.js';
+
+describe('serializeToCss', () => {
+  it('emits an empty @theme block for empty data', () => {
+    const out = serializeToCss({});
+    expect(out).toBe('@theme {\n}\n');
+  });
+
+  it('emits a single color declaration', () => {
+    const data: TailwindV4ThemeData = { colors: { primary: '#647d66' } };
+    expect(serializeToCss(data)).toBe('@theme {\n  --color-primary: #647d66;\n}\n');
+  });
+
+  it('uses the correct CSS-variable prefix per category', () => {
+    const data: TailwindV4ThemeData = {
+      colors: { primary: '#000000' },
+      fontFamily: { 'headline-lg': '"Roboto"' },
+      fontSize: { 'headline-lg': '42px' },
+      lineHeight: { 'headline-lg': '50px' },
+      letterSpacing: { 'headline-lg': '1.2px' },
+      fontWeight: { 'headline-lg': '500' },
+      borderRadius: { regular: '4px' },
+      spacing: { 'gutter-s': '8px' },
+    };
+    const out = serializeToCss(data);
+    expect(out).toContain('--color-primary: #000000;');
+    expect(out).toContain('--font-headline-lg: "Roboto";');
+    expect(out).toContain('--text-headline-lg: 42px;');
+    expect(out).toContain('--leading-headline-lg: 50px;');
+    expect(out).toContain('--tracking-headline-lg: 1.2px;');
+    expect(out).toContain('--font-weight-headline-lg: 500;');
+    expect(out).toContain('--radius-regular: 4px;');
+    expect(out).toContain('--spacing-gutter-s: 8px;');
+  });
+
+  it('emits categories in fixed order: colors → fontFamily → fontSize → lineHeight → letterSpacing → fontWeight → borderRadius → spacing', () => {
+    const data: TailwindV4ThemeData = {
+      spacing: { s: '8px' },
+      colors: { primary: '#000000' },
+      borderRadius: { r: '4px' },
+      fontFamily: { f: '"X"' },
+    };
+    const out = serializeToCss(data);
+    const colorIdx = out.indexOf('--color-primary');
+    const fontFamilyIdx = out.indexOf('--font-f');
+    const radiusIdx = out.indexOf('--radius-r');
+    const spacingIdx = out.indexOf('--spacing-s');
+    expect(colorIdx).toBeLessThan(fontFamilyIdx);
+    expect(fontFamilyIdx).toBeLessThan(radiusIdx);
+    expect(radiusIdx).toBeLessThan(spacingIdx);
+  });
+
+  it('skips empty categories (no blank lines)', () => {
+    const data: TailwindV4ThemeData = {
+      colors: { primary: '#000000' },
+      fontFamily: {},
+      spacing: { s: '8px' },
+    };
+    const out = serializeToCss(data);
+    // no blank body lines
+    expect(out).not.toMatch(/\n\s*\n/);
+    expect(out).toBe('@theme {\n  --color-primary: #000000;\n  --spacing-s: 8px;\n}\n');
+  });
+
+  it('preserves insertion order of keys within a category', () => {
+    const colors: Record<string, string> = {};
+    colors['zulu'] = '#000000';
+    colors['alpha'] = '#ffffff';
+    const out = serializeToCss({ colors });
+    expect(out.indexOf('--color-zulu')).toBeLessThan(out.indexOf('--color-alpha'));
+  });
+
+  it('emits font-family values verbatim (already quoted)', () => {
+    const data: TailwindV4ThemeData = {
+      fontFamily: { body: '"Google Sans Display"' },
+    };
+    const out = serializeToCss(data);
+    expect(out).toContain('--font-body: "Google Sans Display";');
+  });
+});

--- a/packages/cli/src/linter/tailwind/v4/serialize.ts
+++ b/packages/cli/src/linter/tailwind/v4/serialize.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { TailwindV4ThemeData } from './spec.js';
+
+// Category → CSS-variable prefix. Iteration order of this array is the output order.
+const CATEGORIES: ReadonlyArray<readonly [keyof TailwindV4ThemeData, string]> = [
+  ['colors', '--color-'],
+  ['fontFamily', '--font-'],
+  ['fontSize', '--text-'],
+  ['lineHeight', '--leading-'],
+  ['letterSpacing', '--tracking-'],
+  ['fontWeight', '--font-weight-'],
+  ['borderRadius', '--radius-'],
+  ['spacing', '--spacing-'],
+];
+
+/**
+ * Serialize a Tailwind v4 theme data object to a CSS `@theme { ... }` block string.
+ * Pure function — no I/O. Values are emitted verbatim (font-family quoting must
+ * be done by the handler before calling this).
+ */
+export function serializeToCss(data: TailwindV4ThemeData): string {
+  const lines: string[] = [];
+  for (const [category, prefix] of CATEGORIES) {
+    const entries = data[category];
+    if (!entries) continue;
+    for (const [name, value] of Object.entries(entries)) {
+      lines.push(`  ${prefix}${name}: ${value};`);
+    }
+  }
+  if (lines.length === 0) return '@theme {\n}\n';
+  return `@theme {\n${lines.join('\n')}\n}\n`;
+}

--- a/packages/cli/src/linter/tailwind/v4/spec.ts
+++ b/packages/cli/src/linter/tailwind/v4/spec.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { z } from 'zod';
+import type { DesignSystemState } from '../../model/spec.js';
+
+// ── TAILWIND v4 THEME DATA SCHEMA ────────────────────────────────────
+// Category-keyed record of CSS-variable name → value strings.
+// The serializer flattens this into an `@theme { ... }` block.
+export const TailwindV4ThemeDataSchema = z.object({
+  colors: z.record(z.string()).optional(),
+  fontFamily: z.record(z.string()).optional(),
+  fontSize: z.record(z.string()).optional(),
+  lineHeight: z.record(z.string()).optional(),
+  letterSpacing: z.record(z.string()).optional(),
+  fontWeight: z.record(z.string()).optional(),
+  borderRadius: z.record(z.string()).optional(),
+  spacing: z.record(z.string()).optional(),
+});
+
+export type TailwindV4ThemeData = z.infer<typeof TailwindV4ThemeDataSchema>;
+
+export const TailwindV4EmitterResultSchema = z.discriminatedUnion('success', [
+  z.object({
+    success: z.literal(true),
+    data: z.object({
+      theme: TailwindV4ThemeDataSchema,
+    }),
+  }),
+  z.object({
+    success: z.literal(false),
+    error: z.object({
+      code: z.string(),
+      message: z.string(),
+    }),
+  }),
+]);
+
+export type TailwindV4EmitterResult = z.infer<typeof TailwindV4EmitterResultSchema>;
+
+// ── INTERFACE ──────────────────────────────────────────────────────
+export interface TailwindV4EmitterSpec {
+  execute(state: DesignSystemState): TailwindV4EmitterResult;
+}

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'bun:test';
+import { formatOutput } from './utils.js';
+
+describe('formatOutput', () => {
+  describe('--format markdown', () => {
+    it('renders a lint report instead of [object Object]', () => {
+      const lintOutput = {
+        findings: [
+          { severity: 'warning', path: 'colors.surface', message: "'surface' is defined but never referenced." },
+          { severity: 'info', message: 'Design system defines 10 colors.' },
+        ],
+        summary: { errors: 0, warnings: 1, infos: 1 },
+      };
+
+      const result = formatOutput(lintOutput, { format: 'markdown' });
+      expect(result).not.toContain('[object Object]');
+      expect(result).toContain('# Lint Report');
+      expect(result).toContain('**0 errors**');
+      expect(result).toContain('**1 warnings**');
+      expect(result).toContain('**1 infos**');
+      expect(result).toContain("'surface' is defined but never referenced.");
+      expect(result).toContain('`colors.surface`');
+    });
+
+    it('renders findings without a path', () => {
+      const lintOutput = {
+        findings: [
+          { severity: 'info', message: 'Token count summary.' },
+        ],
+        summary: { errors: 0, warnings: 0, infos: 1 },
+      };
+
+      const result = formatOutput(lintOutput, { format: 'markdown' });
+      expect(result).toContain('- **info**: Token count summary.');
+    });
+
+    it('renders an empty findings section when there are none', () => {
+      const lintOutput = {
+        findings: [],
+        summary: { errors: 0, warnings: 0, infos: 0 },
+      };
+
+      const result = formatOutput(lintOutput, { format: 'markdown' });
+      expect(result).toContain('# Lint Report');
+      expect(result).not.toContain('## Findings');
+    });
+
+    it('handles the --format md alias', () => {
+      const lintOutput = {
+        findings: [],
+        summary: { errors: 0, warnings: 0, infos: 0 },
+      };
+
+      const result = formatOutput(lintOutput, { format: 'md' });
+      expect(result).toContain('# Lint Report');
+    });
+
+    it('preserves legacy fixer shape with string summary', () => {
+      const fixerOutput = {
+        summary: 'Fixed 3 issues',
+        details: 'Some details here',
+      };
+
+      const result = formatOutput(fixerOutput, { format: 'markdown' });
+      expect(result).toContain('# Fixed 3 issues');
+      expect(result).toContain('## Details');
+    });
+  });
+
+  describe('default format (JSON)', () => {
+    it('returns valid JSON', () => {
+      const data = { findings: [], summary: { errors: 0, warnings: 0, infos: 0 } };
+      const result = formatOutput(data, {});
+      expect(JSON.parse(result)).toEqual(data);
+    });
+  });
+});

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -1,0 +1,167 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, spyOn } from 'bun:test';
+import { readInput, FileReadError, formatOutput } from './utils.js';
+import type { StdinStream } from './utils.js';
+
+function makeStdin(content: string, isTTY: boolean): StdinStream {
+  async function* gen() { yield Buffer.from(content); }
+  return Object.assign(gen(), { isTTY });
+}
+
+describe('readInput', () => {
+  it('throws FileReadError when file does not exist', async () => {
+    const err = await readInput('/nonexistent-path/DESIGN.md').catch(e => e);
+    expect(err).toBeInstanceOf(FileReadError);
+  });
+
+  it('FileReadError carries the missing file path', async () => {
+    const err = await readInput('/nonexistent-path/DESIGN.md').catch(e => e);
+    expect((err as FileReadError).filePath).toBe('/nonexistent-path/DESIGN.md');
+  });
+
+  it('FileReadError carries the underlying OS error message', async () => {
+    const err = await readInput('/nonexistent-path/DESIGN.md').catch(e => e);
+    expect((err as FileReadError).message).toContain('ENOENT');
+  });
+
+  it('friendlyMessage says "not found" for ENOENT', async () => {
+    const err = await readInput('/nonexistent-path/DESIGN.md').catch(e => e);
+    expect((err as FileReadError).friendlyMessage).toContain('not found');
+  });
+
+  it('friendlyMessage says "permission denied" for EACCES', () => {
+    const cause = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+    const err = new FileReadError('/some/file.md', cause);
+    expect(err.friendlyMessage).toContain('permission denied');
+    expect(err.friendlyMessage).not.toContain('not found');
+  });
+
+  it('friendlyMessage falls back to the raw message for unknown errors', () => {
+    const cause = Object.assign(new Error('ENOMEM: out of memory'), { code: 'ENOMEM' });
+    const err = new FileReadError('/some/file.md', cause);
+    expect(err.friendlyMessage).toContain('ENOMEM');
+  });
+});
+
+describe('readInput stdin ("-")', () => {
+  it('reads content from a piped stream', async () => {
+    const result = await readInput('-', makeStdin('hello world', false));
+    expect(result).toBe('hello world');
+  });
+
+  it('returns empty string for an empty piped stream', async () => {
+    async function* empty() {}
+    const result = await readInput('-', Object.assign(empty(), { isTTY: false }));
+    expect(result).toBe('');
+  });
+
+  it('writes a hint to stderr when stdin is a TTY', async () => {
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      await readInput('-', makeStdin('some content', true));
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Press Ctrl+D')
+      );
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('does not write a hint when stdin is not a TTY', async () => {
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      await readInput('-', makeStdin('piped content', false));
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+});
+
+describe('formatOutput', () => {
+  describe('--format markdown', () => {
+    it('renders a lint report instead of [object Object]', () => {
+      const lintOutput = {
+        findings: [
+          { severity: 'warning', path: 'colors.surface', message: "'surface' is defined but never referenced." },
+          { severity: 'info', message: 'Design system defines 10 colors.' },
+        ],
+        summary: { errors: 0, warnings: 1, infos: 1 },
+      };
+
+      const result = formatOutput(lintOutput, { format: 'markdown' });
+      expect(result).not.toContain('[object Object]');
+      expect(result).toContain('# Lint Report');
+      expect(result).toContain('**0 errors**');
+      expect(result).toContain('**1 warnings**');
+      expect(result).toContain('**1 infos**');
+      expect(result).toContain("'surface' is defined but never referenced.");
+      expect(result).toContain('`colors.surface`');
+    });
+
+    it('renders findings without a path', () => {
+      const lintOutput = {
+        findings: [
+          { severity: 'info', message: 'Token count summary.' },
+        ],
+        summary: { errors: 0, warnings: 0, infos: 1 },
+      };
+
+      const result = formatOutput(lintOutput, { format: 'markdown' });
+      expect(result).toContain('- **info**: Token count summary.');
+    });
+
+    it('renders an empty findings section when there are none', () => {
+      const lintOutput = {
+        findings: [],
+        summary: { errors: 0, warnings: 0, infos: 0 },
+      };
+
+      const result = formatOutput(lintOutput, { format: 'markdown' });
+      expect(result).toContain('# Lint Report');
+      expect(result).not.toContain('## Findings');
+    });
+
+    it('handles the --format md alias', () => {
+      const lintOutput = {
+        findings: [],
+        summary: { errors: 0, warnings: 0, infos: 0 },
+      };
+
+      const result = formatOutput(lintOutput, { format: 'md' });
+      expect(result).toContain('# Lint Report');
+    });
+
+    it('preserves legacy fixer shape with string summary', () => {
+      const fixerOutput = {
+        summary: 'Fixed 3 issues',
+        details: 'Some details here',
+      };
+
+      const result = formatOutput(fixerOutput, { format: 'markdown' });
+      expect(result).toContain('# Fixed 3 issues');
+      expect(result).toContain('## Details');
+    });
+  });
+
+  describe('default format (JSON)', () => {
+    it('returns valid JSON', () => {
+      const data = { findings: [], summary: { errors: 0, warnings: 0, infos: 0 } };
+      const result = formatOutput(data, {});
+      expect(JSON.parse(result)).toEqual(data);
+    });
+  });
+});

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -13,7 +13,42 @@
 // limitations under the License.
 
 import { describe, it, expect } from 'bun:test';
-import { formatOutput } from './utils.js';
+import { readInput, FileReadError, formatOutput } from './utils.js';
+
+describe('readInput', () => {
+  it('throws FileReadError when file does not exist', async () => {
+    const err = await readInput('/nonexistent-path/DESIGN.md').catch(e => e);
+    expect(err).toBeInstanceOf(FileReadError);
+  });
+
+  it('FileReadError carries the missing file path', async () => {
+    const err = await readInput('/nonexistent-path/DESIGN.md').catch(e => e);
+    expect((err as FileReadError).filePath).toBe('/nonexistent-path/DESIGN.md');
+  });
+
+  it('FileReadError carries the underlying OS error message', async () => {
+    const err = await readInput('/nonexistent-path/DESIGN.md').catch(e => e);
+    expect((err as FileReadError).message).toContain('ENOENT');
+  });
+
+  it('friendlyMessage says "not found" for ENOENT', async () => {
+    const err = await readInput('/nonexistent-path/DESIGN.md').catch(e => e);
+    expect((err as FileReadError).friendlyMessage).toContain('not found');
+  });
+
+  it('friendlyMessage says "permission denied" for EACCES', () => {
+    const cause = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+    const err = new FileReadError('/some/file.md', cause);
+    expect(err.friendlyMessage).toContain('permission denied');
+    expect(err.friendlyMessage).not.toContain('not found');
+  });
+
+  it('friendlyMessage falls back to the raw message for unknown errors', () => {
+    const cause = Object.assign(new Error('ENOMEM: out of memory'), { code: 'ENOMEM' });
+    const err = new FileReadError('/some/file.md', cause);
+    expect(err.friendlyMessage).toContain('ENOMEM');
+  });
+});
 
 describe('formatOutput', () => {
   describe('--format markdown', () => {

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, spyOn } from 'bun:test';
 import { readInput, FileReadError, formatOutput } from './utils.js';
+import type { StdinStream } from './utils.js';
+
+function makeStdin(content: string, isTTY: boolean): StdinStream {
+  async function* gen() { yield Buffer.from(content); }
+  return Object.assign(gen(), { isTTY });
+}
 
 describe('readInput', () => {
   it('throws FileReadError when file does not exist', async () => {
@@ -47,6 +53,41 @@ describe('readInput', () => {
     const cause = Object.assign(new Error('ENOMEM: out of memory'), { code: 'ENOMEM' });
     const err = new FileReadError('/some/file.md', cause);
     expect(err.friendlyMessage).toContain('ENOMEM');
+  });
+});
+
+describe('readInput stdin ("-")', () => {
+  it('reads content from a piped stream', async () => {
+    const result = await readInput('-', makeStdin('hello world', false));
+    expect(result).toBe('hello world');
+  });
+
+  it('returns empty string for an empty piped stream', async () => {
+    async function* empty() {}
+    const result = await readInput('-', Object.assign(empty(), { isTTY: false }));
+    expect(result).toBe('');
+  });
+
+  it('writes a hint to stderr when stdin is a TTY', async () => {
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      await readInput('-', makeStdin('some content', true));
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Press Ctrl+D')
+      );
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('does not write a hint when stdin is not a TTY', async () => {
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      await readInput('-', makeStdin('piped content', false));
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -14,16 +14,39 @@
 
 import { readFileSync } from 'node:fs';
 
+export type StdinStream = AsyncIterable<Buffer | string> & { isTTY?: boolean };
+
+export class FileReadError extends Error {
+  readonly code = 'FILE_READ_ERROR' as const;
+  constructor(public readonly filePath: string, cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+    this.name = 'FileReadError';
+  }
+
+  get friendlyMessage(): string {
+    const errCode = (this.cause as { code?: string })?.code;
+    if (errCode === 'ENOENT') {
+      return `"${this.filePath}" not found. Create a DESIGN.md file or pass "-" to read from stdin.`;
+    }
+    if (errCode === 'EACCES') {
+      return `"${this.filePath}" could not be read: permission denied.`;
+    }
+    return `"${this.filePath}" could not be read: ${this.message}`;
+  }
+}
+
 /**
  * Read input from a file path or stdin ("-").
- * Never throws — returns the content string or exits with error JSON.
+ * Throws FileReadError if the file cannot be read.
  */
-export async function readInput(filePath: string): Promise<string> {
+export async function readInput(filePath: string, stdin: StdinStream = process.stdin): Promise<string> {
   if (filePath === '-') {
-    // Read from stdin
+    if (stdin.isTTY) {
+      process.stderr.write('Reading from stdin… Press Ctrl+D when done.\n');
+    }
     const chunks: Buffer[] = [];
-    for await (const chunk of process.stdin) {
-      chunks.push(chunk as Buffer);
+    for await (const chunk of stdin) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     }
     return Buffer.concat(chunks).toString('utf-8');
   }
@@ -31,13 +54,7 @@ export async function readInput(filePath: string): Promise<string> {
   try {
     return readFileSync(filePath, 'utf-8');
   } catch (error) {
-    console.error(JSON.stringify({
-      error: 'FILE_READ_ERROR',
-      message: error instanceof Error ? error.message : String(error),
-      path: filePath,
-    }));
-    process.exitCode = 2;
-    throw error; // bubbles up, but process will exit with code 2 if uncaught
+    throw new FileReadError(filePath, error);
   }
 }
 
@@ -52,25 +69,72 @@ export function formatOutput(data: unknown, args: { format?: string }): string {
 }
 
 function formatAsMarkdown(data: unknown): string {
-  if (typeof data === 'object' && data !== null) {
-    const obj = data as Record<string, unknown>;
-    let result = '';
-    if (obj.summary) {
-      result += `# ${obj.summary}\n\n`;
-    }
-    if (obj.details) {
-      result += `## Details\n\n`;
-      result += formatAsText(obj.details);
-      result += '\n';
-    }
-    if (obj.patches && Array.isArray(obj.patches) && obj.patches.length > 0) {
-      result += `## Patches\n\n`;
-      result += formatAsText(obj.patches);
-      result += '\n';
-    }
-    return result || formatAsText(data);
+  if (typeof data !== 'object' || data === null) {
+    return String(data);
   }
-  return String(data);
+
+  const obj = data as Record<string, unknown>;
+
+  // Lint output: { findings: [...], summary: { errors, warnings, infos } }
+  if (isLintOutput(obj)) {
+    return formatLintAsMarkdown(obj);
+  }
+
+  // Legacy fixer/diff shape: { summary: string, details?, patches? }
+  let result = '';
+  if (typeof obj.summary === 'string') {
+    result += `# ${obj.summary}\n\n`;
+  }
+  if (obj.details) {
+    result += `## Details\n\n`;
+    result += formatAsText(obj.details);
+    result += '\n';
+  }
+  if (obj.patches && Array.isArray(obj.patches) && obj.patches.length > 0) {
+    result += `## Patches\n\n`;
+    result += formatAsText(obj.patches);
+    result += '\n';
+  }
+  return result || formatAsText(data);
+}
+
+interface LintSummary {
+  errors: number;
+  warnings: number;
+  infos: number;
+}
+
+interface LintFinding {
+  severity: string;
+  message: string;
+  path?: string;
+}
+
+function isLintOutput(obj: Record<string, unknown>): boolean {
+  if (!Array.isArray(obj.findings)) return false;
+  if (typeof obj.summary !== 'object' || obj.summary === null) return false;
+  const s = obj.summary as Record<string, unknown>;
+  return typeof s.errors === 'number'
+    && typeof s.warnings === 'number'
+    && typeof s.infos === 'number';
+}
+
+function formatLintAsMarkdown(obj: Record<string, unknown>): string {
+  const summary = obj.summary as LintSummary;
+  const findings = obj.findings as LintFinding[];
+
+  let result = '# Lint Report\n\n';
+  result += `**${summary.errors} errors**, **${summary.warnings} warnings**, **${summary.infos} infos**\n`;
+
+  if (findings.length > 0) {
+    result += '\n## Findings\n\n';
+    for (const f of findings) {
+      const location = f.path ? ` \`${f.path}\`:` : ':';
+      result += `- **${f.severity}**${location} ${f.message}\n`;
+    }
+  }
+
+  return result;
 }
 
 function formatAsText(data: unknown, indent = 0): string {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -14,6 +14,8 @@
 
 import { readFileSync } from 'node:fs';
 
+export type StdinStream = AsyncIterable<Buffer | string> & { isTTY?: boolean };
+
 export class FileReadError extends Error {
   readonly code = 'FILE_READ_ERROR' as const;
   constructor(public readonly filePath: string, cause: unknown) {
@@ -37,11 +39,14 @@ export class FileReadError extends Error {
  * Read input from a file path or stdin ("-").
  * Throws FileReadError if the file cannot be read.
  */
-export async function readInput(filePath: string): Promise<string> {
+export async function readInput(filePath: string, stdin: StdinStream = process.stdin): Promise<string> {
   if (filePath === '-') {
+    if (stdin.isTTY) {
+      process.stderr.write('Reading from stdin… Press Ctrl+D when done.\n');
+    }
     const chunks: Buffer[] = [];
-    for await (const chunk of process.stdin) {
-      chunks.push(chunk as Buffer);
+    for await (const chunk of stdin) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     }
     return Buffer.concat(chunks).toString('utf-8');
   }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -14,13 +14,31 @@
 
 import { readFileSync } from 'node:fs';
 
+export class FileReadError extends Error {
+  readonly code = 'FILE_READ_ERROR' as const;
+  constructor(public readonly filePath: string, cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+    this.name = 'FileReadError';
+  }
+
+  get friendlyMessage(): string {
+    const errCode = (this.cause as { code?: string })?.code;
+    if (errCode === 'ENOENT') {
+      return `"${this.filePath}" not found. Create a DESIGN.md file or pass "-" to read from stdin.`;
+    }
+    if (errCode === 'EACCES') {
+      return `"${this.filePath}" could not be read: permission denied.`;
+    }
+    return `"${this.filePath}" could not be read: ${this.message}`;
+  }
+}
+
 /**
  * Read input from a file path or stdin ("-").
- * Never throws — returns the content string or exits with error JSON.
+ * Throws FileReadError if the file cannot be read.
  */
 export async function readInput(filePath: string): Promise<string> {
   if (filePath === '-') {
-    // Read from stdin
     const chunks: Buffer[] = [];
     for await (const chunk of process.stdin) {
       chunks.push(chunk as Buffer);
@@ -31,13 +49,7 @@ export async function readInput(filePath: string): Promise<string> {
   try {
     return readFileSync(filePath, 'utf-8');
   } catch (error) {
-    console.error(JSON.stringify({
-      error: 'FILE_READ_ERROR',
-      message: error instanceof Error ? error.message : String(error),
-      path: filePath,
-    }));
-    process.exitCode = 2;
-    throw error; // bubbles up, but process will exit with code 2 if uncaught
+    throw new FileReadError(filePath, error);
   }
 }
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -52,25 +52,72 @@ export function formatOutput(data: unknown, args: { format?: string }): string {
 }
 
 function formatAsMarkdown(data: unknown): string {
-  if (typeof data === 'object' && data !== null) {
-    const obj = data as Record<string, unknown>;
-    let result = '';
-    if (obj.summary) {
-      result += `# ${obj.summary}\n\n`;
-    }
-    if (obj.details) {
-      result += `## Details\n\n`;
-      result += formatAsText(obj.details);
-      result += '\n';
-    }
-    if (obj.patches && Array.isArray(obj.patches) && obj.patches.length > 0) {
-      result += `## Patches\n\n`;
-      result += formatAsText(obj.patches);
-      result += '\n';
-    }
-    return result || formatAsText(data);
+  if (typeof data !== 'object' || data === null) {
+    return String(data);
   }
-  return String(data);
+
+  const obj = data as Record<string, unknown>;
+
+  // Lint output: { findings: [...], summary: { errors, warnings, infos } }
+  if (isLintOutput(obj)) {
+    return formatLintAsMarkdown(obj);
+  }
+
+  // Legacy fixer/diff shape: { summary: string, details?, patches? }
+  let result = '';
+  if (typeof obj.summary === 'string') {
+    result += `# ${obj.summary}\n\n`;
+  }
+  if (obj.details) {
+    result += `## Details\n\n`;
+    result += formatAsText(obj.details);
+    result += '\n';
+  }
+  if (obj.patches && Array.isArray(obj.patches) && obj.patches.length > 0) {
+    result += `## Patches\n\n`;
+    result += formatAsText(obj.patches);
+    result += '\n';
+  }
+  return result || formatAsText(data);
+}
+
+interface LintSummary {
+  errors: number;
+  warnings: number;
+  infos: number;
+}
+
+interface LintFinding {
+  severity: string;
+  message: string;
+  path?: string;
+}
+
+function isLintOutput(obj: Record<string, unknown>): boolean {
+  if (!Array.isArray(obj.findings)) return false;
+  if (typeof obj.summary !== 'object' || obj.summary === null) return false;
+  const s = obj.summary as Record<string, unknown>;
+  return typeof s.errors === 'number'
+    && typeof s.warnings === 'number'
+    && typeof s.infos === 'number';
+}
+
+function formatLintAsMarkdown(obj: Record<string, unknown>): string {
+  const summary = obj.summary as LintSummary;
+  const findings = obj.findings as LintFinding[];
+
+  let result = '# Lint Report\n\n';
+  result += `**${summary.errors} errors**, **${summary.warnings} warnings**, **${summary.infos} infos**\n`;
+
+  if (findings.length > 0) {
+    result += '\n## Findings\n\n';
+    for (const f of findings) {
+      const location = f.path ? ` \`${f.path}\`:` : ':';
+      result += `- **${f.severity}**${location} ${f.message}\n`;
+    }
+  }
+
+  return result;
 }
 
 function formatAsText(data: unknown, indent = 0): string {


### PR DESCRIPTION
## Summary

Merges `google-labs-code/design.md@main` (releases 0.2.0 + 0.3.0, 37 commits) into the fork, resolving 18 conflicted files. The branches diverged 2026-04-22; upstream added two export formats, a spec-grade color engine, five lint rules, and a long tail of CLI hardening.

**New from upstream**
- `--format css-vars` export; upstream's Tailwind v4 emitter kept as a library export
- CSS Color Module parser: named colors, `hwb()`, `lch()`, `color-mix()` (fallback behind the fork's parser, which keeps `display-p3` and `format`/`raw` round-trip metadata)
- Nested token declarations with flattening + collision detection
- `unknown-key` (Levenshtein "did you mean") and `token-like-ignored` lint rules; typography sub-property warnings
- Exit-code fixes for scripted use, TTY-stdin hint, graceful ENOENT, Windows `designmd` alias, bounded validation cost
- PHILOSOPHY.md, config-driven spec type docs (docs/spec.md regenerated)

**Key resolutions (details in the merge commit and CHANGELOG.md)**
- Model pipeline: fork's architecture kept; upstream improvements grafted in (forEachLeaf, collision guards, symbol-table phase-2, unknown-key tracking)
- `tailwind` export stays aliased to the fork's shadcn-style `css-tailwind` CSS (deviates from upstream's `json-tailwind` alias to avoid silently changing fork output); v3 JSON available at `json-tailwind`
- `orphaned-tokens` combines fork ramp/pair provenance with upstream MD3 family heuristics
- `SCHEMA_KEYS` extended with fork primitives so `unknown-key` stays quiet on them

## Test plan
- [x] `bun run lint` clean
- [x] `bun run test` — 774 pass / 0 fail across cli + evals
- [x] Smoke test: lint + all 4 export formats on a DESIGN.md exercising nested colors, ramps, named colors, `color-mix`; typo'd top-level key gets a suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)